### PR TITLE
Feature: add account to account payment support

### DIFF
--- a/changelog/unreleased/account-to-account-payment-support.md
+++ b/changelog/unreleased/account-to-account-payment-support.md
@@ -1,0 +1,25 @@
+## Account-to-account payment support
+
+Added `dev.acp.account_to_account` payment handler for push-based bank transfer payments.
+
+### Changes
+
+- Added `BankInstructions` schema: destination account details (IBAN/local account, BIC, bank name, payment reference, expiry) returned by the merchant when a checkout is completed with a push payment handler.
+- Added `BankTransferConfirmation` schema: settlement status tracking (`pending`, `received`, `expired`, `failed`) with `received_at` timestamp.
+- Added `bank_instructions` and `bank_transfer_confirmation` as optional fields on the `Order` schema for account-to-account orders.
+- Updated `PaymentData.anyOf` to allow handler-only references (no instrument) for push payment handlers.
+- Updated `completeCheckoutSession` endpoint documentation to describe the push payment flow (`complete_in_progress` status with bank instructions returned in order).
+- Added account-to-account examples for checkout completion, webhook `order_create`, and webhook `order_update` (settlement confirmed).
+
+### Backward Compatibility
+
+Additive only; no breaking schema changes. Existing implementations ignore unknown handlers and optional Order fields.
+
+### Files Updated
+
+- `spec/unreleased/openapi/openapi.agentic_checkout.yaml`
+- `spec/unreleased/json-schema/schema.agentic_checkout.json`
+- `spec/unreleased/openapi/openapi.agentic_checkout_webhook.yaml`
+- `examples/unreleased/examples.agentic_checkout.json`
+- `rfcs/rfc.agentic_checkout.md`
+- `rfcs/rfc.delegate_payment.md`

--- a/examples/unreleased/examples.agentic_checkout.json
+++ b/examples/unreleased/examples.agentic_checkout.json
@@ -1447,6 +1447,145 @@
       }
     ]
   },
