### PR TITLE
docs: add community implementation — ACP + zkML authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ To start building with ACP:
 
 ---
 
+## 🌱 Community Implementations
+
+- ACP + zkML Authorization (community demo) — A community-maintained reference showing how to bind a zkML authorization proof to ACP flows and verify it on-chain before completing payment. Includes UI, services, and contract verification on Base Sepolia.
+  - Repo: https://github.com/hshadab/agentkit/tree/main/acp
+
+This external project is not part of ACP’s standard and does not modify the spec; it demonstrates one way to add verifiable authorization on top of ACP.
+
+---
+
 ## 📝 Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for:

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Docs: Add “Community Implementations” section to README with a link to a community zkML authorization demo that layers verifiable proofs on top of ACP without changing the spec.


### PR DESCRIPTION
- Summary
  - Adds a "Community Implementations" section to README referencing a community zkML authorization demo that layers verifiable proofs on top of ACP without changing the spec.
  - Adds a corresponding entry to changelog/unreleased.md per contribution guidelines.
- Motivation
  - Provide developers a concrete, runnable example of augmenting ACP flows with cryptographic verification (zkML + on-chain), without expanding scope of the ACP spec.
- Changes
  - README: new section "Community Implementations" linking to https://github.com/hshadab/agentkit/tree/main/acp
  - Changelog: added docs entry in changelog/unreleased.md
- How To Verify
  - Open README and confirm the new section; follow the link to the community project.
  - Note no spec files (OpenAPI/JSON Schema) were changed.
- Checklist
  - [x] Docs-only update
  - [x] Aligns with CONTRIBUTING (adds changelog entry)
  - [x] No spec or example changes
