### PR TITLE
Fix FulfillmentOption money fields type inconsistency

### DIFF
--- a/spec/openapi/openapi.agentic_checkout.yaml
+++ b/spec/openapi/openapi.agentic_checkout.yaml
@@ -377,9 +377,9 @@ components:
         carrier: { type: string }
         earliest_delivery_time: { type: string, format: date-time }
         latest_delivery_time: { type: string, format: date-time }
-        subtotal: { type: string }
-        tax: { type: string }
-        total: { type: string }
+        subtotal: { type: integer }
+        tax: { type: integer }
+        total: { type: integer }
       required: [type, id, title, subtotal, tax, total]
 
     FulfillmentOptionDigital:
@@ -390,9 +390,9 @@ components:
         id: { type: string }
         title: { type: string }
         subtitle: { type: string }
-        subtotal: { type: string }
-        tax: { type: string }
-        total: { type: string }
+        subtotal: { type: integer }
+        tax: { type: integer }
+        total: { type: integer }
       required: [type, id, title, subtotal, tax, total]
 
     MessageInfo:


### PR DESCRIPTION
Hi,

I noticed that the spec has `subtotal`, `tax`, and `total` defined as `string` in both FulfillmentOption types, but the JSON Schema has them as `integer`. The examples also use numbers, not strings. Looking at the rest of the spec, all other money fields (LineItem, Total) use `integer` for minor units, so this looks like a typo.

Let me know if I missed something or if there was a reason for using strings here.

Thanks!