### PR TITLE
fix: resolves consistency issues in spec and examples

### DIFF
--- a/spec/json-schema/schema.agentic_checkout.json
+++ b/spec/json-schema/schema.agentic_checkout.json
@@ -181,13 +181,13 @@
           "format": "date-time"
         },
         "subtotal": {
-          "type": "number"
+          "type": "integer"
         },
         "tax": {
-          "type": "number"
+          "type": "integer"
         },
         "total": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "required": ["type", "id", "title", "subtotal", "tax", "total"]
@@ -210,13 +210,13 @@
           "type": "string"
         },
         "subtotal": {
-          "type": "number"
+          "type": "integer"
         },
         "tax": {
-          "type": "number"
+          "type": "integer"
         },
         "total": {
-          "type": "number"
+          "type": "integer"
         }
       },
       "required": ["type", "id", "title", "subtotal", "tax", "total"]

--- a/spec/openapi/openapi.agentic_checkout.yaml
+++ b/spec/openapi/openapi.agentic_checkout.yaml
@@ -377,9 +377,9 @@ components:
         carrier: { type: string }
         earliest_delivery_time: { type: string, format: date-time }
         latest_delivery_time: { type: string, format: date-time }
-        subtotal: { type: number }
-        tax: { type: number }
-        total: { type: number }
+        subtotal: { type: string }
+        tax: { type: string }
+        total: { type: string }
       required: [type, id, title, subtotal, tax, total]
 
     FulfillmentOptionDigital:
@@ -390,9 +390,9 @@ components:
         id: { type: string }
         title: { type: string }
         subtitle: { type: string }
-        subtotal: { type: number }
-        tax: { type: number }
-        total: { type: number }
+        subtotal: { type: string }
+        tax: { type: string }
+        total: { type: string }
       required: [type, id, title, subtotal, tax, total]
 
     MessageInfo:


### PR DESCRIPTION
# Agentic Checkout Spec Review

---

## ~Issue-1: Type Mismatch in *FulfillmentOption* Fields~

> [!NOTE]
> This issue is resolved by PR #11  

**Location:** `spec/openapi/openapi.agentic_checkout.yaml:380–395`

**Problem:**
In the `FulfillmentOptionShipping` and `FulfillmentOptionDigital` schemas, the `subtotal`, `tax`, and `total` fields are defined as `type: string`, but they should be `type: number` to match:

1. The JSON Schema definition (`schema.agentic_checkout.json:183–220`)
2. The RFC documentation, which explicitly states: “All money fields are integers (minor units)”
3. The example data, which uses integer values (e.g., `"subtotal": 100`)

**Impact:**
This inconsistency could lead to integration errors where implementations following the OpenAPI spec send strings while the JSON schema and examples expect integers.

---

## Issue-2: Missing `payment_provider` in Response Examples

**Location:** `examples/examples.agentic_checkout.json`

**Problem:**
Several response examples are missing the `payment_provider` field, which is **required** in the `CheckoutSessionBase` schema. Specifically:

* `update_checkout_session_response` (line 115)
* `get_checkout_session_response` (line 320)
* `cancel_checkout_session_response` (line 409)

These responses should include the `payment_provider` object to be valid according to the schema.

---

## Issue-3: Missing `order` Field in Complete Response Example

**Location:** `examples/examples.agentic_checkout.json:225` (`complete_checkout_session_response`)

**Problem:**
The `complete_checkout_session_response` example is missing the `order` field, which is required by the `CheckoutSessionWithOrder` schema and the RFC specification (Section 4.4: “Response MUST include status: completed and an order”).

---

## Issue-4: Inconsistent Error Response Format in Delegate Payment API

**Location:** `spec/openapi/openapi.delegate_payment.yaml:105–121`

**Problem:**
The error examples in the Delegate Payment API wrap the error object in an `error` property, e.g.:

```json
{
  "error": { "type": "...", "code": "...", ... }
}
```

…but the schema definition at lines 409–430 shows the `Error` object is returned **directly** (not wrapped).

**Impact:**
This inconsistency could cause confusion for implementers.
The schema should match the examples—or vice versa.

---

## Issue-5: Invalid Error Codes in Delegate Payment Examples

**Location:** `spec/openapi/openapi.delegate_payment.yaml`

**Problem:**
The error examples use `type` values not listed in the `Error` schema enum (defined at lines 413–420). Specifically:

* Line 117: `type: unauthorized` → ❌ not in enum
* Line 162: `type: internal_server_error` → ❌ not in enum
* Line 174: `type: service_unavailable` → ✅ valid

**Allowed values:**
`invalid_request | rate_limit_exceeded | processing_error | service_unavailable`

The schema only allows these four specific error types, but the examples use values outside that list.

---

## ~Issue-6: Inconsistent `fulfillment_option_id` in Complete Response~ 

> [!NOTE]
> This issue is resolved by PR #7 

**Location:** `examples/examples.agentic_checkout.json:258` (`complete_checkout_session_response`)

**Problem:**
In the `complete_checkout_session_response` example,
`fulfillment_option_id` = `"fulfillment_option_123"` (Standard shipping $1.00)
but earlier in the update flow (lines 113–142) the user selected
`"fulfillment_option_456"` (Express shipping $5.00), and the update response confirmed this change.

**Expected:**
The complete response should maintain the **Express shipping** option that was selected, not revert to Standard.

---
