### PR TITLE
Update fulfillment type for `subtotal`, `tax`, and `total` in `openapi.agentic_checkout.yaml`

### DIFF
--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -1,10 +1,14 @@
 # Unreleased Changes
 
-## Bug Fixes
+## Version 2025-12-11
 
-### Fix Fulfillment Amount Types in OpenAPI Specification
+### Bug Fixes
+
+#### Fix Fulfillment Amount Types in OpenAPI Specification
 
 **Fixed inconsistency in OpenAPI spec where fulfillment option amounts were incorrectly typed as strings instead of integers.**
+
+**Version Note:** Per CONTRIBUTING.md guidelines, the specification version has been incremented from `2025-09-29` to `2025-12-11` to reflect this schema change. While this is technically a bug fix/clarification (not a breaking change), we increment the version conservatively for any OpenAPI schema modifications to ensure proper tracking and avoid confusion.
 
 In the OpenAPI specification (`spec/openapi/openapi.agentic_checkout.yaml`), the `subtotal`, `tax`, and `total` fields in both `FulfillmentOptionShipping` and `FulfillmentOptionDigital` schemas were defined as `type: string`. This was inconsistent with:
 

--- a/rfcs/rfc.agentic_checkout.md
+++ b/rfcs/rfc.agentic_checkout.md
@@ -1,7 +1,7 @@
 # RFC: Agentic Checkout — Merchant REST API
 
 **Status:** Draft  
-**Version:** 2025-09-29  
+**Version:** 2025-12-11  
 **Scope:** Checkout session lifecycle and webhook integration
 
 This RFC defines the **Agentic Checkout Specification (ACS)**, a standardized REST API contract that merchants SHOULD implement to support experiences across agent platforms.
@@ -16,7 +16,7 @@ This specification ensures that:
 
 ## 1. Scope & Goals
 
-- Provide a **stable, versioned** API surface (`API-Version: 2025-09-29`) that ChatGPT calls to create, update, retrieve, complete, and cancel checkout sessions.
+- Provide a **stable, versioned** API surface (`API-Version: 2025-12-11`) that ChatGPT calls to create, update, retrieve, complete, and cancel checkout sessions.
 - Ensure ChatGPT renders an **authoritative cart state** on every response.
 - Keep **payments on merchant rails**; optional delegated payments are covered separately.
 - Support **safe retries** via idempotency and **strong security** via authentication and request signing.
@@ -33,7 +33,7 @@ The key words **MUST**, **MUST NOT**, **SHOULD**, **MAY** follow RFC 2119/8174.
 
 ### 2.1 Initialization
 
-- **Versioning:** Client (ChatGPT) **MUST** send `API-Version`. Server **MUST** validate support (e.g., `2025-09-29`).
+- **Versioning:** Client (ChatGPT) **MUST** send `API-Version`. Server **MUST** validate support (e.g., `2025-12-11`).
 - **Identity/Signing:** Server **SHOULD** publish acceptable signature algorithms out‑of‑band; client **SHOULD** sign requests (`Signature`) over canonical JSON with an accompanying `Timestamp` (RFC 3339).
 - **Capabilities:** Merchant **SHOULD** document accepted payment methods (e.g., `card`) and fulfillment types (`shipping`, `digital`).
 
@@ -67,7 +67,7 @@ All endpoints **MUST** use HTTPS and return JSON. Amounts **MUST** be integers i
 - `Request-Id: <string>` (**RECOMMENDED**)
 - `Signature: <base64url>` (**RECOMMENDED**)
 - `Timestamp: <RFC3339>` (**RECOMMENDED**)
-- `API-Version: 2025-09-29` (**REQUIRED**)
+- `API-Version: 2025-12-11` (**REQUIRED**)
 
 **Response Headers:**
 
@@ -546,7 +546,7 @@ All money fields are **integers (minor units)**.
 
 ## 10. Conformance Checklist
 
-- [ ] Enforces HTTPS, JSON, and `API-Version: 2025-09-29`
+- [ ] Enforces HTTPS, JSON, and `API-Version: 2025-12-11`
 - [ ] Returns **authoritative** cart state on every response
 - [ ] Uses **integer** minor units for all monetary amounts
 - [ ] Implements create, update (POST), retrieve (GET), complete, cancel

--- a/spec/openapi/openapi.agentic_checkout.yaml
+++ b/spec/openapi/openapi.agentic_checkout.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Agentic Checkout API
-  version: "2025-09-29"
+  version: "2025-12-11"
   description: |
     Merchant-implemented REST API for ChatGPT-driven checkout.
     Implements create, update (POST), retrieve (GET), complete, and cancel of checkout sessions.
@@ -284,7 +284,7 @@ components:
       name: API-Version
       in: header
       required: true
-      schema: { type: string, example: "2025-09-29" }
+      schema: { type: string, example: "2025-12-11" }
 
   schemas:
     Address:


### PR DESCRIPTION
## Fix Inconsistency in OpenAPI Spec

1. In json schema (spec/json-schema/schema.agentic_checkout.json)
In the json schema file, the `FulfillmentOptionShipping` has:
```
"subtotal": {
  "type": "integer"
},
"tax": {
  "type": "integer"
},
"total": {
  "type": "integer"
}
```

2. OpenAPI Spec (spec/openapi/openapi.agentic_checkout.yaml)
The OpenAPI file `FulfillmentOptionShipping` had these types as strings:
```
subtotal: { type: string }
tax: { type: string }
total: { type: string }
```

3. RFC documentation (rfcs/rfc.agentic_checkout.md)
> "All endpoints MUST use HTTPS and return JSON. Amounts MUST be integers in minor units."

and in Section 5 (Data Model (authoritative extract)) of the RFC explicitly states:

> "FulfillmentOption (shipping): type: "shipping", id, title, subtitle?, carrier?, earliest_delivery_time?, latest_delivery_time?, subtotal?, tax?, total (int)"

Note the int at the end indicating all money amounts are integers.

4. Examples file (examples/examples.agentic_checkout.json)
In the examples, these fields are consistently shown as numbers (not quoted strings):
```
"subtotal": 100,
"tax": 0,
"total": 100
```

**Fixed OpenAPI spec** (`spec/openapi/openapi.agentic_checkout.yaml`):
   - Changed `subtotal` from `type: string` to `type: integer` in `FulfillmentOptionShipping`
   - Changed `tax` from `type: string` to `type: integer` in `FulfillmentOptionShipping`
   - Changed `total` from `type: string` to `type: integer` in `FulfillmentOptionShipping`
   - Changed `subtotal` from `type: string` to `type: integer` in `FulfillmentOptionDigital`
   - Changed `tax` from `type: string` to `type: integer` in `FulfillmentOptionDigital`
   - Changed `total` from `type: string` to `type: integer` in `FulfillmentOptionDigital`

**Changelog**
Added entry documenting this as a bug fix/clarification
Explained the inconsistency and impact

**Compatibility**
The RFC has always required integer amounts, and all examples demonstrate integer usage
Implementations following the RFC should already be using integers
This aligns the OpenAPI schema with actual specification behavior