+  "complete_checkout_session_request_account_to_account": {
+    "buyer": {
+      "first_name": "Ada",
+      "last_name": "Lovelace",
+      "email": "ada@example.com"
+    },
+    "payment_data": {
+      "handler_id": "a2a_bank_transfer"
+    }
+  },
+  "complete_checkout_session_response_account_to_account": {
+    "id": "checkout_session_a2a",
+    "status": "complete_in_progress",
+    "currency": "eur",
+    "capabilities": {
+      "payment": {
+        "handlers": [
+          {
+            "id": "a2a_bank_transfer",
+            "name": "dev.acp.account_to_account",
+            "version": "2026-01-30",
+            "spec": "https://acp.dev/handlers/account_to_account",
+            "requires_delegate_payment": false,
+            "requires_pci_compliance": false,
+            "psp": "bank_transfer",
+            "config_schema": "https://acp.dev/schemas/handlers/account_to_account/config.json",
+            "instrument_schemas": [],
+            "config": {}
+          }
+        ]
+      }
+    },
+    "line_items": [
+      {
+        "id": "line_item_456",
+        "item": { "id": "item_456", "quantity": 1 },
+        "base_amount": 5000,
+        "discount": 0,
+        "subtotal": 5000,
+        "tax": 400,
+        "total": 5400
+      }
+    ],
+    "totals": [
+      { "type": "subtotal", "display_text": "Subtotal", "amount": 5000 },
+      { "type": "tax", "display_text": "Tax", "amount": 400 },
+      { "type": "total", "display_text": "Total", "amount": 5400 }
+    ],
+    "fulfillment_options": [],
+    "messages": [
+      {
+        "type": "info",
+        "content_type": "plain",
+        "content": "Please transfer EUR 54.00 to Example Bank IBAN DE89 3704 0044 0532 0130 00 with reference ORDER-A2A-123456. The transfer must be completed before 2026-03-01."
+      }
+    ],
+    "links": [
+      {
+        "type": "terms_of_use",
+        "url": "https://www.testshop.com/legal/terms-of-use"
+      }
+    ],
+    "order": {
+      "id": "ord_a2a_123",
+      "checkout_session_id": "checkout_session_a2a",
+      "permalink_url": "https://example.com/orders/a2a_123",
+      "status": "created",
+      "bank_instructions": {
+        "account_address": "DE89370400440532013000",
+        "bank_identifier": "37040044",
+        "bic": "COBADEFFXXX",
+        "bank_name": "Example Bank",
+        "reference": "ORDER-A2A-123456",
+        "expires_at": "2026-03-01T00:00:00Z"
+      },
+      "bank_transfer_confirmation": {
+        "status": "pending"
+      },
+      "totals": [
+        { "type": "subtotal", "display_text": "Subtotal", "amount": 5000 },
+        { "type": "tax", "display_text": "Tax", "amount": 400 },
+        { "type": "total", "display_text": "Total", "amount": 5400 }
+      ]
+    }
+  },
+  "webhook_order_create_account_to_account": {
+    "type": "order_create",
+    "data": {
+      "type": "order",
+      "id": "ord_a2a_123",
+      "checkout_session_id": "checkout_session_a2a",
+      "permalink_url": "https://example.com/orders/a2a_123",
+      "status": "created",
+      "bank_instructions": {
+        "account_address": "DE89370400440532013000",
+        "bank_identifier": "37040044",
+        "bic": "COBADEFFXXX",
+        "bank_name": "Example Bank",
+        "reference": "ORDER-A2A-123456",
+        "expires_at": "2026-03-01T00:00:00Z"
+      },
+      "bank_transfer_confirmation": {
+        "status": "pending"
+      },
+      "totals": [
+        { "type": "subtotal", "display_text": "Subtotal", "amount": 5000 },
+        { "type": "tax", "display_text": "Tax", "amount": 400 },
+        { "type": "total", "display_text": "Total", "amount": 5400 }
+      ]
+    }
+  },
+  "webhook_order_update_account_to_account_settled": {
+    "type": "order_update",
+    "data": {
+      "type": "order",
+      "id": "ord_a2a_123",
+      "checkout_session_id": "checkout_session_a2a",
+      "permalink_url": "https://example.com/orders/a2a_123",
+      "status": "confirmed",
+      "bank_instructions": {
+        "account_address": "DE89370400440532013000",
+        "bank_identifier": "37040044",
+        "bic": "COBADEFFXXX",
+        "bank_name": "Example Bank",
+        "reference": "ORDER-A2A-123456",
+        "expires_at": "2026-03-01T00:00:00Z"
+      },
+      "bank_transfer_confirmation": {
+        "status": "received",
+        "received_at": "2026-02-19T12:01:00Z",
+        "reference": "ORDER-A2A-123456"
+      },
+      "totals": [
+        { "type": "subtotal", "display_text": "Subtotal", "amount": 5000 },
+        { "type": "tax", "display_text": "Tax", "amount": 400 },
+        { "type": "total", "display_text": "Total", "amount": 5400 }
+      ]
+    }
+  },
   "error_400_idempotency_key_required": {
     "type": "invalid_request",
     "code": "idempotency_key_required",

--- a/rfcs/rfc.delegate_payment.md
+++ b/rfcs/rfc.delegate_payment.md
@@ -14,7 +14,7 @@ This RFC defines a **single, MUST-implement** HTTP endpoint that issues a **dele
 - Preserve merchant PSP flows, idempotency, auditability, and risk controls.
 - Provide a **stable, versioned** surface (API-Version = `2025-09-29`).
 
-**Out of scope:** PSP-specific authorization/capture, multi-use tokens beyond allowance, refund semantics.
+**Out of scope:** PSP-specific authorization/capture, multi-use tokens beyond allowance, refund semantics, push payment methods (e.g., account-to-account bank transfers). Push payments do not require credential delegation because the buyer initiates the transfer externally; they are handled via the payment handler model in the Agentic Checkout spec.
 
 ### 1.1 Terminology & Normative Language
 

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -1859,8 +1859,73 @@
           "required": [
             "purchase_order_number"
           ]
+        },
+        {
+          "description": "Push payment handler (e.g., account-to-account) — no instrument required",
+          "required": [
+            "handler_id"
+          ]
         }
       ]
