### PR TITLE
SEP: Recurring payment support

### DIFF
--- a/changelog/unreleased/sep-recurring-payment-support.md
+++ b/changelog/unreleased/sep-recurring-payment-support.md
@@ -1,0 +1,10 @@
+# SEP: Recurring Payment Support
+
+**Delegate Payment API – Schema & Examples**
+
+- **Allowance schema**: Extended `reason` enum to include `recurring` and `subscription` values. Added optional fields for billing cycles (`billing_cycle`), per-cycle amounts (`amount_per_cycle`), cycle limits (`max_cycles`), trial periods (`trial_period_days`, `trial_amount`), usage-based billing (`usage_based`), and proration (`proration_enabled`). When `reason` is `recurring` or `subscription`, `billing_cycle` and `amount_per_cycle` are required.
+  - `spec/unreleased/json-schema/schema.delegate_payment.json`
+- **Recurring payment example**: Added `delegate_payment_recurring_request` and `delegate_payment_recurring_response` showing a monthly subscription delegation with trial period, cycle limits, and proration.
+  - `examples/unreleased/examples.delegate_payment.json`
+
+Addresses #12

--- a/examples/unreleased/examples.delegate_payment.json
+++ b/examples/unreleased/examples.delegate_payment.json
@@ -72,5 +72,73 @@
     "type": "rate_limit_exceeded",
     "code": "too_many_requests",
     "message": "Too many requests, please retry later"
+  },
+  "delegate_payment_recurring_request": {
+    "payment_method": {
+      "type": "card",
+      "card_number_type": "fpan",
+      "number": "4242424242424242",
+      "exp_month": "11",
+      "exp_year": "2026",
+      "name": "Jane Doe",
+      "cvc": "223",
+      "checks_performed": ["avs", "cvv"],
+      "iin": "424242",
+      "display_card_funding_type": "credit",
+      "display_wallet_type": "apple_pay",
+      "display_brand": "visa",
+      "display_last4": "4242",
+      "metadata": {
+        "issuing_bank": "temp"
+      }
+    },
+    "allowance": {
+      "reason": "recurring",
+      "max_amount": 10000,
+      "currency": "usd",
+      "checkout_session_id": "csn_01HV3P3XYZ9ABC",
+      "merchant_id": "acme_store",
+      "expires_at": "2026-12-31T23:59:59Z",
+      "billing_cycle": {
+        "interval": "month",
+        "interval_count": 1,
+        "anchor_date": "2026-01-01T00:00:00Z"
+      },
+      "amount_per_cycle": 2999,
+      "max_cycles": 12,
+      "trial_period_days": 14,
+      "trial_amount": 0,
+      "usage_based": false,
+      "proration_enabled": true
+    },
+    "billing_address": {
+      "name": "Ada Lovelace",
+      "line_one": "1234 Chat Road",
+      "line_two": "",
+      "city": "San Francisco",
+      "state": "CA",
+      "country": "US",
+      "postal_code": "94131"
+    },
+    "risk_signals": [
+      {
+        "type": "card_testing",
+        "score": 10,
+        "action": "manual_review"
+      }
+    ],
+    "metadata": {
+      "campaign": "subscription_q1",
+      "source": "chatgpt_checkout"
+    }
+  },
+  "delegate_payment_recurring_response": {
+    "id": "vt_01J8Z3WXYZ9ABC",
+    "created": "2026-01-10T11:00:00Z",
+    "metadata": {
+      "source": "agent_checkout",
+      "merchant_id": "acme_store",
+      "idempotency_key": "idem_recurring_abc123"
+    }
   }
 }

