### PR TITLE
Explicit display_last4 length

### DIFF
--- a/spec/openapi/openapi.delegate_payment.yaml
+++ b/spec/openapi/openapi.delegate_payment.yaml
@@ -320,7 +320,9 @@ components:
           type: string
         display_last4:
           type: string
+          minLength: 4
           maxLength: 4
+          pattern: "^[0-9]{4}$"
         metadata:
           type: object
           additionalProperties: { type: string }


### PR DESCRIPTION
Force display_last4 to be exactly four digits in length.