### PR TITLE
Add PIX payment method support to Agentic Checkout and Delegate Payment APIs

### DIFF
--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -1,0 +1,36 @@
+# Unreleased Changes
+
+## Payment Method Expansion: PIX Support
+
+- **Added PIX payment method support** to both Agentic Checkout and Delegate Payment specifications.
+  - PIX is the instant payment system developed by the Brazilian Central Bank (Banco Central do Brasil).
+  - Enables instant payments in Brazilian Real (BRL) with near-instant settlement.
+
+- **Added Brazilian payment providers:**
+  - `mercadopago`  Mercado Pago, major Latin American payment platform
+  - `pagseguro`  PagSeguro, Brazilian payment gateway
+  - Existing `stripe` provider now supports PIX alongside card payments
+
+- **New PaymentMethodPix schema** in Delegate Payment API:
+  - `cpf_cnpj` field for Brazilian tax identification (required)
+  - `pix_key` and `pix_key_type` for payment routing (optional)
+  - `qr_code_data` for PIX QR code EMV payload (optional)
+  - Validation rules for CPF (11 digits) and CNPJ (14 digits) formats
+
+- **Updated schemas:**
+  - `PaymentProvider.provider` enum now includes: `stripe`, `mercadopago`, `pagseguro`
+  - `PaymentProvider.supported_payment_methods` enum now includes: `card`, `pix`
+  - `PaymentData.provider` enum updated to match payment provider options
+
+- **New examples added:**
+  - Agentic Checkout examples for PIX with all three providers
+  - Delegate Payment examples showing PIX tokenization with various field combinations
+  - Examples demonstrate Brazilian addresses, currency (BRL), and PIX-specific flows
+
+- **RFC documentation updated:**
+  - New section in Agentic Checkout RFC (5.1) documenting PIX payment method
+  - New section in Delegate Payment RFC (3.4) documenting PaymentMethodPix structure
+  - Updated validation rules to include PIX-specific requirements
+  - Added guidance on currency, geography, and instant settlement characteristics
+
+This change enables merchants in Brazil to accept PIX payments through AI agent-driven checkout flows, supporting the growing adoption of instant payments in Latin America.

--- a/examples/examples.agentic_checkout.json
+++ b/examples/examples.agentic_checkout.json
@@ -513,5 +513,232 @@
         }
       ]
     }
