### PR TITLE
Increase IIN field max length from 6 to 8 characters

### DIFF
--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -1,0 +1,9 @@
+# Unreleased Changes
+
+## Delegate Payment API
+
+### Changed
+- **IIN field length**: Updated `iin` field `maxLength` from 6 to 8 characters in `PaymentMethodCard` schema to support extended IIN ranges.
+  - Updated in: `spec/openapi/openapi.delegate_payment.yaml`
+  - Updated in: `spec/json-schema/schema.delegate_payment_schema.json`
+  - Updated in: `rfcs/rfc.delegate_payment.md`

--- a/rfcs/rfc.delegate_payment.md
+++ b/rfcs/rfc.delegate_payment.md
@@ -105,7 +105,7 @@ Exactly **one** credential type is supported today: **card**.
 - `name`: string
 - `cvc`: string (max 4)
 - `checks_performed`: array of `avs` | `cvv` | `ani` | `auth0`
-- `iin`: string (max 6)
+- `iin`: string (max 8)
 - `display_card_funding_type`: `credit` | `debit` | `prepaid` (**REQUIRED**)
 - `display_wallet_type`: string (e.g., wallet indicator for virtual)
 - `display_brand`: string (e.g., `visa`, `amex`)
@@ -218,7 +218,7 @@ Exactly **one** credential type is supported today: **card**.
   - `exp_month` length ≤ 2 and value `"01"`–`"12"`.
   - `exp_year` length ≤ 4 and four digits.
   - `cvc` length ≤ 4.
-  - `iin` length ≤ 6.
+  - `iin` length ≤ 8.
 - `display_card_funding_type` ∈ `credit|debit|prepaid`.
 - `allowance.currency` matches `^[a-z]{3}$` (e.g., `usd`).
 - `allowance.expires_at` must be RFC 3339.

--- a/spec/json-schema/schema.delegate_payment_schema.json
+++ b/spec/json-schema/schema.delegate_payment_schema.json
@@ -93,7 +93,7 @@
         },
         "iin": {
           "type": "string",
-          "maxLength": 6
+          "maxLength": 8
         },
         "display_card_funding_type": {
           "type": "string",

--- a/spec/openapi/openapi.delegate_payment.yaml
+++ b/spec/openapi/openapi.delegate_payment.yaml
@@ -310,7 +310,7 @@ components:
             enum: [avs, cvv, ani, auth0]
         iin:
           type: string
-          maxLength: 6
+          maxLength: 8
         display_card_funding_type:
           type: string
           enum: [credit, debit, prepaid]


### PR DESCRIPTION
# Increase IIN field max length from 6 to 8 characters

## Summary

This PR updates the `iin` (Issuer Identification Number) field in the `PaymentMethodCard` schema to support a maximum length of 8 characters instead of 6, aligning with extended IIN ranges used by payment networks (ISO/IEC 7812-1).

## Motivation

The current 6-character limit for IIN fields is insufficient considering the ISO/IEC 7812-1 norm. This change ensures the Delegate Payment API can accommodate these extended IIN formats.

## Changes

### Modified Files

- **`spec/openapi/openapi.delegate_payment.yaml`** (Line 313)
  - Updated `iin.maxLength` from `6` to `8`

- **`spec/json-schema/schema.delegate_payment_schema.json`** (Line 96)
  - Updated `iin.maxLength` from `6` to `8`

- **`rfcs/rfc.delegate_payment.md`** (Lines 108, 221)
  - Updated documentation to reflect `iin: string (max 8)`
  - Updated validation rules to `iin length ≤ 8`

- **`changelog/unreleased.md`**
  - Added changelog entry documenting this change

## Backward Compatibility

✅ **Fully backward compatible** - This is a non-breaking change. All existing IIN values (6 characters or fewer) remain valid under the new 8-character maximum.

## Validation

- All example values in the repository (e.g., `"424242"`) remain valid
- No changes required to existing implementations
- Schema validation now accepts both legacy 6-digit and new 8-digit IINs

## Checklist

- [x] OpenAPI spec updated
- [x] JSON Schema updated
- [x] RFC documentation updated
- [x] Changelog entry added
- [x] All changes are backward compatible
- [x] CI checks passed

---

**Related to:** Extended IIN support for modern data management