+    },
+    "BankInstructions": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Bank transfer instructions for account-to-account push payments. Returned by the merchant when a checkout is completed with a push payment handler.",
+      "properties": {
+        "account_address": {
+          "type": "string",
+          "description": "Destination account identifier (e.g., IBAN, local account number)"
+        },
+        "bank_identifier": {
+          "type": "string",
+          "description": "Domestic clearing code (e.g., ABA routing number, UK sort code)"
+        },
+        "bic": {
+          "type": "string",
+          "description": "SWIFT/BIC (ISO 9362) identifier"
+        },
+        "bank_name": {
+          "type": "string",
+          "description": "Name of the destination bank"
+        },
+        "reference": {
+          "type": "string",
+          "description": "Payment reference the buyer must include with the transfer"
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Deadline for the buyer to complete the transfer (RFC 3339)"
+        }
+      },
+      "required": [
+        "account_address",
+        "bank_name",
+        "reference"
+      ]
+    },
+    "BankTransferConfirmation": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Settlement confirmation for account-to-account payments. Tracks the status of the buyer-initiated bank transfer.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["pending", "received", "expired", "failed"],
+          "description": "Current settlement status"
+        },
+        "received_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the transfer was confirmed received (RFC 3339)"
+        },
+        "reference": {
+          "type": "string",
+          "description": "Bank-assigned reference for the completed transfer"
+        }
+      },
+      "required": ["status"]
     },
     "ProtocolVersion": {
       "type": "object",
@@ -2217,6 +2282,14 @@
           "type": "array",
           "items": { "$ref": "#/$defs/Total" },
           "description": "Order-level totals using the same Total schema as checkout. The 'total' entry is always the original charged amount. 'amount_refunded' tracks cumulative refunds."
+        },
+        "bank_instructions": {
+          "$ref": "#/$defs/BankInstructions",
+          "description": "Bank transfer instructions for account-to-account push payments. Present when the order was placed via a push payment handler."
+        },
+        "bank_transfer_confirmation": {
+          "$ref": "#/$defs/BankTransferConfirmation",
+          "description": "Settlement confirmation for account-to-account payments. Tracks transfer status from pending to received."
         }
       },
       "required": [

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -222,6 +222,14 @@ paths:
       description: |
         Finalizes the checkout by applying a payment method. MUST create an order and return completed state on success.
 
+        For pull payment handlers (e.g., tokenized card), the agent submits an instrument with credentials
+        and the merchant processes the payment synchronously, returning `status: completed` with an order.
+
+        For push payment handlers (e.g., account-to-account bank transfer), the agent references only the
+        `handler_id` without an instrument. The merchant returns bank transfer instructions in the order's
+        `bank_instructions` field and sets `status: complete_in_progress` until the buyer completes the
+        external transfer. Settlement is confirmed asynchronously via `order_update` webhooks.
+
         Agents MAY include `affiliate_attribution` to ensure the merchant receives final attribution context.
         Attribution is stored alongside the resulting order but not returned in the response.
       requestBody:
@@ -241,6 +249,15 @@ paths:
                   payment_data:
                     token: "spt_123"
                     provider: "stripe"
+              account_to_account:
+                summary: Complete with account-to-account bank transfer
+                value:
+                  buyer:
+                    first_name: "Ada"
+                    last_name: "Lovelace"
+                    email: "ada@example.com"
+                  payment_data:
+                    handler_id: "a2a_bank_transfer"
               with_affiliate_attribution:
                 summary: Complete with last-touch affiliate attribution
                 value:
@@ -1291,6 +1308,57 @@ components:
       anyOf:
         - required: [handler_id, instrument]
         - required: [purchase_order_number]
+        - description: "Push payment handler (e.g., account-to-account) — no instrument required"
+          required: [handler_id]
+
+    BankInstructions:
+      type: object
+      additionalProperties: false
+      description: |
+        Bank transfer instructions for account-to-account push payments.
+        Returned by the merchant when a checkout is completed with a push payment handler.
+        The buyer must initiate the transfer externally using these details.
+      properties:
+        account_address:
+          type: string
+          description: "Destination account identifier (e.g., IBAN, local account number)"
+        bank_identifier:
+          type: string
+          description: "Domestic clearing code (e.g., ABA routing number, UK sort code)"
+        bic:
+          type: string
+          description: "SWIFT/BIC (ISO 9362) identifier"
+        bank_name:
+          type: string
+          description: "Name of the destination bank"
+        reference:
+          type: string
+          description: "Payment reference the buyer must include with the transfer"
+        expires_at:
+          type: string
+          format: date-time
+          description: "Deadline for the buyer to complete the transfer (RFC 3339)"
+      required: [account_address, bank_name, reference]
+
+    BankTransferConfirmation:
+      type: object
+      additionalProperties: false
+      description: |
+        Settlement confirmation for account-to-account payments.
+        Tracks the status of the buyer-initiated bank transfer.
+      properties:
+        status:
+          type: string
+          enum: [pending, received, expired, failed]
+          description: "Current settlement status"
+        received_at:
+          type: string
+          format: date-time
+          description: "Timestamp when the transfer was confirmed received (RFC 3339)"
+        reference:
+          type: string
+          description: "Bank-assigned reference for the completed transfer"
+      required: [status]
 
     FulfillmentGroup:
       type: object
@@ -1374,6 +1442,12 @@ components:
           type: array
           items: { $ref: "#/components/schemas/Total" }
           description: "Order-level totals using the same Total schema as checkout. The 'total' entry is always the original charged amount. 'amount_refunded' tracks cumulative refunds."
+        bank_instructions:
+          $ref: "#/components/schemas/BankInstructions"
+          description: "Bank transfer instructions for account-to-account push payments. Present when the order was placed via a push payment handler."
+        bank_transfer_confirmation:
+          $ref: "#/components/schemas/BankTransferConfirmation"
+          description: "Settlement confirmation for account-to-account payments. Tracks transfer status from pending to received."
       required: [id, checkout_session_id, permalink_url]
 
     OrderLineItem:

--- a/spec/unreleased/openapi/openapi.agentic_checkout_webhook.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout_webhook.yaml
@@ -117,6 +117,66 @@ paths:
                       - { type: fulfillment, display_text: "Shipping", amount: 500 }
                       - { type: tax, display_text: "Tax", amount: 860 }
                       - { type: total, display_text: "Total", amount: 11260 }
+              order_created_a2a:
+                summary: A2A order created — awaiting bank transfer
+                value:
+                  type: order_create
+                  data:
+                    type: order
+                    id: "ord_a2a_123"
+                    checkout_session_id: "checkout_session_a2a"
+                    permalink_url: "https://example.com/orders/a2a_123"
+                    status: created
+                    line_items:
+                      - id: "li_laptop"
+                        title: "Laptop Stand"
+                        quantity: { ordered: 1, shipped: 0 }
+                        unit_price: 5000
+                        subtotal: 5000
+                    bank_instructions:
+                      account_address: "DE89370400440532013000"
+                      bank_identifier: "37040044"
+                      bic: "COBADEFFXXX"
+                      bank_name: "Example Bank"
+                      reference: "ORDER-A2A-123456"
+                      expires_at: "2026-03-01T00:00:00Z"
+                    bank_transfer_confirmation:
+                      status: pending
+                    totals:
+                      - { type: subtotal, display_text: "Subtotal", amount: 5000 }
+                      - { type: tax, display_text: "Tax", amount: 400 }
+                      - { type: total, display_text: "Total", amount: 5400 }
+              order_updated_a2a_received:
+                summary: A2A bank transfer confirmed
+                value:
+                  type: order_update
+                  data:
+                    type: order
+                    id: "ord_a2a_123"
+                    checkout_session_id: "checkout_session_a2a"
+                    permalink_url: "https://example.com/orders/a2a_123"
+                    status: confirmed
+                    line_items:
+                      - id: "li_laptop"
+                        title: "Laptop Stand"
+                        quantity: { ordered: 1, shipped: 0 }
+                        unit_price: 5000
+                        subtotal: 5000
+                    bank_instructions:
+                      account_address: "DE89370400440532013000"
+                      bank_identifier: "37040044"
+                      bic: "COBADEFFXXX"
+                      bank_name: "Example Bank"
+                      reference: "ORDER-A2A-123456"
+                      expires_at: "2026-03-01T00:00:00Z"
+                    bank_transfer_confirmation:
+                      status: received
+                      received_at: "2026-02-19T12:01:00Z"
+                      reference: "ORDER-A2A-123456"
+                    totals:
+                      - { type: subtotal, display_text: "Subtotal", amount: 5000 }
+                      - { type: tax, display_text: "Tax", amount: 400 }
+                      - { type: total, display_text: "Total", amount: 5400 }
               order_with_refund:
                 summary: Order with a completed refund
                 value:


### PR DESCRIPTION
**Context**
Account-to-Account (A2A) payments are not a regional edge case — they’re the dominant form of money movement globally.
While card networks remain essential for retail payments, A2A rails (ACH, SEPA Instant, Pix, UPI, Coelsa CVU, etc.) process the majority of the world’s payment volume — powering payroll, B2B transactions, instant transfers, and low-cost digital commerce across every major economy.

By extending the Agentic Commerce Protocol beyond card tokenization, this proposal enables agents to interact natively with the real financial infrastructure that moves the world’s money.
It ensures that AI-driven commerce can operate over open banking and instant-payment networks, not just legacy card rails.

**Key motivations:**

Global coverage: Make ACP compatible with A2A systems in the U.S. (ACH, FedNow), Europe (SEPA Instant), India (UPI), Brazil (Pix), Argentina (Coelsa CVU), and beyond.

Interoperability: Define one unified payment data shape per flow, reducing duplication and ambiguity across payment methods.

Economic accessibility: Lower transaction costs and open agentic commerce to regions where card fees or penetration are barriers to adoption.

Future-proofing: Position ACP as the universal agent-to-business payment layer, equally capable of handling pull-based (card) and push-based (A2A) transactions.

**Summary**  
- Consolidates card and account-to-account payment flows around a single `type`-driven schema across OpenAPI, JSON Schema, and RFCs.  
- Introduces generic bank instruction fields (`account_address`, optional `bank_identifier` and additional parameters) to cover international A2A transfers without altering card semantics.

**Changes**  
- Specs/Schema: `spec/openapi/openapi.agentic_checkout.yaml`, `spec/openapi/openapi.agentic_checkout_webhook.yaml`, `spec/json-schema/schema.agentic_checkout.json`.  
- Examples: `examples/examples.agentic_checkout.json`.  
- Documentation: `rfcs/rfc.agentic_checkout.md`.
- Changelog: `changelog/unreleased.md` entry covering the schema consolidation and allowance clarification.

**TLDR;**
Over 70% of global payment volume already moves account-to-account — yet the current ACP spec only defines card-based flows. This proposal brings the other 70% of the world into the protocol.