+  },
+  "create_checkout_session_response_pix_stripe": {
+    "id": "checkout_session_456",
+    "payment_provider": {
+      "provider": "stripe",
+      "supported_payment_methods": ["card", "pix"]
+    },
+    "status": "ready_for_payment",
+    "currency": "brl",
+    "line_items": [
+      {
+        "id": "line_item_456",
+        "item": {
+          "id": "item_456",
+          "quantity": 1
+        },
+        "base_amount": 10000,
+        "discount": 0,
+        "subtotal": 10000,
+        "tax": 1000,
+        "total": 11000
+      }
+    ],
+    "fulfillment_address": {
+      "name": "João Silva",
+      "line_one": "Avenida Paulista, 1000",
+      "line_two": "Apto 123",
+      "city": "São Paulo",
+      "state": "SP",
+      "country": "BR",
+      "postal_code": "01310-100"
+    },
+    "fulfillment_option_id": "fulfillment_option_digital_001",
+    "totals": [
+      {
+        "type": "items_base_amount",
+        "display_text": "Total dos Itens",
+        "amount": 10000
+      },
+      {
+        "type": "subtotal",
+        "display_text": "Subtotal",
+        "amount": 10000
+      },
+      {
+        "type": "tax",
+        "display_text": "Impostos",
+        "amount": 1000
+      },
+      {
+        "type": "total",
+        "display_text": "Total",
+        "amount": 11000
+      }
+    ],
+    "fulfillment_options": [
+      {
+        "type": "digital",
+        "id": "fulfillment_option_digital_001",
+        "title": "Entrega Digital",
+        "subtitle": "Disponível imediatamente",
+        "subtotal": 0,
+        "tax": 0,
+        "total": 0
+      }
+    ],
+    "messages": [],
+    "links": [
+      {
+        "type": "terms_of_use",
+        "url": "https://www.testshop.com.br/legal/termos-de-uso"
+      }
+    ]
+  },
+  "create_checkout_session_response_pix_mercadopago": {
+    "id": "checkout_session_789",
+    "payment_provider": {
+      "provider": "mercadopago",
+      "supported_payment_methods": ["pix"]
+    },
+    "status": "ready_for_payment",
+    "currency": "brl",
+    "line_items": [
+      {
+        "id": "line_item_789",
+        "item": {
+          "id": "item_789",
+          "quantity": 2
+        },
+        "base_amount": 5000,
+        "discount": 500,
+        "subtotal": 9500,
+        "tax": 950,
+        "total": 10450
+      }
+    ],
+    "fulfillment_address": {
+      "name": "Maria Santos",
+      "line_one": "Rua das Flores, 456",
+      "line_two": "",
+      "city": "Rio de Janeiro",
+      "state": "RJ",
+      "country": "BR",
+      "postal_code": "20000-000"
+    },
+    "fulfillment_option_id": "fulfillment_option_shipping_br",
+    "totals": [
+      {
+        "type": "items_base_amount",
+        "display_text": "Total dos Itens",
+        "amount": 10000
+      },
+      {
+        "type": "items_discount",
+        "display_text": "Desconto",
+        "amount": -500
+      },
+      {
+        "type": "subtotal",
+        "display_text": "Subtotal",
+        "amount": 9500
+      },
+      {
+        "type": "tax",
+        "display_text": "Impostos",
+        "amount": 950
+      },
+      {
+        "type": "fulfillment",
+        "display_text": "Frete",
+        "amount": 1500
+      },
+      {
+        "type": "total",
+        "display_text": "Total",
+        "amount": 11950
+      }
+    ],
+    "fulfillment_options": [
+      {
+        "type": "shipping",
+        "id": "fulfillment_option_shipping_br",
+        "title": "Correios PAC",
+        "subtitle": "Chega em 7-10 dias úteis",
+        "carrier": "Correios",
+        "earliest_delivery_time": "2025-11-05T00:00:00Z",
+        "latest_delivery_time": "2025-11-10T00:00:00Z",
+        "subtotal": 1500,
+        "tax": 0,
+        "total": 1500
+      }
+    ],
+    "messages": [],
+    "links": [
+      {
+        "type": "terms_of_use",
+        "url": "https://www.testshop.com.br/legal/termos-de-uso"
+      }
+    ]
+  },
+  "create_checkout_session_response_pix_pagseguro": {
+    "id": "checkout_session_012",
+    "payment_provider": {
+      "provider": "pagseguro",
+      "supported_payment_methods": ["pix"]
+    },
+    "status": "ready_for_payment",
+    "currency": "brl",
+    "line_items": [
+      {
+        "id": "line_item_012",
+        "item": {
+          "id": "item_012",
+          "quantity": 1
+        },
+        "base_amount": 15000,
+        "discount": 0,
+        "subtotal": 15000,
+        "tax": 0,
+        "total": 15000
+      }
+    ],
+    "fulfillment_address": {
+      "name": "Carlos Oliveira",
+      "line_one": "Avenida Atlântica, 2000",
+      "line_two": "Cobertura",
+      "city": "Salvador",
+      "state": "BA",
+      "country": "BR",
+      "postal_code": "40000-000"
+    },
+    "fulfillment_option_id": "fulfillment_option_digital_002",
+    "totals": [
+      {
+        "type": "items_base_amount",
+        "display_text": "Total dos Itens",
+        "amount": 15000
+      },
+      {
+        "type": "subtotal",
+        "display_text": "Subtotal",
+        "amount": 15000
+      },
+      {
+        "type": "total",
+        "display_text": "Total",
+        "amount": 15000
+      }
+    ],
+    "fulfillment_options": [
+      {
+        "type": "digital",
+        "id": "fulfillment_option_digital_002",
+        "title": "Download Imediato",
+        "subtitle": "Acesso após confirmação do pagamento",
+        "subtotal": 0,
+        "tax": 0,
+        "total": 0
+      }
+    ],
+    "messages": [],
+    "links": [
+      {
+        "type": "terms_of_use",
+        "url": "https://www.testshop.com.br/legal/termos-de-uso"
+      }
+    ]
   }
 }

--- a/examples/examples.delegate_payment.json
+++ b/examples/examples.delegate_payment.json
@@ -72,5 +72,138 @@
     "type": "rate_limit_exceeded",
     "code": "too_many_requests",
     "message": "Too many requests, please retry later"
