### PR TITLE
Fix monetary fields in FulfillmentOptionShipping and FulfillmentOptionDigital

### DIFF
--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -1,0 +1,5 @@
+- **2025-10-03**: Fixed `subtotal`, `tax`, and `total` fields in `FulfillmentOptionShipping` and `FulfillmentOptionDigital` schemas from `spec/openapi/openapi.agentic_checkout.yaml`
+
+Previously they were type `string`, now they are type `integer`
+
+This aligns with the conformance checklist to use **integer** minor units for all monetary amounts and the json schema

--- a/spec/openapi/openapi.agentic_checkout.yaml
+++ b/spec/openapi/openapi.agentic_checkout.yaml
@@ -377,9 +377,9 @@ components:
         carrier: { type: string }
         earliest_delivery_time: { type: string, format: date-time }
         latest_delivery_time: { type: string, format: date-time }
-        subtotal: { type: string }
-        tax: { type: string }
-        total: { type: string }
+        subtotal: { type: integer }
+        tax: { type: integer }
+        total: { type: integer }
       required: [type, id, title, subtotal, tax, total]
 
     FulfillmentOptionDigital:
@@ -390,9 +390,9 @@ components:
         id: { type: string }
         title: { type: string }
         subtitle: { type: string }
-        subtotal: { type: string }
-        tax: { type: string }
-        total: { type: string }
+        subtotal: { type: integer }
+        tax: { type: integer }
+        total: { type: integer }
       required: [type, id, title, subtotal, tax, total]
 
     MessageInfo:


### PR DESCRIPTION
Fix monetary fields in FulfillmentOptionShipping and FulfillmentOptionDigital to use integer types in openapi spec