### PR TITLE
Add error response examples to examples.agentic_checkout.json

### DIFF
--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -40,3 +40,7 @@ If any implementation was incorrectly sending/receiving these values as quoted s
   - `spec/openapi/openapi.agentic_checkout.yaml`
   - `rfcs/rfc.agentic_checkout.md`
   - `examples/examples.agentic_checkout.json`
+
+## Examples
+
+- Added error response examples for invalid item ID, out-of-stock, and payment failure to `examples/examples.agentic_checkout.json`.

--- a/examples/examples.agentic_checkout.json
+++ b/examples/examples.agentic_checkout.json
@@ -539,5 +539,22 @@
         }
       ]
     }
+  },
+  "create_checkout_session_error_invalid_item_id": {
+    "type": "invalid_request",
+    "code": "invalid_item_id",
+    "message": "The item ID 'invalid_item' is not valid.",
+    "param": "$.items[0].id"
+  },
+  "create_checkout_session_error_out_of_stock": {
+    "type": "processing_error",
+    "code": "item_out_of_stock",
+    "message": "Item 'item_123' is out of stock.",
+    "param": "$.items[0].id"
+  },
+  "complete_checkout_session_error_payment_failed": {
+    "type": "processing_error",
+    "code": "payment_failed",
+    "message": "Payment processing failed due to insufficient funds."
   }
 }


### PR DESCRIPTION
Added three error response examples to `examples.agentic_checkout.json` for common failure cases:
- Invalid item ID during session creation
- Out-of-stock item error
- Payment failure during session completion

This helps developers understand error handling in the Agentic Checkout API.

Updated `changelog/unreleased.md` accordingly.

No spec changes or breaking updates. Follows contributing guidelines.