+  },
+  "delegate_payment_request_pix_with_key": {
+    "payment_method": {
+      "type": "pix",
+      "cpf_cnpj": "12345678901",
+      "pix_key": "joao.silva@example.com",
+      "pix_key_type": "email",
+      "metadata": {
+        "pix_provider": "banco_do_brasil"
+      }
+    },
+    "allowance": {
+      "reason": "one_time",
+      "max_amount": 50000,
+      "currency": "brl",
+      "checkout_session_id": "csn_br_01HV3P3XYZ9ABC",
+      "merchant_id": "loja_brasil",
+      "expires_at": "2025-10-09T07:20:50.52Z"
+    },
+    "billing_address": {
+      "name": "João Silva",
+      "line_one": "Avenida Paulista, 1000",
+      "line_two": "Apto 123",
+      "city": "São Paulo",
+      "state": "SP",
+      "country": "BR",
+      "postal_code": "01310-100"
+    },
+    "risk_signals": [
+      {
+        "type": "card_testing",
+        "score": 5,
+        "action": "authorized"
+      }
+    ],
+    "metadata": {
+      "campaign": "black_friday_br",
+      "source": "chatgpt_checkout_pix"
+    }
+  },
+  "delegate_payment_request_pix_with_qr": {
+    "payment_method": {
+      "type": "pix",
+      "cpf_cnpj": "12345678000190",
+      "qr_code_data": "00020126580014br.gov.bcb.pix0136a1b2c3d4-e5f6-7890-abcd-ef1234567890520400005303986540550.005802BR5913Loja Exemplo6009SAO PAULO62070503***63041D3D",
+      "metadata": {
+        "pix_provider": "mercadopago"
+      }
+    },
+    "allowance": {
+      "reason": "one_time",
+      "max_amount": 100000,
+      "currency": "brl",
+      "checkout_session_id": "csn_br_02HV3P3XYZ9ABC",
+      "merchant_id": "loja_brasil",
+      "expires_at": "2025-10-09T07:20:50.52Z"
+    },
+    "billing_address": {
+      "name": "Empresa LTDA",
+      "line_one": "Rua do Comércio, 500",
+      "line_two": "Sala 201",
+      "city": "Rio de Janeiro",
+      "state": "RJ",
+      "country": "BR",
+      "postal_code": "20000-000"
+    },
+    "risk_signals": [
+      {
+        "type": "card_testing",
+        "score": 3,
+        "action": "authorized"
+      }
+    ],
+    "metadata": {
+      "campaign": "corporate_sales",
+      "source": "chatgpt_checkout_pix",
+      "business_customer": "true"
+    }
+  },
+  "delegate_payment_request_pix_cpf_phone": {
+    "payment_method": {
+      "type": "pix",
+      "cpf_cnpj": "98765432100",
+      "pix_key": "+5511987654321",
+      "pix_key_type": "phone",
+      "metadata": {
+        "pix_provider": "pagseguro"
+      }
+    },
+    "allowance": {
+      "reason": "one_time",
+      "max_amount": 25000,
+      "currency": "brl",
+      "checkout_session_id": "csn_br_03HV3P3XYZ9ABC",
+      "merchant_id": "loja_brasil",
+      "expires_at": "2025-10-09T07:20:50.52Z"
+    },
+    "billing_address": {
+      "name": "Maria Santos",
+      "line_one": "Rua das Flores, 456",
+      "line_two": "",
+      "city": "Belo Horizonte",
+      "state": "MG",
+      "country": "BR",
+      "postal_code": "30000-000"
+    },
+    "risk_signals": [
+      {
+        "type": "card_testing",
+        "score": 8,
+        "action": "manual_review"
+      }
+    ],
+    "metadata": {
+      "campaign": "summer_sale",
+      "source": "chatgpt_checkout_pix"
+    }
+  },
+  "delegate_payment_success_response_pix": {
+    "id": "vt_pix_01J8Z3WXYZ9ABC",
+    "created": "2025-09-29T11:00:00Z",
+    "metadata": {
+      "source": "agent_checkout_pix",
+      "merchant_id": "loja_brasil",
+      "idempotency_key": "idem_pix_abc123",
+      "payment_method_type": "pix"
+    }
+  },
+  "delegate_payment_error_invalid_cpf": {
+    "type": "invalid_request",
+    "code": "invalid_card",
+    "message": "Invalid CPF/CNPJ format",
+    "param": "payment_method.cpf_cnpj"
   }
 }

--- a/spec/json-schema/schema.agentic_checkout.json
+++ b/spec/json-schema/schema.agentic_checkout.json
@@ -78,13 +78,13 @@
       "properties": {
         "provider": {
           "type": "string",
-          "enum": ["stripe"]
+          "enum": ["stripe", "mercadopago", "pagseguro"]
         },
         "supported_payment_methods": {
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["card"]
+            "enum": ["card", "pix"]
           }
         }
       },
