### PR TITLE
SEP: Split Address into BillingAddress and FulfillmentAddress

### DIFF
--- a/changelog/unreleased/split-billing-fulfillment-address.md
+++ b/changelog/unreleased/split-billing-fulfillment-address.md
@@ -1,0 +1,66 @@
+## Split Address into BillingAddress and FulfillmentAddress
+
+### Motivation
+
+A single `Address` model served two contexts with genuinely different requirements.
+Fulfillment needs a complete, deliverable address. Billing does not: for address
+verification (AVS), tax determination, and 3DS risk assessment, a postal code and
+country are sufficient.
+
+Because `Address` required `name`, `line_one`, `city`, and `state`, agents had no way
+to pass a partial billing address. They were forced to either collect a full address
+the merchant did not need — adding friction at the highest-drop-off point in checkout
+— or fabricate placeholder values to satisfy the schema. Neither is acceptable.
+
+Splitting the model lets each context state its own requirements honestly.
+
+### Breaking Changes
+
+- The `Address` model is removed. It is replaced by `BillingAddress` and
+  `FulfillmentAddress`.
+- `BillingAddress` requires only `country` and `postal_code`. `name`, `line_one`,
+  `line_two`, `city`, and `state` are now optional.
+
+Migration:
+
+- **Producers** (agents sending addresses) need no data changes. Every address that
+  validated against `Address` still validates against its replacement — the required
+  set was narrowed, never widened.
+- **Consumers** (merchants and PSPs reading billing addresses) must treat `name`,
+  `line_one`, `city`, and `state` as optional on `BillingAddress` and handle their
+  absence. Code that assumes those fields are present will break.
+- Type references named `Address` must be renamed to `BillingAddress` or
+  `FulfillmentAddress` depending on context.
+
+### Changes
+
+- Added `BillingAddress`: `country` and `postal_code` required; all other fields optional.
+- Added `FulfillmentAddress`: identical field requirements to the previous `Address`
+  (all fields except `line_two` required).
+- Retargeted every `Address` reference to its context-appropriate type:
+  - `PaymentData.billing_address` → `BillingAddress`
+  - `DelegatePaymentRequest.billing_address` → `BillingAddress`
+  - `ShopperDetails.address` (3DS authentication) → `BillingAddress`
+  - `FulfillmentDetails.address` → `FulfillmentAddress`
+  - `FulfillmentOptionPickup` location address → `FulfillmentAddress`
+  - `Fulfillment.destination` → `FulfillmentAddress`
+- Per-file length constraints (`maxLength` on `name`, `line_one`, `city`,
+  `postal_code`; `minLength`/`maxLength` on `country`) are preserved unchanged in the
+  delegate payment and delegate authentication specs.
+
+### Files Updated
+
+- `spec/unreleased/openapi/openapi.agentic_checkout.yaml`
+- `spec/unreleased/openapi/openapi.delegate_payment.yaml`
+- `spec/unreleased/openapi/openapi.delegate_authentication.yaml`
+- `spec/unreleased/json-schema/schema.agentic_checkout.json`
+- `spec/unreleased/json-schema/schema.delegate_payment.json`
+- `spec/unreleased/json-schema/schema.delegate_authentication.json`
+- `rfcs/rfc.agentic_checkout.md`
+- `rfcs/rfc.delegate_payment.md`
+- `rfcs/rfc.delegate_authentication.md`
+- `rfcs/rfc.orders.md`
+
+### Reference
+
+- PR: #10

