### PR TITLE
Add multi-item checkout example

### DIFF
--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -40,3 +40,8 @@ If any implementation was incorrectly sending/receiving these values as quoted s
   - `spec/openapi/openapi.agentic_checkout.yaml`
   - `rfcs/rfc.agentic_checkout.md`
   - `examples/examples.agentic_checkout.json`
+
+## Examples
+
+- Added error response examples for invalid item ID, out-of-stock, and payment failure to `examples/examples.agentic_checkout.json`.
+- Added multi-item checkout example to `examples/examples.multi_item_checkout.json`.

--- a/examples/examples.multi_item_checkout.json
+++ b/examples/examples.multi_item_checkout.json
@@ -1,0 +1,120 @@
+{
+  "create_checkout_session_request": {
+    "items": [
+      {
+        "id": "item_123",
+        "quantity": 2
+      },
+      {
+        "id": "item_456",
+        "quantity": 1
+      }
+    ],
+    "fulfillment_address": {
+      "name": "John Doe",
+      "line_one": "1234 Chat Road",
+      "line_two": "",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "US",
+      "postal_code": "94131"
+    }
+  },
+  "create_checkout_session_response": {
+    "id": "checkout_session_123",
+    "payment_provider": {
+      "provider": "stripe",
+      "supported_payment_methods": ["card"]
+    },
+    "status": "ready_for_payment",
+    "currency": "usd",
+    "line_items": [
+      {
+        "id": "line_item_123",
+        "item": {
+          "id": "item_123",
+          "quantity": 2
+        },
+        "base_amount": 300,
+        "discount": 0,
+        "subtotal": 600,
+        "tax": 60,
+        "total": 660
+      },
+      {
+        "id": "line_item_456",
+        "item": {
+          "id": "item_456",
+          "quantity": 1
+        },
+        "base_amount": 500,
+        "discount": 50,
+        "subtotal": 450,
+        "tax": 45,
+        "total": 495
+      }
+    ],
+    "fulfillment_address": {
+      "name": "John Doe",
+      "line_one": "1234 Chat Road",
+      "line_two": "",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "US",
+      "postal_code": "94131"
+    },
+    "fulfillment_option_id": "fulfillment_option_mixed",
+    "totals": [
+      {
+        "type": "items_base_amount",
+        "display_text": "Item(s) total",
+        "amount": 800
+      },
+      {
+        "type": "discount",
+        "display_text": "Discount",
+        "amount": 50
+      },
+      {
+        "type": "subtotal",
+        "display_text": "Subtotal",
+        "amount": 1050
+      },
+      {
+        "type": "tax",
+        "display_text": "Tax",
+        "amount": 105
+      },
+      {
+        "type": "fulfillment",
+        "display_text": "Fulfillment",
+        "amount": 150
+      },
+      {
+        "type": "fee",
+        "display_text": "Service Fee",
+        "amount": 75,
+        "description": "Processing and handling fee"
+      },
+      {
+        "type": "total",
+        "display_text": "Total",
+        "amount": 1380
+      }
+    ],
+    "fulfillment_options": [
+      {
+        "type": "shipping",
+        "id": "fulfillment_option_mixed",
+        "title": "Mixed Shipping & Digital",
+        "subtitle": "Physical items shipped, digital delivered instantly",
+        "carrier": "USPS",
+        "earliest_delivery_time": "2025-10-12T07:20:50.52Z",
+        "latest_delivery_time": "2025-10-13T07:20:50.52Z",
+        "subtotal": 150,
+        "tax": 15,
+        "total": 165
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Added a new example file `examples/examples.multi_item_checkout.json` demonstrating a checkout session with multiple items (2 physical, 1 with discount), mixed fulfillment options, and detailed totals including fees.

This expands the examples to cover more complex cart scenarios, helping developers integrate multi-item checkouts.

Updated `changelog/unreleased.md` accordingly.

No spec changes or breaking updates. Follows contributing guidelines.