@@ -300,7 +300,7 @@
         },
         "provider": {
           "type": "string",
-          "enum": ["stripe"]
+          "enum": ["stripe", "mercadopago", "pagseguro"]
         },
         "billing_address": {
           "$ref": "#/$defs/Address"

--- a/spec/json-schema/schema.delegate_payment_schema.json
+++ b/spec/json-schema/schema.delegate_payment_schema.json
@@ -124,6 +124,41 @@
         "metadata"
       ]
     },
+    "PaymentMethodPix": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "pix"
+        },
+        "cpf_cnpj": {
+          "type": "string",
+          "description": "Brazilian tax ID (CPF for individuals, CNPJ for businesses)",
+          "pattern": "^[0-9]{11}$|^[0-9]{14}$"
+        },
+        "pix_key": {
+          "type": "string",
+          "description": "PIX key for payment routing (optional)"
+        },
+        "pix_key_type": {
+          "type": "string",
+          "enum": ["cpf", "cnpj", "email", "phone", "random"],
+          "description": "Type of PIX key used"
+        },
+        "qr_code_data": {
+          "type": "string",
+          "description": "PIX QR code EMV payload (optional)"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["type", "cpf_cnpj", "metadata"]
+    },
     "Allowance": {
       "type": "object",
       "additionalProperties": false,
@@ -185,7 +220,14 @@
       "additionalProperties": false,
       "properties": {
         "payment_method": {
-          "$ref": "#/$defs/PaymentMethodCard"
+          "oneOf": [
+            {
+              "$ref": "#/$defs/PaymentMethodCard"
+            },
+            {
+              "$ref": "#/$defs/PaymentMethodPix"
+            }
+          ]
         },
         "allowance": {
           "$ref": "#/$defs/Allowance"

--- a/spec/openapi/openapi.agentic_checkout.yaml
+++ b/spec/openapi/openapi.agentic_checkout.yaml
@@ -324,12 +324,12 @@ components:
       properties:
         provider:
           type: string
-          enum: [stripe]
+          enum: [stripe, mercadopago, pagseguro]
         supported_payment_methods:
           type: array
           items:
             type: string
-            enum: [card]
+            enum: [card, pix]
       required: [provider, supported_payment_methods]
 
     LineItem:
@@ -446,7 +446,7 @@ components:
       additionalProperties: false
       properties:
         token: { type: string }
-        provider: { type: string, enum: [stripe] }
+        provider: { type: string, enum: [stripe, mercadopago, pagseguro] }
         billing_address: { $ref: "#/components/schemas/Address" }
       required: [token, provider]
 

--- a/spec/openapi/openapi.delegate_payment.yaml
+++ b/spec/openapi/openapi.delegate_payment.yaml
@@ -260,7 +260,14 @@ components:
       additionalProperties: false
       properties:
         payment_method:
-          $ref: "#/components/schemas/PaymentMethodCard"
+          oneOf:
+            - $ref: "#/components/schemas/PaymentMethodCard"
+            - $ref: "#/components/schemas/PaymentMethodPix"
+          discriminator:
+            propertyName: type
+            mapping:
+              card: "#/components/schemas/PaymentMethodCard"
+              pix: "#/components/schemas/PaymentMethodPix"
         allowance:
           $ref: "#/components/schemas/Allowance"
         billing_address:
@@ -325,6 +332,32 @@ components:
           type: object
           additionalProperties: { type: string }
       required: [type, card_number_type, number, display_card_funding_type, metadata]
+
+    PaymentMethodPix:
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          enum: [pix]
+        cpf_cnpj:
+          type: string
+          description: "Brazilian tax ID (CPF for individuals, CNPJ for businesses)"
+          pattern: "^[0-9]{11}$|^[0-9]{14}$"
+        pix_key:
+          type: string
+          description: "PIX key for payment routing (optional)"
+        pix_key_type:
+          type: string
+          enum: [cpf, cnpj, email, phone, random]
+          description: "Type of PIX key used"
+        qr_code_data:
+          type: string
+          description: "PIX QR code EMV payload (optional)"
+        metadata:
+          type: object
+          additionalProperties: { type: string }
+      required: [type, cpf_cnpj, metadata]
 
     Address:
       type: object


### PR DESCRIPTION
- Introduced PIX as a payment method, enabling instant payments in Brazilian Real (BRL).
- Updated schemas to include Brazilian payment providers: **Mercado Pago** and **PagSeguro**.
- Enhanced examples for Agentic Checkout and Delegate Payment to demonstrate PIX integration.
- Updated RFC documentation to include details on PIX payment method and its requirements.
- Added validation rules for CPF/CNPJ formats and PIX-specific fields.

This change supports the growing adoption of instant payments in Brazil and enhances the payment options available for merchants.