### PR TITLE
Add optional `description` field to Total type

### DIFF
--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -25,3 +25,14 @@ In the OpenAPI specification (`spec/openapi/openapi.agentic_checkout.yaml`), the
 This is a **clarification/bug fix**, not a breaking change. The specification has always required integer amounts in minor units (per the RFC), and all examples demonstrate integer usage. Implementations following the RFC and examples should already be using integers, so this change aligns the OpenAPI schema with the actual specification behavior.
 
 If any implementation was incorrectly sending/receiving these values as quoted strings (e.g., `"100"` instead of `100`), they should update to use numeric integers to comply with the specification.
+
+## Total Description Field
+
+- Added optional `description` field to the `Total` type to provide additional context for line items, especially fees
+- The `description` field is optional and can be used to explain charges (e.g., "Processing and handling fee")
+- Updated specification files:
+  - `spec/json-schema/schema.agentic_checkout.json`
+  - `spec/openapi/openapi.agentic_checkout.yaml`
+  - `rfcs/rfc.agentic_checkout.md`
+  - `examples/examples.agentic_checkout.json`
+

--- a/examples/examples.agentic_checkout.json
+++ b/examples/examples.agentic_checkout.json
@@ -70,9 +70,15 @@
         "amount": 100
       },
       {
+        "type": "fee",
+        "display_text": "Service Fee",
+        "amount": 50,
+        "description": "Processing and handling fee"
+      },
+      {
         "type": "total",
         "display_text": "Total",
-        "amount": 430
+        "amount": 480
       }
     ],
     "fulfillment_options": [

--- a/rfcs/rfc.agentic_checkout.md
+++ b/rfcs/rfc.agentic_checkout.md
@@ -157,7 +157,7 @@ Response **MUST** include `status: completed` and an `order` with `id`, `checkou
 
 - **Item**: `id` (string), `quantity` (int ≥ 1)
 - **LineItem**: `id`, `item`, `base_amount`, `discount`, `subtotal`, `tax`, `total` (**int**)
-- **Total**: `type` (`items_base_amount | items_discount | subtotal | discount | fulfillment | tax | fee | total`), `display_text`, `amount` (**int**)
+- **Total**: `type` (`items_base_amount | items_discount | subtotal | discount | fulfillment | tax | fee | total`), `display_text`, `amount` (**int**), `description?` (optional string for fees)
 - **FulfillmentOption (shipping)**: `id`, `title`, `subtitle?`, `carrier?`, `earliest_delivery_time?`, `latest_delivery_time?`, `subtotal`, `tax`, `total` (**int**)
 - **FulfillmentOption (digital)**: `id`, `title`, `subtitle?`, `subtotal`, `tax`, `total` (**int**)
 - **PaymentProvider**: `provider` (`stripe`), `supported_payment_methods` (`["card"]`)

--- a/spec/json-schema/schema.agentic_checkout.json
+++ b/spec/json-schema/schema.agentic_checkout.json
@@ -148,6 +148,9 @@
         },
         "amount": {
           "type": "integer"
+        },
+        "description": {
+          "type": "string"
         }
       },
       "required": ["type", "display_text", "amount"]

--- a/spec/openapi/openapi.agentic_checkout.yaml
+++ b/spec/openapi/openapi.agentic_checkout.yaml
@@ -364,6 +364,7 @@ components:
             ]
         display_text: { type: string }
         amount: { type: integer }
+        description: { type: string }
       required: [type, display_text, amount]
 
     FulfillmentOptionShipping:


### PR DESCRIPTION
- Added `description` field to provide context for fees and charges
- Field is optional and accepts a string value
- Updated JSON schema, OpenAPI spec, RFC, and examples
- Updated changelog with unreleased changes