### PR TITLE
[SEP #79] Allow merchants to specify their authentication_provider

### DIFF
--- a/changelog/2026-01-16.md
+++ b/changelog/2026-01-16.md
@@ -1,0 +1,20 @@
+# Version 2026-01-16
+
+---
+
+# Authentication Provider 
+
+**Added** – Initial support for an **open authentication provider model**, allowing merchants to specify their preferred 3DS 
+provider. Also adding required `merchant_id` field to `PaymentProvider`
+
+**Schema Changes:**
+- Added `merchant_id` required field to `PaymentProvider`
+- Added `AuthenticationProvider` schema with `provider`, `merchant_id`, and `supported_authentication_methods` fields
+- Added `authentication_provider` field to `CheckoutSessionBase`
+- Added `adyen` to the provider enum for both `PaymentProvider` and `AuthenticationProvider`
+
+**Files Updated:**
+- `spec/2026-01-16/schema.agentic_checkout.json`
+- `spec/2026-01-16/openapi.agentic_checkout.yaml`
+- `examples/2026-01-16/examples.agentic_checkout.json`
+- `rfcs/rfc.agentic_checkout.md`

--- a/examples/2026-01-16/examples.agentic_checkout.json
+++ b/examples/2026-01-16/examples.agentic_checkout.json
@@ -39,12 +39,18 @@
     "id": "checkout_session_123",
     "payment_provider": {
       "provider": "stripe",
+      "merchant_id": "acct_1234567890",
       "supported_payment_methods": [
         {
           "type": "card",
           "supported_card_networks": ["amex", "discover", "mastercard", "visa"]
         }
       ]
+    },
+    "authentication_provider": {
+      "provider": "stripe",
+      "merchant_id": "acct_1234567890",
+      "supported_authentication_methods": ["3ds"]
     },
     "status": "ready_for_payment",
     "currency": "usd",
@@ -738,12 +744,18 @@
     "id": "checkout_session_3ds_001",
     "payment_provider": {
       "provider": "stripe",
+      "merchant_id": "acct_1234567890",
       "supported_payment_methods": [
         {
           "type": "card",
           "supported_card_networks": ["amex", "discover", "mastercard", "visa"]
         }
       ]
+    },
+    "authentication_provider": {
+      "provider": "stripe",
+      "merchant_id": "acct_1234567890",
+      "supported_authentication_methods": ["3ds"]
     },
     "status": "authentication_required",
     "currency": "usd",

--- a/spec/2026-01-16/json-schema/schema.agentic_checkout.json
+++ b/spec/2026-01-16/json-schema/schema.agentic_checkout.json
@@ -222,6 +222,9 @@
           "type": "string",
           "enum": ["stripe"]
         },
+        "merchant_id": {
+          "type": "string"
+        },
         "supported_payment_methods": {
           "type": "array",
           "items": {
@@ -229,7 +232,7 @@
           }
         }
       },
-      "required": ["provider", "supported_payment_methods"]
+      "required": ["provider", "merchant_id", "supported_payment_methods"]
     },
     "PaymentMethod": {
       "type": "object",
@@ -700,6 +703,27 @@
       },
       "required": ["id", "checkout_session_id", "permalink_url"]
     },
+    "AuthenticationProvider": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "enum": ["stripe", "adyen"]
+        },
+        "merchant_id": {
+          "type": "string"
+        },
+        "supported_authentication_methods": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["3ds"]
+          }
+        }
+      },
+      "required": ["provider", "merchant_id", "supported_authentication_methods"]
+    },
     "CheckoutSessionBase": {
       "type": "object",
       "additionalProperties": false,
@@ -712,6 +736,9 @@
         },
         "payment_provider": {
           "$ref": "#/$defs/PaymentProvider"
+        },
+        "authentication_provider": {
+          "$ref": "#/$defs/AuthenticationProvider"
         },
         "status": {
           "type": "string",

--- a/spec/2026-01-16/openapi/openapi.agentic_checkout.yaml
+++ b/spec/2026-01-16/openapi/openapi.agentic_checkout.yaml
@@ -494,11 +494,13 @@ components:
         provider:
           type: string
           enum: [stripe]
+        merchant_id:
+          type: string
         supported_payment_methods:
           type: array
           items:
             $ref: "#/components/schemas/PaymentMethod"
-      required: [provider, supported_payment_methods]
+      required: [provider, merchant_id, supported_payment_methods]
 
     PaymentMethod:
       type: object
@@ -772,6 +774,22 @@ components:
         permalink_url: { type: string, format: uri }
       required: [id, checkout_session_id, permalink_url]
 
+    AuthenticationProvider:
+      type: object
+      additionalProperties: false
+      properties:
+        provider:
+          type: string
+          enum: [stripe, adyen]
+        merchant_id:
+          type: string
+        supported_authentication_methods:
+          type: array
+          items:
+            type: string
+            enum: [3ds]
+      required: [provider, merchant_id, supported_authentication_methods]
+
     CheckoutSessionBase:
       type: object
       additionalProperties: false
@@ -779,6 +797,7 @@ components:
         id: { type: string }
         buyer: { $ref: "#/components/schemas/Buyer" }
         payment_provider: { $ref: "#/components/schemas/PaymentProvider" }
+        authentication_provider: { $ref: "#/components/schemas/AuthenticationProvider" }
         status:
           {
             type: string,

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Agentic Checkout API
-  version: "2025-12-12"
+  version: "unreleased"
   description: |
     Merchant-implemented REST API for ChatGPT-driven checkout.
     Implements create, update (POST), retrieve (GET), complete, and cancel of checkout sessions.


### PR DESCRIPTION
This is the first PR for SEP #79 allowing for merchants first to specify their authentication provider. 

Add ability for the merchant to specify their authentication provider through the `authentication_provider` field and amend `PaymentProvider` to add `merchant_id` to reflect the current production state

- Added `AuthenticationProvider` schema and `authentication_provider` field
- Added `merchant_id `to PaymentProvider (breaking change)
- Extended provider enum to include adyen