--- a/rfcs/rfc.agentic_checkout.md
+++ b/rfcs/rfc.agentic_checkout.md
@@ -177,8 +177,9 @@ If a client calls `POST .../complete` while `session.status` is `authentication_
 - **CustomAttribute**: `display_name` (string), `value` (string)
 - **MarketplaceSellerDetails**: `name` (string)
 - **Total**: `type` (`items_base_amount | items_discount | subtotal | discount | fulfillment | tax | fee | total`), `display_text`, `amount` (**int**), `description?` (optional string for fees)
-- **Address**: `name`, `line_one`, `line_two?`, `city`, `state`, `country`, `postal_code`
-- **FulfillmentDetails**: `name?`, `phone?`, `email?`, `address?` (nested Address object)
+- **BillingAddress**: `country`, `postal_code`, `name?`, `line_one?`, `line_two?`, `city?`, `state?`
+- **FulfillmentAddress**: `name`, `line_one`, `line_two?`, `city`, `state`, `country`, `postal_code`
+- **FulfillmentDetails**: `name?`, `phone?`, `email?`, `address?` (nested FulfillmentAddress object)
 - **FulfillmentOption (shipping)**: `id`, `title`, `description?`, `carrier?`, `earliest_delivery_time?`, `latest_delivery_time?`, `totals` (array of **Total**)
 - **FulfillmentOption (digital)**: `id`, `title`, `description?`, `totals` (array of **Total**)
 - **FulfillmentOption (pickup)**: `id`, `title`, `description?`, `location`, `pickup_type?`, `ready_by?`, `pickup_by?`, `totals` (array of **Total**)

--- a/rfcs/rfc.delegate_authentication.md
+++ b/rfcs/rfc.delegate_authentication.md
@@ -108,7 +108,7 @@ All endpoints **MUST** use HTTPS and return JSON.
 - `checkout_session_id` (**OPTIONAL**) - Checkout session identifier
 - `flow_preference` (**OPTIONAL**) - Object with `type` (`challenge` | `frictionless`) and optional subtype details
 - `challenge_notification_url` (**OPTIONAL**) - URL for challenge result callback
-- `shopper_details` (**OPTIONAL**) - Object with `name?`, `email?`, `phone_number?`, `address?` (nested Address)
+- `shopper_details` (**OPTIONAL**) - Object with `name?`, `email?`, `phone_number?`, `address?` (nested BillingAddress)
 
 **Response body:**
 
@@ -168,8 +168,8 @@ All endpoints **MUST** use HTTPS and return JSON.
 - **PaymentMethod**: `type` (`card`), `number`, `exp_month`, `exp_year`, `name`
 - **Amount**: `value` (int, minor units), `currency` (ISO 4217)
 - **Channel**: `type` (`browser`), `browser` (object with `accept_header`, `ip_address`, `javascript_enabled`, `language`, `user_agent`, `color_depth`, `java_enabled`, `screen_height`, `screen_width`, `timezone_offset`)
-- **Address**: `name`, `line_one`, `line_two?`, `city`, `state`, `country`, `postal_code`
-- **ShopperDetails**: `name?`, `email?`, `phone_number?`, `address?` (nested Address object)
+- **BillingAddress**: `country`, `postal_code`, `name?`, `line_one?`, `line_two?`, `city?`, `state?`
+- **ShopperDetails**: `name?`, `email?`, `phone_number?`, `address?` (nested BillingAddress object)
 - **FlowPreference**: `type` (`challenge` | `frictionless`), `challenge?` (object with `type`: `mandated` | `preferred`), `frictionless?` (object). Clients **MAY** request a preference, but issuers ultimately decide the actual flow.
 - **Action (fingerprint)**: `type: fingerprint`, `fingerprint` (object with `three_ds_method_url`, `three_ds_server_trans_id`)
 - **Action (challenge)**: `type: challenge`, `challenge` (object with `acs_url`, `acs_trans_id`, `three_ds_server_trans_id`, `message_version`)

--- a/rfcs/rfc.delegate_payment.md
+++ b/rfcs/rfc.delegate_payment.md
@@ -91,7 +91,7 @@ Exactly **one** credential type is supported today: **card**.
 | ----------------- | -------------------- | :-: | -------------------------------------------------- |
 | `payment_method`  | PaymentMethodCard    | ✅  | The credential to tokenize. (type MUST be `card`.) |
 | `allowance`       | Allowance            | ✅  | Constraints on how the token may be used.          |
-| `billing_address` | Address              | ❌  | Address associated with the payment method.        |
+| `billing_address` | BillingAddress       | ❌  | Billing address associated with the payment method. |
 | `risk_signals`    | RiskSignal[]         | ✅  | One or more risk signals.                          |
 | `metadata`        | object (map<string>) | ✅  | Arbitrary key/values for correlation.              |
 
@@ -113,10 +113,13 @@ Exactly **one** credential type is supported today: **card**.
 - `display_last4`: string (max 4)
 - `metadata`: map<string,string> (**REQUIRED**)
 
-### 3.4 Address (OPTIONAL)
+### 3.4 BillingAddress (OPTIONAL)
 
-- `name` (≤256), `line_one` (≤60), `line_two` (≤60), `city` (≤60),  
-  `state` (ISO-3166-2 where applicable), `country` (ISO-3166-1 alpha-2), `postal_code` (≤20)
+Providers **MAY** send a complete address, but **MUST NOT** require one.
+
+- **REQUIRED**: `country` (ISO-3166-1 alpha-2), `postal_code` (≤20)
+- **OPTIONAL**: `name` (≤256), `line_one` (≤60), `line_two` (≤60), `city` (≤60),  
+  `state` (ISO-3166-2 where applicable)
 
 ### 3.5 Allowance (REQUIRED)
 

--- a/rfcs/rfc.orders.md
+++ b/rfcs/rfc.orders.md
@@ -178,7 +178,7 @@ The existing `Order` schema gains optional fields:
 | `carrier` | string | No | Carrier name (shipping only) |
 | `tracking_number` | string | No | Tracking number (shipping only) |
 | `tracking_url` | string (uri) | No | Tracking URL (shipping only) |
-| `destination` | Address | No | Delivery address |
+| `destination` | FulfillmentAddress | No | Delivery address |
 | `estimated_delivery` | EstimatedDelivery | No | Delivery estimate |
 | `digital_delivery` | object | No | Digital delivery details (digital only) |
 | `description` | string | No | Human-readable description |

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -143,8 +143,55 @@
         "source": "coupon"
       }
     },
-    "Address": {
-      "description": "Physical address for shipping, billing, or pickup locations",
+    "BillingAddress": {
+      "description": "Billing address associated with a payment method",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Cardholder name associated with this billing address"
+        },
+        "line_one": {
+          "type": "string",
+          "description": "Primary street address line"
+        },
+        "line_two": {
+          "type": "string",
+          "description": "Secondary address line (apartment, suite, etc.)"
+        },
+        "city": {
+          "type": "string",
+          "description": "City name"
+        },
+        "state": {
+          "type": "string",
+          "description": "State or province code"
+        },
+        "country": {
+          "type": "string",
+          "description": "ISO 3166-1 alpha-2 country code"
+        },
+        "postal_code": {
+          "type": "string",
+          "description": "Postal or ZIP code"
+        },
+        "company": {
+          "type": "string",
+          "description": "Company or organization name"
+        }
+      },
+      "required": [
+        "country",
+        "postal_code"
+      ],
+      "example": {
+        "country": "US",
+        "postal_code": "10001"
+      }
+    },
+    "FulfillmentAddress": {
+      "description": "Physical address for shipping, delivery, or pickup locations",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -353,7 +400,7 @@
           "description": "Contact email address"
         },
         "address": {
-          "$ref": "#/$defs/Address",
+          "$ref": "#/$defs/FulfillmentAddress",
           "description": "Fulfillment address"
         }
       },
@@ -1356,7 +1403,7 @@
               "description": "Location name"
             },
             "address": {
-              "$ref": "#/$defs/Address",
+              "$ref": "#/$defs/FulfillmentAddress",
               "description": "Pickup address"
             },
             "phone": {
@@ -2160,7 +2207,7 @@
           ]
         },
         "billing_address": {
-          "$ref": "#/$defs/Address",
+          "$ref": "#/$defs/BillingAddress",
           "description": "Billing address for the payment"
         },
         "purchase_order_number": {
@@ -2813,7 +2860,7 @@
           "description": "URL to track this shipment. Applies to type: shipping."
         },
         "destination": {
-          "$ref": "#/$defs/Address"
+          "$ref": "#/$defs/FulfillmentAddress"
         },
         "estimated_delivery": {
           "$ref": "#/$defs/EstimatedDelivery"

--- a/spec/unreleased/json-schema/schema.delegate_authentication.json
+++ b/spec/unreleased/json-schema/schema.delegate_authentication.json
@@ -3,15 +3,15 @@
   "$id": "https://example.com/schemas/delegate-authentication/bundle.schema.json",
   "title": "Delegate Authentication - Schema Bundle",
   "$defs": {
-    "Address": {
+    "BillingAddress": {
       "type": "object",
-      "description": "The physical address details for the shopper.",
+      "description": "Billing address associated with the payment method.",
       "additionalProperties": false,
       "properties": {
         "name": {
           "type": "string",
           "maxLength": 256,
-          "description": "Full name of the recipient"
+          "description": "Cardholder name associated with this billing address"
         },
         "line_one": {
           "type": "string",
@@ -44,13 +44,9 @@
           "description": "Postal or ZIP code"
         }
       },
-      "required": ["name", "line_one", "city", "state", "country", "postal_code"],
+      "required": ["country", "postal_code"],
       "examples": [
         {
-          "name": "Jane Doe",
-          "line_one": "123 Main Street",
-          "city": "Amsterdam",
-          "state": "NH",
           "country": "NL",
           "postal_code": "1012 AB"
         }
@@ -280,7 +276,7 @@
           "description": "Shopper phone number"
         },
         "address": {
-          "$ref": "#/$defs/Address"
+          "$ref": "#/$defs/BillingAddress"
         }
       },
       "examples": [

--- a/spec/unreleased/json-schema/schema.delegate_payment.json
+++ b/spec/unreleased/json-schema/schema.delegate_payment.json
@@ -3,15 +3,15 @@
   "$id": "https://example.com/schemas/delegate-payment/bundle.schema.json",
   "title": "Delegate Payment \u2014 Schema Bundle",
   "$defs": {
-    "Address": {
-      "description": "Physical address for billing or shipping purposes",
+    "BillingAddress": {
+      "description": "Billing address associated with a payment method",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "name": {
           "type": "string",
           "maxLength": 256,
-          "description": "Full name of the person at this address"
+          "description": "Cardholder name associated with this billing address"
         },
         "line_one": {
           "type": "string",
@@ -45,19 +45,10 @@
         }
       },
       "required": [
-        "name",
-        "line_one",
-        "city",
-        "state",
         "country",
         "postal_code"
       ],
       "example": {
-        "name": "John Smith",
-        "line_one": "555 Golden Gate Avenue",
-        "line_two": "Apt 401",
-        "city": "San Francisco",
-        "state": "CA",
         "country": "US",
         "postal_code": "94102"
       }
@@ -272,7 +263,7 @@
           "description": "Constraints on how the payment method can be used"
         },
         "billing_address": {
-          "$ref": "#/$defs/Address",
+          "$ref": "#/$defs/BillingAddress",
           "description": "Billing address associated with the payment method"
         },
         "risk_signals": {

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -492,7 +492,39 @@ components:
                 code: idempotency_conflict
                 message: Idempotency-Key has already been used with a different request body
   schemas:
-    Address:
+    BillingAddress:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: Cardholder name associated with this billing address
+        line_one:
+          type: string
+          description: Primary street address line
+        line_two:
+          type: string
+          description: Secondary address line (apartment, suite, etc.)
+        city:
+          type: string
+          description: City name
+        state:
+          type: string
+          description: State or province code
+        country:
+          type: string
+          description: ISO 3166-1 alpha-2 country code
+        postal_code:
+          type: string
+          description: Postal or ZIP code
+      required:
+        - country
+        - postal_code
+      example:
+        country: US
+        postal_code: "10001"
+      description: Billing address associated with a payment method
+    FulfillmentAddress:
       type: object
       additionalProperties: false
       properties:
@@ -532,7 +564,7 @@ components:
         state: NY
         country: US
         postal_code: "10001"
-      description: Physical address for shipping, billing, or pickup locations
+      description: Physical address for shipping, delivery, or pickup locations
     AffiliateAttributionSource:
       type: object
       additionalProperties: false
@@ -651,7 +683,7 @@ components:
           format: email
           description: Contact email address
         address:
-          $ref: "#/components/schemas/Address"
+          $ref: "#/components/schemas/FulfillmentAddress"
           description: Fulfillment address
       example:
         name: John Smith
@@ -1539,7 +1571,7 @@ components:
               type: string
               description: Location name
             address:
-              $ref: "#/components/schemas/Address"
+              $ref: "#/components/schemas/FulfillmentAddress"
             phone:
               type: string
               description: Location phone number
@@ -2088,7 +2120,7 @@ components:
             - type
             - credential
         billing_address:
-          $ref: "#/components/schemas/Address"
+          $ref: "#/components/schemas/BillingAddress"
         purchase_order_number:
           type: string
           description: Purchase order number
@@ -2421,7 +2453,7 @@ components:
           format: uri
           description: "URL to track this shipment. Applies to type: shipping."
         destination:
-          $ref: "#/components/schemas/Address"
+          $ref: "#/components/schemas/FulfillmentAddress"
         estimated_delivery:
           $ref: "#/components/schemas/EstimatedDelivery"
         digital_delivery:

--- a/spec/unreleased/openapi/openapi.delegate_authentication.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_authentication.yaml
@@ -714,24 +714,20 @@ components:
           type: string
           description: Shopper phone number
         address:
-          $ref: "#/components/schemas/Address"
+          $ref: "#/components/schemas/BillingAddress"
 
-    Address:
+    BillingAddress:
       type: object
-      description: Physical address schema for shopper or shipping.
+      description: Billing address associated with the payment method.
       additionalProperties: false
       example:
-        name: "Jane Doe"
-        line_one: "123 Main St"
-        city: "Amsterdam"
-        state: "NH"
         country: "NL"
         postal_code: "1012 AB"
       properties:
         name:
           type: string
           maxLength: 256
-          description: Full name of the recipient.
+          description: Cardholder name associated with this billing address.
         line_one:
           type: string
           maxLength: 60
@@ -756,7 +752,7 @@ components:
           type: string
           maxLength: 20
           description: Postal code or ZIP code.
-      required: [name, line_one, city, state, country, postal_code]
+      required: [country, postal_code]
 
     Action:
       type: object

--- a/spec/unreleased/openapi/openapi.delegate_payment.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_payment.yaml
@@ -303,7 +303,7 @@ components:
           $ref: "#/components/schemas/Allowance"
           description: Constraints on how the payment method can be used
         billing_address:
-          $ref: "#/components/schemas/Address"
+          $ref: "#/components/schemas/BillingAddress"
           description: Billing address associated with the payment method
         risk_signals:
           type: array
@@ -467,14 +467,14 @@ components:
         metadata:
           card_origin: manual_entry
       description: Card payment method details including card number, expiration, and verification data
-    Address:
+    BillingAddress:
       type: object
       additionalProperties: false
       properties:
         name:
           type: string
           maxLength: 256
-          description: Full name of the person at this address
+          description: Cardholder name associated with this billing address
         line_one:
           type: string
           maxLength: 60
@@ -500,21 +500,12 @@ components:
           maxLength: 20
           description: ZIP or postal code
       required:
-        - name
-        - line_one
-        - city
-        - state
         - country
         - postal_code
       example:
-        name: John Smith
-        line_one: 555 Golden Gate Avenue
-        line_two: Apt 401
-        city: San Francisco
-        state: CA
         country: US
         postal_code: "94102"
-      description: Physical address for billing or shipping purposes
+      description: Billing address associated with a payment method
     Allowance:
       type: object
       additionalProperties: false


### PR DESCRIPTION
# SEP: Split Address into BillingAddress and FulfillmentAddress

## 📋 SEP Metadata

- **SEP Number**: #286 
- **Author(s)**: Camil Haroune (@Camil-H)
- **Status**: `proposal` (awaiting sponsor)
- **Type**: [x] Major Change [ ] Process Change

---

## 🎯 Abstract

A single `Address` model serves two contexts with different requirements.
Fulfillment needs a complete, deliverable address; billing does not. Because
`Address` requires `name`, `line_one`, `city`, and `state`, an agent cannot send a
partial billing address — it must either collect fields the merchant never needed or
fabricate placeholder values to pass validation.

This SEP replaces `Address` with `BillingAddress` (requires `country` and
`postal_code`) and `FulfillmentAddress` (requirements unchanged from `Address`), and
retargets each existing reference to the model appropriate to its context.

---

## 💡 Motivation

Requiring a complete billing address adds friction at the highest-drop-off point in
checkout, and the workaround — synthesizing values to satisfy the schema — produces
data that looks valid but is not, undermining the fraud signal the field exists to
provide.

---

## 📐 Specification

**`BillingAddress`** — required: `country`, `postal_code`. Optional: `name`,
`line_one`, `line_two`, `city`, `state`.

**`FulfillmentAddress`** — required: `name`, `line_one`, `city`, `state`, `country`,
`postal_code`. Optional: `line_two`. Identical to the previous `Address`.

| Reference | Spec | New type |
| --- | --- | --- |
| `PaymentData.billing_address` | agentic_checkout | `BillingAddress` |
| `DelegatePaymentRequest.billing_address` | delegate_payment | `BillingAddress` |
| `ShopperDetails.address` | delegate_authentication | `BillingAddress` |
| `FulfillmentDetails.address` | agentic_checkout | `FulfillmentAddress` |
| `FulfillmentOptionPickup` location address | agentic_checkout | `FulfillmentAddress` |
| `Fulfillment.destination` | agentic_checkout | `FulfillmentAddress` |

Existing per-file length constraints are preserved unchanged. Existing examples
validate without modification.

---

## 🤔 Rationale

Two models rather than relaxing `Address` itself: loosening the shared model would
weaken fulfillment, where completeness is a genuine requirement. The difference
belongs in the type system rather than in prose applied per call site.

---

## 🔄 Backward Compatibility

Breaking, but narrower than the rename suggests.

- **Producers**: unaffected. Every address valid under `Address` remains valid; the
  required set was narrowed, never widened.
- **Consumers**: code reading `billing_address` that assumes `name`, `line_one`,
  `city`, or `state` are present must handle their absence. This is the substantive
  break.
- **Type references** named `Address` must be rebound to the appropriate model.

Lands in `spec/unreleased/`, shipping on the next dated release.

---

## 🛠️ Reference Implementation

The specification changes in this PR. Verified with the repository's tooling:
`node scripts/validate-consistency.js` passes with no errors or warnings, and all
seven schemas compile under `ajv --spec=draft2020`.

---

## 🔒 Security Implications

No changes to authentication, authorization, or trust relationships.

---

## ✅ Pre-Submission Checklist

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
- [x] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] This PR includes updates to OpenAPI/JSON schemas (if applicable)
- [x] This PR includes example requests/responses (if applicable)
- [x] This PR includes a changelog entry file in `changelog/unreleased/split-billing-fulfillment-address.md`
- [ ] I am seeking or have found a sponsor (Founding Maintainer)

---

## 📚 Additional Context

Supersedes the original implementation in this PR, which was written against the
pre-`spec/unreleased/` layout and had drifted behind `main`. The change was reapplied
cleanly on current `main`. Scope grew in the interim: `delegate_authentication` did
not exist when this was first written, and `Fulfillment.destination` arrived with the
Order Schema alignment SEP; both are handled here.

---

## 🙋 Questions for Reviewers

None.