--- a/spec/unreleased/json-schema/schema.delegate_payment.json
+++ b/spec/unreleased/json-schema/schema.delegate_payment.json
@@ -130,7 +130,7 @@
       "properties": {
         "reason": {
           "type": "string",
-          "enum": ["one_time"]
+          "enum": ["one_time", "recurring", "subscription"]
         },
         "max_amount": {
           "type": "integer",
@@ -151,6 +151,47 @@
         "expires_at": {
           "type": "string",
           "format": "date-time"
+        },
+        "billing_cycle": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "interval": {
+              "type": "string",
+              "enum": ["day", "week", "month", "year"]
+            },
+            "interval_count": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "anchor_date": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "required": ["interval", "interval_count"]
+        },
+        "amount_per_cycle": {
+          "type": "integer",
+          "description": "Amount per billing cycle in minor units"
+        },
+        "max_cycles": {
+          "type": ["integer", "null"],
+          "minimum": 1
+        },
+        "trial_period_days": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "trial_amount": {
+          "type": "integer",
+          "description": "Trial amount in minor units"
+        },
+        "usage_based": {
+          "type": "boolean"
+        },
+        "proration_enabled": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -160,6 +201,20 @@
         "checkout_session_id",
         "merchant_id",
         "expires_at"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "reason": {
+                "enum": ["recurring", "subscription"]
+              }
+            }
+          },
+          "then": {
+            "required": ["billing_cycle", "amount_per_cycle"]
+          }
+        }
       ]
     },
     "RiskSignal": {


### PR DESCRIPTION
# SEP: Recurring payment support

## SEP Metadata

- SEP Number: #12
- Author(s): kxbnb
- Status: `proposal` (awaiting sponsor)
- Type: Major Change
- Related Issues/RFCs: #12

---

## Abstract

This SEP extends the delegate payment Allowance schema to support recurring and subscription payments. Right now, `reason` only allows `"one_time"`, so agents can't delegate tokens for subscriptions or recurring billing. This adds `"recurring"` and `"subscription"` reason types with fields for billing cycles, per-cycle amounts, trials, and proration.

---

## Motivation

Issue #12 lays out the gap: the current delegate payment spec only handles one-time transactions. SaaS platforms, subscription boxes, streaming services, and usage-based billing all need recurring payment support for agents to handle the full purchase lifecycle.

From building payment integrations at Freshop (grocery SaaS with recurring delivery subscriptions), I think the minimum viable recurring support needs a billing interval, a per-cycle amount cap, and an expiration. Everything else (trials, proration, usage-based) can be optional. That's the approach here: extend the existing Allowance rather than creating a whole new object.

---

## Specification

### Schema changes (`spec/unreleased/json-schema/schema.delegate_payment.json`)

`Allowance.reason` enum extended:
- `"one_time"` (existing)
- `"recurring"` (new)
- `"subscription"` (new)

New optional properties on Allowance:

| Field | Type | Description |
|-------|------|-------------|
| `billing_cycle` | object | Contains `interval` (day/week/month/year), `interval_count`, and optional `anchor_date` |
| `amount_per_cycle` | integer | Amount per billing cycle in minor units |
| `max_cycles` | integer or null | Max billing cycles (null = indefinite) |
| `trial_period_days` | integer | Trial period length in days |
| `trial_amount` | integer | Amount charged during trial in minor units |
| `usage_based` | boolean | Whether this is metered/usage-based billing |
| `proration_enabled` | boolean | Whether mid-cycle changes are prorated |

Conditional requirement: when `reason` is `"recurring"` or `"subscription"`, `billing_cycle` and `amount_per_cycle` become required.

### Example (`examples/unreleased/examples.delegate_payment.json`)

Added `delegate_payment_recurring_request` and `delegate_payment_recurring_response` showing a monthly subscription with $29.99/cycle, 12-cycle limit, 14-day trial at $0, and proration enabled.

---

## Rationale

Issue #12 proposed two approaches:
- Option A: Extend the `reason` enum and add fields directly to Allowance
- Option B: Create a separate `recurring_allowance` object

This goes with Option A because it keeps the schema simpler, doesn't require changes to `DelegatePaymentRequest`, and existing `one_time` flows are unaffected. The conditional `allOf`/`if`/`then` pattern means `billing_cycle` and `amount_per_cycle` are only required when the reason is recurring or subscription.

The distinction between `recurring` and `subscription` matters because they map to different payment provider concepts. `recurring` is for fixed-schedule charges (rent, installments). `subscription` is for ongoing service access with lifecycle management (pause, resume, upgrade). Merchants and agents need to communicate this intent to payment providers.

---

## Backward compatibility

No breaking changes. The `reason` enum is extended (additive), and all new fields are optional for `one_time` allowances. Existing delegate payment requests work without modification.

---

## Reference implementation

Schema changes and examples are in this PR. Validation passes with `pnpm run validate:all`.

---

## Security implications

Recurring payments increase the blast radius of a compromised token, since a single delegation can authorize multiple charges over time. Mitigations in the schema:
- `max_amount` caps total exposure
- `max_cycles` limits the number of charges
- `expires_at` provides an absolute cutoff
- `amount_per_cycle` caps each individual charge

Agents and merchants should treat recurring delegations with higher scrutiny in risk scoring.

---

## Pre-submission checklist

- [x] Related GitHub Issue exists (#12)
- [x] CLA signed
- [x] PR includes schema updates
- [x] PR includes example requests/responses
- [x] PR includes changelog entry
- [ ] Seeking a sponsor (Founding Maintainer)

---

## Questions for reviewers

1. Should `recurring` and `subscription` be separate reason values, or would a single `recurring` with an optional `subscription_lifecycle` flag be cleaner?
2. Is extending Allowance directly the right call, or should recurring fields live in a nested object (like `recurring_details`) to keep the flat Allowance cleaner?
3. Should this SEP also cover subscription-specific checkout session types and webhook events, or should those be separate SEPs?

Addresses #12