### PR TITLE
Fix: Remove merge conflict markers from openapi.agentic_checkout.yaml

### DIFF
--- a/spec/openapi/openapi.agentic_checkout.yaml
+++ b/spec/openapi/openapi.agentic_checkout.yaml
@@ -1,11 +1,7 @@
 openapi: 3.1.0
 info:
   title: Agentic Checkout API
-<<<<<<< HEAD
-  version: "2025-12-11"
-=======
   version: "2025-12-12"
->>>>>>> 18aaf70 (fullfillment details changes)
   description: |
     Merchant-implemented REST API for ChatGPT-driven checkout.
     Implements create, update (POST), retrieve (GET), complete, and cancel of checkout sessions.


### PR DESCRIPTION
## Summary
Cleaned up leftover merge conflict markers in the OpenAPI spec file that were accidentally committed.

## Changes
- Removed merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) from `spec/openapi/openapi.agentic_checkout.yaml`
- Resolved to use version `2025-12-12` which corresponds to the merged fulfillment enhancement changes

## Checklist
- [x] OpenAPI / JSON Schema: No schema changes, only cleanup
- [x] Examples: No example changes needed
- [x] Changelog: Not applicable (cleanup/fix)
- [x] Documentation: No documentation changes needed
- [x] CLA: Will be signed via CLA Assistant bot