### PR TITLE
feat: drop `channel` field from `AuthenticationMetadata`

### DIFF
--- a/examples/unreleased/examples.agentic_checkout.json
+++ b/examples/unreleased/examples.agentic_checkout.json
@@ -964,21 +964,6 @@
       }
     ],
     "authentication_metadata": {
-      "channel": {
-        "type": "browser",
-        "browser": {
-          "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-          "ip_address": "203.0.113.42",
-          "javascript_enabled": true,
-          "language": "en-US",
-          "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 12_3) AppleWebKit/605.1.15 (KHTML, like Gecko)",
-          "color_depth": 24,
-          "java_enabled": false,
-          "screen_height": 1440,
-          "screen_width": 900,
-          "timezone_offset": -480
-        }
-      },
       "acquirer_details": {
         "acquirer_bin": "123456",
         "acquirer_country": "US",

--- a/rfcs/rfc.agentic_checkout.md
+++ b/rfcs/rfc.agentic_checkout.md
@@ -193,8 +193,7 @@ If a client calls `POST .../complete` while `session.status` is `authentication_
 - **Total**: `type`, `display_text`, `amount` (**int**), `description?`
 
 3D Secure / Authentication-specific types:
-- **AuthenticationMetadata**: 
-  - `channel` (object): `type` ("browser"), `browser` (object containing `accept_header`, `ip_address`, `javascript_enabled` (bool), `language`, `user_agent`; plus conditional fields if JS enabled: `color_depth`, `java_enabled`, `screen_height`, `screen_width`, `timezone_offset`).
+- **AuthenticationMetadata**:
   - `acquirer_details` (object): `acquirer_bin`, `acquirer_country`, `acquirer_merchant_id`, `merchant_name`, `requestor_id?`.
   - `directory_server`: enum `american_express` | `mastercard` | `visa`.
   - `flow_preference?` (object): `type` ("challenge" | "frictionless"), `challenge?` (object), `frictionless?` (object).

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -897,85 +897,10 @@
       "additionalProperties": true,
       "description": "Seller-provided authentication metadata for 3DS flows.",
       "required": [
-        "channel",
         "acquirer_details",
         "directory_server"
       ],
       "properties": {
-        "channel": {
-          "type": "object",
-          "additionalProperties": false,
-          "description": "Details about the channel used for this 3DS Authentication.",
-          "required": [
-            "type",
-            "browser"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "browser"
-              ],
-              "description": "Use 'browser' to indicate the transaction originated from a browser."
-            },
-            "browser": {
-              "type": "object",
-              "additionalProperties": false,
-              "description": "Browser details collected server- or client-side.",
-              "properties": {
-                "accept_header": {
-                  "type": "string",
-                  "description": "The HTTP Accept header from the cardholder\u2019s browser."
-                },
-                "ip_address": {
-                  "type": "string",
-                  "maxLength": 45,
-                  "description": "The IP address of the browser."
-                },
-                "javascript_enabled": {
-                  "type": "boolean",
-                  "description": "Whether the cardholder browser can execute JavaScript."
-                },
-                "language": {
-                  "type": "string",
-                  "maxLength": 35,
-                  "description": "An IETF BCP 47 language tag representing the browser language."
-                },
-                "user_agent": {
-                  "type": "string",
-                  "description": "The browser user agent string."
-                },
-                "color_depth": {
-                  "type": "integer",
-                  "description": "The screen color depth. Required if javascript_enabled is true."
-                },
-                "java_enabled": {
-                  "type": "boolean",
-                  "description": "Browser Java support. Required if javascript_enabled is true."
-                },
-                "screen_height": {
-                  "type": "integer",
-                  "description": "Screen height in pixels. Required if javascript_enabled is true."
-                },
-                "screen_width": {
-                  "type": "integer",
-                  "description": "Screen width in pixels. Required if javascript_enabled is true."
-                },
-                "timezone_offset": {
-                  "type": "integer",
-                  "description": "Time difference in minutes between UTC and the browser local time. Required if javascript_enabled is true."
-                }
-              },
-              "required": [
-                "accept_header",
-                "ip_address",
-                "javascript_enabled",
-                "language",
-                "user_agent"
-              ]
-            }
-          }
-        },
         "acquirer_details": {
           "type": "object",
           "additionalProperties": false,
@@ -1071,43 +996,7 @@
             "type"
           ]
         }
-      },
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "channel": {
-                "properties": {
-                  "browser": {
-                    "properties": {
-                      "javascript_enabled": {
-                        "const": true
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "channel": {
-                "properties": {
-                  "browser": {
-                    "required": [
-                      "color_depth",
-                      "java_enabled",
-                      "screen_height",
-                      "screen_width",
-                      "timezone_offset"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      ]
+      }
     },
     "AuthenticationResult": {
       "type": "object",

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -1170,66 +1170,9 @@ components:
       description: >
         Seller-provided authentication metadata for 3DS flows.
       required:
-        - channel
         - acquirer_details
         - directory_server
       properties:
-        channel:
-          type: object
-          additionalProperties: false
-          description: Details about the channel used for this 3DS Authentication.
-          required:
-            - type
-            - browser
-          properties:
-            type:
-              type: string
-              enum: [browser]
-              description: Use "browser" to indicate the transaction originated from a browser.
-            browser:
-              type: object
-              additionalProperties: false
-              description: Browser details collected server- or client-side.
-              properties:
-                accept_header:
-                  type: string
-                  description: The HTTP Accept header from the cardholder’s browser.
-                ip_address:
-                  type: string
-                  maxLength: 45
-                  description: The IP address of the browser.
-                javascript_enabled:
-                  type: boolean
-                  description: Whether the cardholder browser can execute JavaScript.
-                language:
-                  type: string
-                  maxLength: 35
-                  description: An IETF BCP 47 language tag representing the browser language.
-                user_agent:
-                  type: string
-                  description: The browser user agent string.
-                color_depth:
-                  type: integer
-                  description: The screen color depth. Required if javascript_enabled is true.
-                java_enabled:
-                  type: boolean
-                  description: Browser Java support. Required if javascript_enabled is true.
-                screen_height:
-                  type: integer
-                  description: Screen height in pixels. Required if javascript_enabled is true.
-                screen_width:
-                  type: integer
-                  description: Screen width in pixels. Required if javascript_enabled is true.
-                timezone_offset:
-                  type: integer
-                  description: Time difference in minutes between UTC and the browser local time. Required if javascript_enabled is true.
-              required:
-                - accept_header
-                - ip_address
-                - javascript_enabled
-                - language
-                - user_agent
-
         acquirer_details:
           type: object
           additionalProperties: false
@@ -1298,26 +1241,6 @@ components:
               description: >
                 Details about the requested frictionless flow.
           required: [type]
-      allOf:
-        - if:
-            properties:
-              channel:
-                properties:
-                  browser:
-                    properties:
-                      javascript_enabled:
-                        const: true
-          then:
-            properties:
-              channel:
-                properties:
-                  browser:
-                    required:
-                      - color_depth
-                      - java_enabled
-                      - screen_height
-                      - screen_width
-                      - timezone_offset
 
     AuthenticationResult:
       type: object


### PR DESCRIPTION
Removes the `channel` field from the 3DS `AuthenticationMetadata` schema.

Since the specification currently supports only agent-driven 3DS execution and the agent controls the frontend, the seller-provided `channel` data is unnecessary. This will be revisited upon the introduction of merchant-driven execution.