### PR TITLE
[SEP] Delegated Authentication: API contract for agent to merchant-specified authentication provider #79

### DIFF
--- a/changelog/unreleased/delegate-authentication.md
+++ b/changelog/unreleased/delegate-authentication.md
@@ -1,0 +1,21 @@
+# Unreleased Changes
+
+## Delegate Authentication 
+
+This RFC defines a standardized REST API contract for **delegated consumer authentication**. It enables agents to execute 3DS2 browser-based authentication directly with merchant specified authentication providers. 
+
+### Changes
+
+- **Delegate Authentication API**: Established a session-based authentication lifecycle (Create → Authenticate → Retrieve) to manage 3DS2 states across asynchronous browser actions.
+- **Data Models**: Defined schemas for `PaymentMethod`, `BrowserInfo` and `AuthenticationResult` (Cryptograms and ECI).
+- **Webhook Definitions**: Added support for asynchronous notifications, including Fingerprint completion, Challenge results, and an optional RReq webhook to prevent browser-to-backend race conditions.
+
+### Benefits
+
+- **Standardization**: Provides a single contract for agents to interact with any compliant 3DS2 provider.
+
+### Files Created
+- `rfcs/rfc.delegate_authentication.md`
+- `spec/unreleased/json-schema/schema.delegate_authentication.json`
+- `spec/unreleased/openapi/openapi.delegate_authentication.yaml`
+- `examples/unreleased/examples.delegate_authentication.json`

--- a/examples/unreleased/examples.delegate_authentication.json
+++ b/examples/unreleased/examples.delegate_authentication.json
@@ -1,0 +1,230 @@
+{
+  "create_authentication_session_request_minimal": {
+    "merchant_id": "merchant_abc123",
+    "payment_method": {
+      "type": "card",
+      "number": "4917610000000000",
+      "exp_month": "03",
+      "exp_year": "2030",
+      "name": "Jane Doe"
+    },
+    "amount": {
+      "value": 1000,
+      "currency": "EUR"
+    }
+  },
+  "create_authentication_session_request_with_channel_and_acquirer_details": {
+    "merchant_id": "merchant_abc123",
+    "acquirer_details": {
+      "acquirer_bin": "412345",
+      "acquirer_country": "US",
+      "acquirer_merchant_id": "123456789012345",
+      "merchant_name": "Example Merchant Inc",
+      "requestor_id": "REQ_12345"
+    },
+    "payment_method": {
+      "type": "card",
+      "number": "4917610000000000",
+      "exp_month": "03",
+      "exp_year": "2030",
+      "name": "Jane Doe"
+    },
+    "amount": {
+      "value": 1000,
+      "currency": "EUR"
+    },
+    "checkout_session_id": "checkout_session_123",
+    "channel": {
+      "type": "browser",
+      "browser": {
+        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "ip_address": "192.168.1.1",
+        "javascript_enabled": true,
+        "language": "en-US",
+        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+        "color_depth": 24,
+        "java_enabled": false,
+        "screen_height": 1080,
+        "screen_width": 1920,
+        "timezone_offset": 0
+      }
+    },
+    "flow_preference": {
+      "type": "challenge",
+      "challenge": {
+        "type": "preferred"
+      }
+    },
+    "challenge_notification_url": "https://agent.example.com/3ds/challenge-callback",
+    "shopper_details": {
+      "name": "Jane Doe",
+      "email": "shopper@example.com",
+      "phone_number": "15551234567",
+      "address": {
+        "name": "Jane Doe",
+        "line_one": "123 Main Street",
+        "line_two": "Apt 4B",
+        "city": "Amsterdam",
+        "state": "NH",
+        "country": "NL",
+        "postal_code": "1012 AB"
+      }
+    }
+  },
+  "create_authentication_session_response_fingerprint_required": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "action_required",
+    "action": {
+      "type": "fingerprint",
+      "fingerprint": {
+        "three_ds_method_url": "https://acs.issuer.com/3dsmethod",
+        "three_ds_server_trans_id": "abc-123-def"
+      }
+    }
+  },
+  "create_authentication_session_response_pending": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "pending"
+  },
+  "create_authentication_session_response_not_supported": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "not_supported"
+  },
+  "authenticate_request_fingerprint_success": {
+    "fingerprint_completion": "Y"
+  },
+  "authenticate_request_fingerprint_timeout": {
+    "fingerprint_completion": "N"
+  },
+  "authenticate_request_fingerprint_unavailable": {
+    "fingerprint_completion": "U"
+  },
+  "authenticate_request_with_deferred_channel": {
+    "fingerprint_completion": "Y",
+    "channel": {
+      "type": "browser",
+      "browser": {
+        "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "ip_address": "192.168.1.1",
+        "javascript_enabled": true,
+        "language": "en-US",
+        "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+        "color_depth": 24,
+        "java_enabled": false,
+        "screen_height": 1080,
+        "screen_width": 1920,
+        "timezone_offset": 0
+      }
+    },
+    "challenge_notification_url": "https://agent.example.com/3ds/challenge-callback"
+  },
+  "authenticate_response_frictionless_authenticated": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "authenticated"
+  },
+  "authenticate_response_frictionless_attempted": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "attempted"
+  },
+  "authenticate_response_challenge_required": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "action_required",
+    "action": {
+      "type": "challenge",
+      "challenge": {
+        "acs_url": "https://acs.issuer.com/challenge",
+        "acs_trans_id": "xyz-789",
+        "three_ds_server_trans_id": "abc-123-def",
+        "message_version": "2.2.0"
+      }
+    }
+  },
+  "authenticate_response_not_authenticated": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "not_authenticated"
+  },
+  "authenticate_response_rejected": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "rejected"
+  },
+  "authenticate_response_expired": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "expired"
+  },
+  "retrieve_session_response_authenticated": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "authenticated",
+    "authentication_result": {
+      "trans_status": "Y",
+      "electronic_commerce_indicator": "05",
+      "three_ds_cryptogram": "AQIDBAUGBwgJCgsMDQ4PEBESExQ=",
+      "transaction_id": "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
+      "three_ds_server_trans_id": "6edcc246-23ee-4e94-ac5d-8ae620bea7d9",
+      "version": "2.2.0",
+      "authentication_value": "CAVV_VALUE"
+    }
+  },
+  "retrieve_session_response_attempted": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "attempted",
+    "authentication_result": {
+      "trans_status": "A",
+      "electronic_commerce_indicator": "06",
+      "three_ds_cryptogram": "AQIDBAUGBwgJCgsMDQ4PEBESExQ=",
+      "transaction_id": "b3d48bea-a271-4c5a-ab76-274c480ea98c",
+      "three_ds_server_trans_id": "5dcbb135-22dd-4d83-ab4d-7ad51fbf6b8e",
+      "version": "2.2.0",
+      "authentication_value": "CAVV_VALUE_ATTEMPTED"
+    }
+  },
+  "retrieve_session_response_not_authenticated": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "not_authenticated",
+    "authentication_result": {
+      "trans_status": "N",
+      "trans_status_reason": "01",
+      "electronic_commerce_indicator": "07",
+      "transaction_id": "3022b509-391e-4c25-a225-f37e062843a5",
+      "three_ds_server_trans_id": "87a357a1-faee-4cd1-b3cf-ea2c704bf073",
+      "version": "2.2.0",
+      "cardholder_info": "Please contact your bank's customer support."
+    }
+  },
+  "retrieve_session_response_rejected": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "rejected",
+    "authentication_result": {
+      "trans_status": "R",
+      "trans_status_reason": "02",
+      "transaction_id": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+      "three_ds_server_trans_id": "9f8e7d6c-5b4a-3c2d-1e0f-9a8b7c6d5e4f",
+      "version": "2.2.0",
+      "cardholder_info": "Transaction rejected by issuer."
+    }
+  },
+  "retrieve_session_response_challenge_abandoned": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "challenge_abandoned",
+    "authentication_result": {
+      "trans_status": "U",
+      "transaction_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "three_ds_server_trans_id": "f0e1d2c3-b4a5-6789-0abc-def123456789",
+      "version": "2.2.0"
+    }
+  },
+  "retrieve_session_response_expired": {
+    "authentication_session_id": "auth_session_abc123",
+    "status": "expired"
+  },
+  "error_invalid_card": {
+    "type": "invalid_request",
+    "code": "invalid_card",
+    "message": "Invalid expiry date (exp_month or exp_year)",
+    "param": "$.payment_method.exp_month"
+  },
+  "error_idempotency_conflict": {
+    "type": "invalid_request",
+    "code": "idempotency_conflict",
+    "message": "Same Idempotency-Key used with different parameters"
+  }
+}

--- a/rfcs/rfc.delegate_authentication.md
+++ b/rfcs/rfc.delegate_authentication.md
@@ -1,0 +1,494 @@
+# RFC: Agentic Commerce - Delegate Authentication API
+
+**Status:** Draft  
+**Version:** 2026-01-28  
+**Scope:** Delegate consumer authentication to merchant-specified providers for agent-driven checkout flows
+
+This RFC defines a standardized REST API contract that authentication providers SHOULD implement to enable **delegated consumer authentication** with merchant-specified authentication providers.
+
+---
+
+## 1. Scope & Goals
+
+- Provide a **stable, versioned** API surface (`API-Version: 2026-01-28`) that the client calls to create authentication sessions, triggers authentication, and retrieve authentication outcomes.
+- Enable merchants to **delegate** authentication to a specified authentication provider.
+- Allow clients to **execute consumer authentication directly** with the specified server using standardized endpoints, without routing through the merchant.
+
+This specification covers:
+- **3D Secure 2** (3DS2) authentication only
+- **Browser channel** only (not app/SDK)
+- **Native integration** (client handles fingerprint/challenge flows, not redirect-based)
+
+**Out of scope:** app-based/SDK authentication, redirect-based flows, payment authorization.
+
+### 1.1 Normative Language
+
+The key words **MUST**, **MUST NOT**, **SHOULD**, **MAY** are to be interpreted as described in RFC 2119.
+
+---
+
+## 2. Protocol Phases
+
+### 2.1 Initialization
+
+- **Versioning:** Client **MUST** send `API-Version`. Server **MUST** validate support (e.g., `2026-01-28`).
+- **Identity/Signing:** Server **SHOULD** publish acceptable signature algorithms out-of-band; client **SHOULD** sign requests (`Signature`) over canonical JSON with an accompanying `Timestamp` (RFC 3339).
+- **Session-based state:** Server **MUST** return an `authentication_session_id`. Client **MUST** include this ID in the URL path for all subsequent requests.
+
+### 2.2 Authentication Lifecycle
+
+1. **Create** - `POST /delegate_authentication` initializes a session with merchant, card, and amount. Returns fingerprint action if supported, `pending` if no fingerprint needed, or `not_supported` if card not enrolled.
+2. **Authenticate** - `POST /delegate_authentication/{authentication_session_id}/authenticate` submits fingerprint result and triggers authentication. Returns challenge action if required, or frictionless result.
+3. **Retrieve** - `GET /delegate_authentication/{authentication_session_id}` retrieves the current session state including the final authentication result (cryptogram, ECI, etc.) when available.
+
+### 2.3 Client Callbacks (Separate)
+
+The client implements callback endpoints to receive asynchronous notifications during the authentication process.
+- **Fingerprint notification** - Receives 3DS Method completion.
+- **Challenge notification** - Receives challenge result (CRes) after shopper verification.
+- **RReq notification** (**OPTIONAL**) - Confirmation from the Authentication Provider that the final result (RReq) is ready.
+
+---
+
+## 3. HTTP Interface
+
+### 3.1 Common Requirements
+
+All endpoints **MUST** use HTTPS and return JSON.
+
+**Request Headers (sent by client):**
+
+- `Authorization: Bearer <token>` (**REQUIRED**)
+- `Content-Type: application/json` (**REQUIRED** on requests with body)
+- `Accept-Language: en-us` (OPTIONAL)
+- `User-Agent: <string>` (OPTIONAL)
+- `Idempotency-Key: <string>` (RECOMMENDED)
+- `Request-Id: <string>` (RECOMMENDED)
+- `Signature: <base64url>` (**REQUIRED**; identity verification over canonical request)
+- `Timestamp: <RFC3339>` (RECOMMENDED)
+- `API-Version: 2026-01-28` (**REQUIRED**)
+
+**Response Headers:**
+
+- `Idempotency-Key` - echo if provided
+- `Request-Id` - echo if provided
+
+**Error Shape (flat):**
+
+```json
+{
+  "type": "invalid_request",
+  "code": "invalid_card",
+  "message": "Missing/malformed field",
+  "param": "$.payment_method.number"
+}
+```
+
+**Type & Code Guidelines**
+
+- `type` ∈ `invalid_request`, `rate_limit_exceeded`, `processing_error`, `service_unavailable`
+- `code` ∈ `invalid_card`, `duplicate_request`, `idempotency_conflict`
+- `param` **SHOULD** be an RFC 9535 JSONPath (when applicable).
+
+---
+
+## 4. Endpoints
+
+### 4.1 Create Session
+
+`POST /delegate_authentication` → **201 Created**
+
+**Request body:**
+
+- `merchant_id` (**REQUIRED**) - Merchant identifier
+- `acquirer_details` (**OPTIONAL**) - Object containing acquirer data (`acquirer_bin`, `acquirer_merchant_id`) used for AReq construction. **RECOMMENDED:** To ensure the AReq matches the final Authorization, especially when using different authentication and payment providers.
+- `payment_method` (**REQUIRED**) - Card details (type, number, exp_month, exp_year, name)
+- `amount` (**REQUIRED**) - Object with `value` (integer, minor units) and `currency` (ISO 4217)
+- `channel` (**OPTIONAL**) - Browser channel data. The Agent can choose to defer this data to the `/authenticate` call, which bypasses the device fingerprinting phase for the session.
+- `checkout_session_id` (**OPTIONAL**) - Checkout session identifier
+- `flow_preference` (**OPTIONAL**) - Object with `type` (`challenge` | `frictionless`) and optional subtype details
+- `challenge_notification_url` (**OPTIONAL**) - URL for challenge result callback
+- `shopper_details` (**OPTIONAL**) - Object with `name?`, `email?`, `phone_number?`, `address?` (nested Address)
+
+**Response body:**
+
+- `authentication_session_id` (string) - Session ID for subsequent requests
+- `status` - `action_required` | `pending` | `not_supported`
+    - `action_required` - **MUST** process the `action` object (fingerprint), then call `/{id}/authenticate`
+    - `pending` - No fingerprint needed; **MUST** call `/{id}/authenticate` directly with `fingerprint_completion: U`
+    - `not_supported` - Card not enrolled or issuer not participating; **MAY** proceed to authorization without 3DS
+- `action` (optional) - Object with `type: fingerprint` and fingerprint details
+
+### 4.2 Authenticate
+
+`POST /delegate_authentication/{authentication_session_id}/authenticate` → **200 OK**
+
+**Request body:**
+
+- `fingerprint_completion` (**REQUIRED**) - `Y` (success), `N` (timeout), or `U` (unavailable)
+- `channel` (**CONDITIONAL**) - Required if not provided in create
+- `checkout_session_id` (**OPTIONAL**)
+- `challenge_notification_url` (**CONDITIONAL**) - Required if not provided in create
+- `shopper_details` (**OPTIONAL**) - Object with `name?`, `email?`, `phone_number?`, `address?`
+
+**Response body:**
+
+- `authentication_session_id` (string) - Session ID
+- `status` - `authenticated` | `action_required` | `attempted` | `not_authenticated` | `rejected` | `unavailable` | `expired`
+    - `authenticated` - Frictionless authentication successful; **MUST** call `GET /{id}` to retrieve result
+    - `action_required` - Challenge required; **MUST** process the `action` object, then call `GET /{id}`
+    - `attempted` - Proof of authentication attempt provided; **MUST** call `GET /{id}` to retrieve result
+    - `not_authenticated` - Authentication failed; **MUST** call `GET /{id}` to retrieve result
+    - `rejected` - Issuer rejected; **MUST NOT** attempt authorization
+    - `unavailable` - Technical error (e.g., `trans_status` `U`, 3DS `Erro` messages, or ACS network timeouts).
+    - `expired` - Session has expired; **MUST** create a new session
+- `action` (optional) - Object with `type: challenge` and challenge details
+
+### 4.3 Retrieve Session
+
+`GET /delegate_authentication/{authentication_session_id}` → **200 OK**
+
+**Response body:**
+
+- `authentication_session_id` (string) - Session ID
+- `status` - `authenticated` | `attempted` | `not_authenticated` | `rejected` | `unavailable` | `expired` | `challenge_abandoned`
+    - `authenticated` - Authentication successful; **SHOULD** use `authentication_result` for authorization
+    - `attempted` - Proof of authentication attempt provided; **MAY** proceed with authorization
+    - `not_authenticated` - Authentication failed; **SHOULD NOT** proceed to authorization
+    - `rejected` - Issuer rejected; **MUST NOT** attempt authorization
+    - `unavailable` - Technical error (e.g., `trans_status` `U`, 3DS `Erro` messages, or ACS network timeouts).
+    - `expired` - Session has expired
+    - `challenge_abandoned` - Challenge was presented but shopper did not complete it
+- `authentication_result` - Object with 3DS data (trans_status, electronic_commerce_indicator, three_ds_cryptogram, transaction_id, three_ds_server_trans_id, version, etc.)
+
+---
+
+## 5. Data Model
+
+- **PaymentMethod**: `type` (`card`), `number`, `exp_month`, `exp_year`, `name`
+- **Amount**: `value` (int, minor units), `currency` (ISO 4217)
+- **Channel**: `type` (`browser`), `browser` (object with `accept_header`, `ip_address`, `javascript_enabled`, `language`, `user_agent`, `color_depth`, `java_enabled`, `screen_height`, `screen_width`, `timezone_offset`)
+- **Address**: `name`, `line_one`, `line_two?`, `city`, `state`, `country`, `postal_code`
+- **ShopperDetails**: `name?`, `email?`, `phone_number?`, `address?` (nested Address object)
+- **FlowPreference**: `type` (`challenge` | `frictionless`), `challenge?` (object with `type`: `mandated` | `preferred`), `frictionless?` (object). Clients **MAY** request a preference, but issuers ultimately decide the actual flow.
+- **Action (fingerprint)**: `type: fingerprint`, `fingerprint` (object with `three_ds_method_url`, `three_ds_server_trans_id`)
+- **Action (challenge)**: `type: challenge`, `challenge` (object with `acs_url`, `acs_trans_id`, `three_ds_server_trans_id`, `message_version`)
+- **AuthenticationResult**: `trans_status`, `electronic_commerce_indicator`, `three_ds_cryptogram`, `transaction_id`, `three_ds_server_trans_id`, `version`, `authentication_value?`, `trans_status_reason?`, `cardholder_info?`
+
+---
+
+## 6. Browser Actions
+
+### 6.1 Device Fingerprinting
+
+When create returns `action.type: fingerprint`:
+
+1. Client **MUST** construct payload with `threeDSServerTransID` and `threeDSMethodNotificationURL`.
+2. Client **MUST** base64-encode and POST as `threeDSMethodData` to `action.fingerprint.three_ds_method_url` via hidden iframe.
+3. ACS collects fingerprint and POSTs to client's notification URL.
+4. Client **MUST** call `/{authentication_session_id}/authenticate` with `fingerprint_completion` after receiving notification (`Y`), or after 10 second timeout (`N`).
+
+### 6.2 Challenge Flow
+
+When authenticate returns `action.type: challenge`:
+
+1. Client **MUST** construct CReq with `threeDSServerTransID`, `acsTransID`, `messageVersion`, `messageType: CReq`, `challengeWindowSize`.
+2. Client **MUST** base64-encode (no padding) and POST as `creq` to `action.challenge.acs_url` via iframe/modal.
+3. Shopper completes challenge.
+4. ACS POSTs `CRes` to client's `challenge_notification_url`.
+5. Client decodes CRes, and call `GET /{authentication_session_id}` to retrieve the result.
+
+---
+
+## 7. Idempotency & Retries
+
+- Clients **SHOULD** provide `Idempotency-Key` on **create** requests for safe retries.
+- Replays with the **same** key and **identical** parameters **MUST** return the original result.
+- If the same key is replayed with **different** parameters, server **MUST** return `409` with:
+  ```json
+  {
+    "type": "invalid_request",
+    "code": "idempotency_conflict",
+    "message": "Same Idempotency-Key used with different parameters"
+  }
+  ```
+- Servers **SHOULD** be tolerant of network timeouts and implement at-least-once processing with idempotency.
+
+---
+
+## 8. Security Considerations
+
+- **Authentication:** `Authorization: Bearer <token>` **REQUIRED**.
+- **Integrity:** `Signature` over canonical JSON **MUST** be verified (algorithm policy advertised out-of-band).
+- **Freshness:** `Timestamp` **SHOULD** be required and checked within an acceptable clock-skew window.
+- **PII/PCI:** Card data handling **MUST** follow applicable PCI DSS requirements; logs **MUST NOT** contain full PAN or CVC.
+- **Transport:** All requests **MUST** use HTTPS/TLS 1.2+.
+- **Callback verification:** Client **SHOULD** validate callback origin where possible.
+- **Agent Infrastructure Allowlisting:** Authentication Providers **MUST** enforce origin restrictions to prevent abuse, 
+and requests can only be accepted if it originates from the Agent's verified infrastructure.
+
+---
+
+## 9. Validation Rules (non-exhaustive)
+
+**Acquirer Details:**
+- `acquirer_bin` length ≤ 11 (string).
+- `acquirer_country`: String, exact length 2 (ISO 3166-1 alpha-2).
+- `acquirer_merchant_id`: String, length ≤ 35.
+- `merchant_name`: String, length ≤ 40.
+- `requestor_id`: String, length ≤ 35.
+
+**Payment Method:**
+- `payment_method.type` **MUST** be `card`.
+- `payment_method.number` present (string).
+- When present:
+    - `exp_month` length ≤ 2 and value `"01"`-`"12"`.
+    - `exp_year` length ≤ 4 and four digits.
+
+**Amount:**
+- `amount.value` **MUST** be a positive integer (minor units).
+- `amount.currency` **MUST** be ISO 4217 (e.g., `EUR`, `USD`).
+
+**Channel:**
+- `channel.type` **MUST** be `browser` when present.
+- `channel.browser` required fields: `accept_header`, `ip_address`, `javascript_enabled`, `language`, `user_agent`.
+- When `javascript_enabled` is `true`: `color_depth`, `java_enabled`, `screen_height`, `screen_width`, `timezone_offset` **MUST** be present.
+
+**Flow Preference:**
+- `flow_preference.type` ∈ `challenge | frictionless` when present.
+- `flow_preference.challenge.type` ∈ `mandated | preferred` when present.
+
+**Shopper Details:**
+- `shopper_details.address.country` **MUST** be ISO 3166-1 alpha-2 when present.
+
+**Status Values:**
+- `fingerprint_completion` ∈ `Y` | `N` | `U`
+- Create `status` ∈ `action_required` | `pending` | `not_supported`
+- Authenticate `status` ∈ `authenticated` | `action_required` | `attempted` | `not_authenticated` | `rejected` | `unavailable` | `expired`
+- Retrieve `status` ∈ `authenticated` | `attempted` | `not_authenticated` | `rejected` | `unavailable` | `expired` | `challenge_abandoned` | `action_required` | `pending` | `not_supported`
+
+---
+
+## 10. Examples
+
+### 10.1 Create - Request (minimal)
+
+```json
+{
+  "merchant_id": "merchant_abc123",
+  "payment_method": {
+    "type": "card",
+    "number": "4917610000000000",
+    "exp_month": "03",
+    "exp_year": "2030",
+    "name": "Jane Doe"
+  },
+  "amount": {
+    "value": 1000,
+    "currency": "EUR"
+  }
+}
+```
+
+### 10.2 Create - Request (with channel and acquirer details)
+
+```json
+{
+  "merchant_id": "merchant_abc123",
+  "acquirer_details": {
+    "acquirer_bin": "412345",
+    "acquirer_country": "US",
+    "acquirer_merchant_id": "123456789012345",
+    "merchant_name": "Example Merchant Inc",
+    "requestor_id": "REQ_12345"
+  },
+  "payment_method": {
+    "type": "card",
+    "number": "4917610000000000",
+    "exp_month": "03",
+    "exp_year": "2030",
+    "name": "Jane Doe"
+  },
+  "amount": {
+    "value": 1000,
+    "currency": "EUR"
+  },
+  "checkout_session_id": "checkout_session_123",
+  "channel": {
+    "type": "browser",
+    "browser": {
+      "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      "ip_address": "192.168.1.1",
+      "javascript_enabled": true,
+      "language": "en-US",
+      "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)...",
+      "color_depth": 24,
+      "java_enabled": false,
+      "screen_height": 1080,
+      "screen_width": 1920,
+      "timezone_offset": 0
+    }
+  },
+  "flow_preference": {
+    "type": "challenge",
+    "challenge": {
+      "type": "preferred"
+    }
+  },
+  "challenge_notification_url": "https://agent.example.com/3ds/challenge-callback",
+  "shopper_details": {
+    "name": "Jane Doe",
+    "email": "shopper@example.com",
+    "phone_number": "15551234567",
+    "address": {
+      "name": "Jane Doe",
+      "line_one": "123 Main Street",
+      "line_two": "Apt 4B",
+      "city": "Amsterdam",
+      "state": "NH",
+      "country": "NL",
+      "postal_code": "1012 AB"
+    }
+  }
+}
+```
+
+### 10.3 Create - Response (201, fingerprint required)
+
+```json
+{
+  "authentication_session_id": "auth_session_abc123",
+  "status": "action_required",
+  "action": {
+    "type": "fingerprint",
+    "fingerprint": {
+      "three_ds_method_url": "https://acs.issuer.com/3dsmethod",
+      "three_ds_server_trans_id": "abc-123-def"
+    }
+  }
+}
+```
+
+### 10.4 Create - Response (201, not supported)
+
+```json
+{
+  "authentication_session_id": "auth_session_abc123",
+  "status": "not_supported"
+}
+```
+
+### 10.5 Authenticate - Request
+
+```json
+{
+  "fingerprint_completion": "Y"
+}
+```
+
+### 10.6 Authenticate - Response (200, frictionless)
+
+```json
+{
+  "authentication_session_id": "auth_session_abc123",
+  "status": "authenticated"
+}
+```
+
+### 10.7 Authenticate - Response (200, challenge required)
+
+```json
+{
+  "authentication_session_id": "auth_session_abc123",
+  "status": "action_required",
+  "action": {
+    "type": "challenge",
+    "challenge": {
+      "acs_url": "https://acs.issuer.com/challenge",
+      "acs_trans_id": "xyz-789",
+      "three_ds_server_trans_id": "abc-123-def",
+      "message_version": "2.2.0"
+    }
+  }
+}
+```
+
+### 10.8 Retrieve - Response (200, authenticated)
+
+```json
+{
+  "authentication_session_id": "auth_session_abc123",
+  "status": "authenticated",
+  "authentication_result": {
+    "trans_status": "Y",
+    "electronic_commerce_indicator": "05",
+    "three_ds_cryptogram": "AQIDBAUGBwgJCgsMDQ4PEBESExQ=",
+    "transaction_id": "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
+    "three_ds_server_trans_id": "6edcc246-23ee-4e94-ac5d-8ae620bea7d9",
+    "version": "2.2.0",
+    "authentication_value": "CAVV_VALUE"
+  }
+}
+```
+
+### 10.9 Retrieve - Response (200, not authenticated)
+
+```json
+{
+  "authentication_session_id": "auth_session_abc123",
+  "status": "not_authenticated",
+  "authentication_result": {
+    "trans_status": "N",
+    "transaction_id": "3022b509-391e-4c25-a225-f37e062843a5",
+    "three_ds_server_trans_id": "87a357a1-faee-4cd1-b3cf-ea2c704bf073",
+    "version": "2.2.0",
+    "electronic_commerce_indicator": "07",
+    "trans_status_reason": "01",
+    "cardholder_info": "Please contact your bank's customer support."
+  }
+}
+```
+
+### 10.10 Error - 400 (invalid card)
+
+```json
+{
+  "type": "invalid_request",
+  "code": "invalid_card",
+  "message": "Invalid expiry date (exp_month or exp_year)",
+  "param": "$.payment_method.exp_month"
+}
+```
+
+### 10.11 Error - 409 (idempotency conflict)
+
+**409 Conflict**
+
+```json
+{
+  "type": "invalid_request",
+  "code": "idempotency_conflict",
+  "message": "Same Idempotency-Key used with different parameters"
+}
+```
+
+---
+
+## 11. Conformance Checklist
+
+- [ ] Accepts `API-Version` and validates `2026-01-28`
+- [ ] Verifies `Authorization` (Bearer)
+- [ ] Verifies auth; signs/verifies requests where applicable
+- [ ] Implements create, authenticate, and retrieve endpoints
+- [ ] Returns appropriate `status` values per endpoint
+- [ ] Returns `action` object when browser action required
+- [ ] Returns `authentication_result` on retrieve (GET)
+- [ ] Emits flat error objects with `type/code/message/param?`
+- [ ] Supports `channel` in either create or authenticate
+- [ ] Honors `Idempotency-Key`; returns `409` on conflict
+
+---
+
+## 12. Change Log
+
+- **2026-01-28**: Initial draft. Scope, goals, and session-based API defined.

--- a/spec/unreleased/json-schema/schema.delegate_authentication.json
+++ b/spec/unreleased/json-schema/schema.delegate_authentication.json
@@ -1,0 +1,675 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/delegate-authentication/bundle.schema.json",
+  "title": "Delegate Authentication - Schema Bundle",
+  "$defs": {
+    "Address": {
+      "type": "object",
+      "description": "The physical address details for the shopper.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "maxLength": 256,
+          "description": "Full name of the recipient"
+        },
+        "line_one": {
+          "type": "string",
+          "maxLength": 60,
+          "description": "First line of the address"
+        },
+        "line_two": {
+          "type": "string",
+          "maxLength": 60,
+          "description": "Second line of the address"
+        },
+        "city": {
+          "type": "string",
+          "maxLength": 60,
+          "description": "City name"
+        },
+        "state": {
+          "type": "string",
+          "description": "ISO-3166-2 where applicable"
+        },
+        "country": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 2,
+          "description": "ISO-3166-1 alpha-2"
+        },
+        "postal_code": {
+          "type": "string",
+          "maxLength": 20,
+          "description": "Postal or ZIP code"
+        }
+      },
+      "required": ["name", "line_one", "city", "state", "country", "postal_code"],
+      "examples": [
+        {
+          "name": "Jane Doe",
+          "line_one": "123 Main Street",
+          "city": "Amsterdam",
+          "state": "NH",
+          "country": "NL",
+          "postal_code": "1012 AB"
+        }
+      ]
+    },
+    "PaymentMethod": {
+      "type": "object",
+      "description": "Payment instrument details used for authentication.",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["card"],
+          "description": "The payment method type"
+        },
+        "number": {
+          "type": "string",
+          "description": "Card number (PAN)"
+        },
+        "exp_month": {
+          "type": "string",
+          "maxLength": 2,
+          "description": "Expiry month (01-12)"
+        },
+        "exp_year": {
+          "type": "string",
+          "maxLength": 4,
+          "description": "Expiry year (4 digits)"
+        },
+        "name": {
+          "type": "string",
+          "description": "Cardholder name"
+        }
+      },
+      "required": ["type", "number", "exp_month", "exp_year", "name"],
+      "examples": [
+        {
+          "type": "card",
+          "number": "4917610000000000",
+          "exp_month": "03",
+          "exp_year": "2030",
+          "name": "Jane Doe"
+        }
+      ]
+    },
+    "Amount": {
+      "type": "object",
+      "description": "The transaction amount and currency.",
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "integer",
+          "description": "Amount in minor units (e.g., 1000 = €10.00)"
+        },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$",
+          "description": "ISO 4217 currency code"
+        }
+      },
+      "required": ["value", "currency"],
+      "examples": [
+        {
+          "value": 1000,
+          "currency": "EUR"
+        }
+      ]
+    },
+    "BrowserInfo": {
+      "type": "object",
+      "description": "Browser-specific metadata required for 3DS2 fingerprinting.",
+      "additionalProperties": false,
+      "properties": {
+        "accept_header": {
+          "type": "string",
+          "description": "HTTP Accept header from the browser"
+        },
+        "ip_address": {
+          "type": "string",
+          "maxLength": 45,
+          "description": "IP address of the browser"
+        },
+        "javascript_enabled": {
+          "type": "boolean",
+          "description": "Whether JavaScript is enabled"
+        },
+        "language": {
+          "type": "string",
+          "maxLength": 35,
+          "description": "IETF BCP 47 language tag"
+        },
+        "user_agent": {
+          "type": "string",
+          "description": "Browser user agent string"
+        },
+        "color_depth": {
+          "type": "integer",
+          "description": "Screen color depth (required if javascript_enabled is true)"
+        },
+        "java_enabled": {
+          "type": "boolean",
+          "description": "Whether Java is enabled (required if javascript_enabled is true)"
+        },
+        "screen_height": {
+          "type": "integer",
+          "description": "Screen height in pixels (required if javascript_enabled is true)"
+        },
+        "screen_width": {
+          "type": "integer",
+          "description": "Screen width in pixels (required if javascript_enabled is true)"
+        },
+        "timezone_offset": {
+          "type": "integer",
+          "description": "Timezone offset in minutes (required if javascript_enabled is true)"
+        }
+      },
+      "required": ["accept_header", "ip_address", "javascript_enabled", "language", "user_agent"],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "javascript_enabled": { "const": true }
+            }
+          },
+          "then": {
+            "required": ["color_depth", "java_enabled", "screen_height", "screen_width", "timezone_offset"]
+          }
+        }
+      ],
+      "examples": [
+        {
+          "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          "ip_address": "192.168.1.1",
+          "javascript_enabled": true,
+          "language": "en-US",
+          "user_agent": "Mozilla/5.0",
+          "color_depth": 24,
+          "java_enabled": false,
+          "screen_height": 1080,
+          "screen_width": 1920,
+          "timezone_offset": 0
+        }
+      ]
+    },
+    "Channel": {
+      "type": "object",
+      "description": "The communication channel between the shopper and the merchant.",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["browser"],
+          "description": "Channel type"
+        },
+        "browser": {
+          "$ref": "#/$defs/BrowserInfo"
+        }
+      },
+      "required": ["type", "browser"],
+      "examples": [
+        {
+          "type": "browser",
+          "browser": {
+            "accept_header": "text/html",
+            "ip_address": "192.168.1.1",
+            "javascript_enabled": false,
+            "language": "en-US",
+            "user_agent": "Mozilla/5.0"
+          }
+        }
+      ]
+    },
+    "FlowPreference": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Preference for the 3DS authentication flow. Clients MAY request a preference, but issuers ultimately decide the actual flow.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["challenge", "frictionless"],
+          "description": "Type of flow requested"
+        },
+        "challenge": {
+          "type": "object",
+          "description": "Specific preferences if a challenge is requested.",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["mandated", "preferred"],
+              "description": "Subtype of challenge preference"
+            }
+          }
+        },
+        "frictionless": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Details about the requested frictionless flow"
+        }
+      },
+      "required": ["type"],
+      "examples": [
+        {
+          "type": "challenge",
+          "challenge": {
+            "type": "preferred"
+          }
+        }
+      ]
+    },
+    "ShopperDetails": {
+      "type": "object",
+      "description": "Information about the shopper performing the transaction.",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Shopper name"
+        },
+        "email": {
+          "type": "string",
+          "format": "email",
+          "description": "Shopper email"
+        },
+        "phone_number": {
+          "type": "string",
+          "description": "Shopper phone number"
+        },
+        "address": {
+          "$ref": "#/$defs/Address"
+        }
+      },
+      "examples": [
+        {
+          "name": "Jane Doe",
+          "email": "jane@example.com"
+        }
+      ]
+    },
+    "FingerprintAction": {
+      "type": "object",
+      "description": "Details for executing a 3DS fingerprinting action.",
+      "additionalProperties": false,
+      "properties": {
+        "three_ds_method_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to POST fingerprint data to via hidden iframe"
+        },
+        "three_ds_server_trans_id": {
+          "type": "string",
+          "description": "3DS Server transaction ID"
+        }
+      },
+      "required": ["three_ds_method_url", "three_ds_server_trans_id"],
+      "examples": [
+        {
+          "three_ds_method_url": "https://acs.issuer.com/3dsmethod",
+          "three_ds_server_trans_id": "abc-123-def"
+        }
+      ]
+    },
+    "ChallengeAction": {
+      "type": "object",
+      "description": "Details for executing a 3DS challenge action.",
+      "additionalProperties": false,
+      "properties": {
+        "acs_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to POST challenge request to"
+        },
+        "acs_trans_id": {
+          "type": "string",
+          "description": "ACS transaction identifier"
+        },
+        "three_ds_server_trans_id": {
+          "type": "string",
+          "description": "3DS Server transaction identifier"
+        },
+        "message_version": {
+          "type": "string",
+          "description": "3DS protocol version (e.g., \"2.2.0\")"
+        }
+      },
+      "required": ["acs_url", "acs_trans_id", "three_ds_server_trans_id", "message_version"],
+      "examples": [
+        {
+          "acs_url": "https://acs.issuer.com/challenge",
+          "acs_trans_id": "xyz-789",
+          "three_ds_server_trans_id": "abc-123-def",
+          "message_version": "2.2.0"
+        }
+      ]
+    },
+    "Action": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Describes browser action required",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["fingerprint", "challenge"],
+          "description": "The type of action required"
+        },
+        "fingerprint": {
+          "$ref": "#/$defs/FingerprintAction"
+        },
+        "challenge": {
+          "$ref": "#/$defs/ChallengeAction"
+        }
+      },
+      "required": ["type"],
+      "oneOf": [
+        {
+          "properties": { "type": { "const": "fingerprint" } },
+          "required": ["fingerprint"]
+        },
+        {
+          "properties": { "type": { "const": "challenge" } },
+          "required": ["challenge"]
+        }
+      ],
+      "examples": [
+        {
+          "type": "fingerprint",
+          "fingerprint": {
+            "three_ds_method_url": "https://acs.issuer.com/3dsmethod",
+            "three_ds_server_trans_id": "abc-123-def"
+          }
+        }
+      ]
+    },
+    "AuthenticationResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "3DS authentication result returned by the authentication provider",
+      "properties": {
+        "trans_status": {
+          "type": "string",
+          "description": "Transaction status (Y, N, A, U, R, etc.)"
+        },
+        "electronic_commerce_indicator": {
+          "type": "string",
+          "description": "Electronic Commerce Indicator"
+        },
+        "three_ds_cryptogram": {
+          "type": "string",
+          "description": "Authentication cryptogram (CAVV/AAV)"
+        },
+        "transaction_id": {
+          "type": "string",
+          "description": "Directory Server transaction ID"
+        },
+        "three_ds_server_trans_id": {
+          "type": "string",
+          "description": "3DS Server transaction ID"
+        },
+        "version": {
+          "type": "string",
+          "description": "3DS protocol version"
+        },
+        "authentication_value": {
+          "type": "string",
+          "description": "Authentication value (CAVV)"
+        },
+        "trans_status_reason": {
+          "type": "string",
+          "description": "Reason code for trans_status"
+        },
+        "cardholder_info": {
+          "type": "string",
+          "description": "Message to display to cardholder"
+        }
+      },
+      "required": [
+        "trans_status", "transaction_id", "three_ds_server_trans_id", "version"
+      ],
+      "examples": [
+        {
+          "trans_status": "Y",
+          "transaction_id": "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
+          "three_ds_server_trans_id": "6edcc246-23ee-4e94-ac5d-8ae620bea7d9",
+          "version": "2.2.0"
+        }
+      ]
+    },
+    "DelegateAuthenticationCreateRequest": {
+      "type": "object",
+      "description": "Request body for creating an authentication session.",
+      "additionalProperties": false,
+      "properties": {
+        "merchant_id": {
+          "type": "string",
+          "description": "Merchant identifier"
+        },
+        "acquirer_details": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Object containing acquirer data used for AReq construction. Recommended to ensure the authentication matches the final authorization.",
+          "properties": {
+            "acquirer_bin": {
+              "type": "string",
+              "maxLength": 11,
+              "description": "The Acquirer BIN."
+            },
+            "acquirer_country": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 2,
+              "description": "Two-letter ISO 3166-1 alpha-2 country code."
+            },
+            "acquirer_merchant_id": {
+              "type": "string",
+              "maxLength": 35,
+              "description": "The Merchant ID assigned by the acquirer."
+            },
+            "merchant_name": {
+              "type": "string",
+              "maxLength": 40,
+              "description": "Merchant name assigned by the acquirer."
+            },
+            "requestor_id": {
+              "type": "string",
+              "maxLength": 35,
+              "description": "3DS Requestor ID (if required by directory server)."
+            }
+          },
+          "required": [
+            "acquirer_bin",
+            "acquirer_country",
+            "acquirer_merchant_id",
+            "merchant_name"
+          ]
+        },
+        "payment_method": {
+          "$ref": "#/$defs/PaymentMethod"
+        },
+        "amount": {
+          "$ref": "#/$defs/Amount"
+        },
+        "channel": {
+          "$ref": "#/$defs/Channel"
+        },
+        "checkout_session_id": {
+          "type": "string",
+          "description": "Checkout session identifier"
+        },
+        "flow_preference": {
+          "$ref": "#/$defs/FlowPreference"
+        },
+        "challenge_notification_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL for challenge result callback"
+        },
+        "shopper_details": {
+          "$ref": "#/$defs/ShopperDetails"
+        }
+      },
+      "required": ["merchant_id", "payment_method", "amount"],
+      "examples": [
+        {
+          "merchant_id": "merchant_abc123",
+          "payment_method": {
+            "type": "card",
+            "number": "4917610000000000",
+            "exp_month": "03",
+            "exp_year": "2030",
+            "name": "Jane Doe"
+          },
+          "amount": {
+            "value": 1000,
+            "currency": "EUR"
+          }
+        }
+      ]
+    },
+    "DelegateAuthenticationAuthenticateRequest": {
+      "type": "object",
+      "description": "Request body for completing authentication after action.",
+      "additionalProperties": false,
+      "properties": {
+        "fingerprint_completion": {
+          "type": "string",
+          "enum": ["Y", "N", "U"],
+          "description": "Result of the 3DS Method fingerprint: Y = Completed successfully, N = Timeout/not completed, U = Unavailable/not performed"
+        },
+        "channel": {
+          "$ref": "#/$defs/Channel"
+        },
+        "checkout_session_id": {
+          "type": "string",
+          "description": "Checkout session identifier"
+        },
+        "challenge_notification_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL for challenge result callback"
+        },
+        "shopper_details": {
+          "$ref": "#/$defs/ShopperDetails"
+        }
+      },
+      "required": ["fingerprint_completion"],
+      "examples": [
+        {
+          "fingerprint_completion": "Y"
+        }
+      ]
+    },
+    "DelegateAuthenticationSessionBase": {
+      "type": "object",
+      "description": "Base properties for an authentication session response.",
+      "additionalProperties": false,
+      "properties": {
+        "authentication_session_id": {
+          "type": "string",
+          "description": "Session ID for subsequent requests"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "action_required",
+            "pending",
+            "not_supported",
+            "authenticated",
+            "attempted",
+            "not_authenticated",
+            "rejected",
+            "unavailable",
+            "expired",
+            "challenge_abandoned"
+          ],
+          "description": "Session status indicating current state and next action"
+        },
+        "action": {
+          "$ref": "#/$defs/Action"
+        }
+      },
+      "required": ["authentication_session_id", "status"],
+      "examples": [
+        {
+          "authentication_session_id": "auth_session_abc123",
+          "status": "pending"
+        }
+      ]
+    },
+    "DelegateAuthenticationSession": {
+      "description": "Object representing the current state of the authentication session.",
+      "allOf": [
+        { "$ref": "#/$defs/DelegateAuthenticationSessionBase" }
+      ],
+      "examples": [
+        {
+          "authentication_session_id": "auth_session_abc123",
+          "status": "authenticated"
+        }
+      ]
+    },
+    "DelegateAuthenticationSessionWithResult": {
+      "description": "The session details including the final 3DS authentication result.",
+      "allOf": [
+        { "$ref": "#/$defs/DelegateAuthenticationSessionBase" },
+        {
+          "type": "object",
+          "description": "Container for the authentication outcome",
+          "properties": {
+            "authentication_result": {
+              "$ref": "#/$defs/AuthenticationResult"
+            }
+          }
+        }
+      ],
+      "examples": [
+        {
+          "authentication_session_id": "auth_session_abc123",
+          "status": "authenticated",
+          "authentication_result": {
+            "trans_status": "Y",
+            "transaction_id": "c4e59ceb-a382-4d6a-bc87-385d591fa09d",
+            "three_ds_server_trans_id": "6edcc246-23ee-4e94-ac5d-8ae620bea7d9",
+            "version": "2.2.0"
+          }
+        }
+      ]
+    },
+    "Error": {
+      "type": "object",
+      "description": "Standard error response format.",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["invalid_request", "rate_limit_exceeded", "processing_error", "service_unavailable"],
+          "description": "High-level error category"
+        },
+        "code": {
+          "type": "string",
+          "enum": ["invalid_card", "duplicate_request", "idempotency_conflict"],
+          "description": "Specific error code for programmatic handling"
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable error message"
+        },
+        "param": {
+          "type": "string",
+          "description": "JSONPath of offending field"
+        }
+      },
+      "required": ["type", "code", "message"],
+      "examples": [
+        {
+          "type": "invalid_request",
+          "code": "invalid_card",
+          "message": "Invalid card number"
+        }
+      ]
+    }
+  }
+}

--- a/spec/unreleased/openapi/openapi.delegate_authentication.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_authentication.yaml
@@ -1,0 +1,890 @@
+openapi: 3.1.0
+info:
+  title: Agentic Commerce — Delegate Authentication API
+  version: "2026-01-28"
+  description: |
+    Delegate consumer authentication (3D Secure) to merchant-specified providers.
+    Implements create, authenticate, and retrieve endpoints for 3DS2 browser-based flows.
+servers:
+  - url: https://authentication-provider.example.com
+security:
+  - bearerAuth: []
+tags:
+  - name: DelegateAuthentication
+    description: Create and manage 3DS authentication sessions
+
+paths:
+  /delegate_authentication:
+    post:
+      tags: [DelegateAuthentication]
+      summary: Create an authentication session
+      operationId: createAuthenticationSession
+      description: |
+        Initializes a 3DS authentication session with merchant, card, and amount details.
+        Returns fingerprint action if supported, `pending` if no fingerprint needed, or `not_supported` if card not enrolled.
+      parameters:
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/ContentType"
+        - $ref: "#/components/parameters/AcceptLanguage"
+        - $ref: "#/components/parameters/UserAgent"
+        - $ref: "#/components/parameters/IdempotencyKey"
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/Signature"
+        - $ref: "#/components/parameters/Timestamp"
+        - $ref: "#/components/parameters/APIVersion"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DelegateAuthenticationCreateRequest"
+            examples:
+              minimal:
+                summary: Minimal request
+                value:
+                  merchant_id: "merchant_abc123"
+                  acquirer_bin: "123456"
+                  acquirer_merchant_id: "merchant_789"
+                  acquirer_details:
+                    acquirer_bin: "412345"
+                    acquirer_country: "US"
+                    acquirer_merchant_id: "123456789012345"
+                    merchant_name: "Example Merchant Inc"
+                    requestor_id: "REQ_12345"
+                  payment_method:
+                    type: "card"
+                    number: "4917610000000000"
+                    exp_month: "03"
+                    exp_year: "2030"
+                    name: "Jane Doe"
+                  amount:
+                    value: 1000
+                    currency: "EUR"
+              with_channel:
+                summary: With channel and shopper details
+                value:
+                  merchant_id: "merchant_abc123"
+                  payment_method:
+                    type: "card"
+                    number: "4917610000000000"
+                    exp_month: "03"
+                    exp_year: "2030"
+                    name: "Jane Doe"
+                  amount:
+                    value: 1000
+                    currency: "EUR"
+                  checkout_session_id: "checkout_session_123"
+                  channel:
+                    type: "browser"
+                    browser:
+                      accept_header: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+                      ip_address: "192.168.1.1"
+                      javascript_enabled: true
+                      language: "en-US"
+                      user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)..."
+                      color_depth: 24
+                      java_enabled: false
+                      screen_height: 1080
+                      screen_width: 1920
+                      timezone_offset: 0
+                  flow_preference:
+                    type: "challenge"
+                    challenge:
+                      type: "preferred"
+                  challenge_notification_url: "https://agent.example.com/3ds/challenge-callback"
+                  shopper_details:
+                    name: "Jane Doe"
+                    email: "shopper@example.com"
+                    phone_number: "15551234567"
+                    address:
+                      name: "Jane Doe"
+                      line_one: "123 Main Street"
+                      line_two: "Apt 4B"
+                      city: "Amsterdam"
+                      state: "NH"
+                      country: "NL"
+                      postal_code: "1012 AB"
+      responses:
+        "201":
+          description: Created
+          headers:
+            Idempotency-Key:
+              description: Echo of the request idempotency key
+              schema: { type: string }
+            Request-Id:
+              description: Echo of the request correlation id
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DelegateAuthenticationSession"
+              examples:
+                fingerprint_required:
+                  summary: Fingerprint action required
+                  value:
+                    authentication_session_id: "auth_session_abc123"
+                    status: "action_required"
+                    action:
+                      type: "fingerprint"
+                      fingerprint:
+                        three_ds_method_url: "https://acs.issuer.com/3dsmethod"
+                        three_ds_server_trans_id: "abc-123-def"
+                pending:
+                  summary: No fingerprint needed
+                  value:
+                    authentication_session_id: "auth_session_abc123"
+                    status: "pending"
+                not_supported:
+                  summary: Card not enrolled
+                  value:
+                    authentication_session_id: "auth_session_abc123"
+                    status: "not_supported"
+        "4XX":
+          description: Client error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "5XX":
+          description: Server error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /delegate_authentication/{authentication_session_id}/authenticate:
+    parameters:
+      - $ref: "#/components/parameters/Authorization"
+      - $ref: "#/components/parameters/ContentType"
+      - $ref: "#/components/parameters/AcceptLanguage"
+      - $ref: "#/components/parameters/UserAgent"
+      - $ref: "#/components/parameters/IdempotencyKey"
+      - $ref: "#/components/parameters/RequestId"
+      - $ref: "#/components/parameters/Signature"
+      - $ref: "#/components/parameters/Timestamp"
+      - $ref: "#/components/parameters/APIVersion"
+      - name: authentication_session_id
+        in: path
+        required: true
+        schema: { type: string }
+    post:
+      tags: [DelegateAuthentication]
+      summary: Submit fingerprint result and trigger authentication
+      operationId: authenticateSession
+      description: |
+        Submits the result of the fingerprint action and triggers the Authentication Request (AReq).
+        Returns challenge action if required, or frictionless result.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DelegateAuthenticationAuthenticateRequest"
+            examples:
+              fingerprint_success:
+                summary: Fingerprint completed successfully
+                value:
+                  fingerprint_completion: "Y"
+              with_deferred_channel:
+                summary: With deferred channel data
+                value:
+                  fingerprint_completion: "Y"
+                  channel:
+                    type: "browser"
+                    browser:
+                      accept_header: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+                      ip_address: "192.168.1.1"
+                      javascript_enabled: true
+                      language: "en-US"
+                      user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)..."
+                      color_depth: 24
+                      java_enabled: false
+                      screen_height: 1080
+                      screen_width: 1920
+                      timezone_offset: 0
+                  challenge_notification_url: "https://agent.example.com/3ds/challenge-callback"
+      responses:
+        "200":
+          description: Authentication result
+          headers:
+            Idempotency-Key:
+              description: Echo of the request idempotency key
+              schema: { type: string }
+            Request-Id:
+              description: Echo of the request correlation id
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DelegateAuthenticationSession"
+              examples:
+                frictionless:
+                  summary: Frictionless authentication successful
+                  value:
+                    authentication_session_id: "auth_session_abc123"
+                    status: "authenticated"
+                challenge_required:
+                  summary: Challenge required
+                  value:
+                    authentication_session_id: "auth_session_abc123"
+                    status: "action_required"
+                    action:
+                      type: "challenge"
+                      challenge:
+                        acs_url: "https://acs.issuer.com/challenge"
+                        acs_trans_id: "xyz-789"
+                        three_ds_server_trans_id: "abc-123-def"
+                        message_version: "2.2.0"
+        "4XX":
+          description: Client error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "5XX":
+          description: Server error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+  /delegate_authentication/{authentication_session_id}:
+    parameters:
+      - $ref: "#/components/parameters/Authorization"
+      - $ref: "#/components/parameters/AcceptLanguage"
+      - $ref: "#/components/parameters/UserAgent"
+      - $ref: "#/components/parameters/RequestId"
+      - $ref: "#/components/parameters/Signature"
+      - $ref: "#/components/parameters/Timestamp"
+      - $ref: "#/components/parameters/APIVersion"
+      - name: authentication_session_id
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      tags: [DelegateAuthentication]
+      summary: Retrieve authentication session
+      operationId: getAuthenticationSession
+      description: |
+        Retrieves the current session state including the final 3DS authentication result (cryptogram, ECI, transaction IDs) when available.
+      responses:
+        "200":
+          description: Current session state
+          headers:
+            Request-Id:
+              description: Echo of the request correlation id
+              schema: { type: string }
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DelegateAuthenticationSessionWithResult"
+              examples:
+                authenticated:
+                  summary: Authentication successful
+                  value:
+                    authentication_session_id: "auth_session_abc123"
+                    status: "authenticated"
+                    authentication_result:
+                      trans_status: "Y"
+                      electronic_commerce_indicator: "05"
+                      three_ds_cryptogram: "AQIDBAUGBwgJCgsMDQ4PEBESExQ="
+                      transaction_id: "c4e59ceb-a382-4d6a-bc87-385d591fa09d"
+                      three_ds_server_trans_id: "6edcc246-23ee-4e94-ac5d-8ae620bea7d9"
+                      version: "2.2.0"
+                      authentication_value: "CAVV_VALUE"
+                not_authenticated:
+                  summary: Authentication failed
+                  value:
+                    authentication_session_id: "auth_session_abc123"
+                    status: "not_authenticated"
+                    authentication_result:
+                      trans_status: "N"
+                      trans_status_reason: "01"
+                      electronic_commerce_indicator: "07"
+                      transaction_id: "3022b509-391e-4c25-a225-f37e062843a5"
+                      three_ds_server_trans_id: "87a357a1-faee-4cd1-b3cf-ea2c704bf073"
+                      version: "2.2.0"
+                      cardholder_info: "Please contact your bank's customer support."
+        "4XX":
+          description: Client error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "5XX":
+          description: Server error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+
+  parameters:
+    Authorization:
+      name: Authorization
+      in: header
+      required: true
+      schema: { type: string, example: "Bearer api_key_123" }
+    ContentType:
+      name: Content-Type
+      in: header
+      required: true
+      schema: { type: string, example: "application/json" }
+    AcceptLanguage:
+      name: Accept-Language
+      in: header
+      required: false
+      schema: { type: string, example: "en-US" }
+    UserAgent:
+      name: User-Agent
+      in: header
+      required: false
+      schema:
+        {
+          type: string,
+          example: "ChatGPT/2.0 (Mac OS X 15.0.1; arm64; build 0)",
+        }
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      schema: { type: string, example: "idempotency_key_123" }
+    RequestId:
+      name: Request-Id
+      in: header
+      required: false
+      schema: { type: string, example: "request_id_123" }
+    Signature:
+      name: Signature
+      in: header
+      required: false
+      schema: { type: string, example: "ZXltZX..." }
+    Timestamp:
+      name: Timestamp
+      in: header
+      required: false
+      schema: { type: string, format: date-time, example: "2026-01-28T10:30:00Z" }
+    APIVersion:
+      name: API-Version
+      in: header
+      required: true
+      schema: { type: string, example: "2026-01-28" }
+
+  schemas:
+    # Request Schemas
+    DelegateAuthenticationCreateRequest:
+      type: object
+      description: Request body to initialize an authentication session.
+      additionalProperties: false
+      example:
+        merchant_id: "merchant_abc123"
+        payment_method:
+          type: "card"
+          number: "4917610000000000"
+          exp_month: "03"
+          exp_year: "2030"
+          name: "Jane Doe"
+        amount:
+          value: 1000
+          currency: "EUR"
+      properties:
+        merchant_id:
+          type: string
+          description: Merchant identifier
+        acquirer_details:
+          type: object
+          additionalProperties: false
+          description: |
+            Object containing acquirer data used for AReq construction. 
+            **Recommended:** To ensure the AReq matches the final Authorization, especially when using different authentication and payment providers.
+          required:
+            - acquirer_bin
+            - acquirer_country
+            - acquirer_merchant_id
+            - merchant_name
+          properties:
+            acquirer_bin:
+              type: string
+              maxLength: 11
+              description: The Acquirer BIN.
+            acquirer_country:
+              type: string
+              minLength: 2
+              maxLength: 2
+              description: Two-letter ISO 3166-1 alpha-2 country code.
+            acquirer_merchant_id:
+              type: string
+              maxLength: 35
+              description: The Merchant ID assigned by the acquirer.
+            merchant_name:
+              type: string
+              maxLength: 40
+              description: Merchant name assigned by the acquirer.
+            requestor_id:
+              type: string
+              maxLength: 35
+              description: 3DS Requestor ID (if required by directory server).
+        payment_method:
+          $ref: "#/components/schemas/PaymentMethod"
+        amount:
+          $ref: "#/components/schemas/Amount"
+        channel:
+          $ref: "#/components/schemas/Channel"
+        checkout_session_id:
+          type: string
+          description: Checkout session identifier
+        flow_preference:
+          $ref: "#/components/schemas/FlowPreference"
+        challenge_notification_url:
+          type: string
+          format: uri
+          description: URL for challenge result callback
+        shopper_details:
+          $ref: "#/components/schemas/ShopperDetails"
+      required: [merchant_id, payment_method, amount]
+
+    DelegateAuthenticationAuthenticateRequest:
+      type: object
+      description: Request body to submit fingerprint result and trigger AReq.
+      additionalProperties: false
+      example:
+        fingerprint_completion: "Y"
+      properties:
+        fingerprint_completion:
+          type: string
+          enum: [Y, N, U]
+          description: |
+            Result of the 3DS Method fingerprint:
+            - Y: Completed successfully
+            - N: Timeout/not completed
+            - U: Unavailable/not performed
+        channel:
+          $ref: "#/components/schemas/Channel"
+        checkout_session_id:
+          type: string
+          description: Checkout session identifier
+        challenge_notification_url:
+          type: string
+          format: uri
+          description: URL for challenge result callback
+        shopper_details:
+          $ref: "#/components/schemas/ShopperDetails"
+      required: [fingerprint_completion]
+
+    # Response Schemas
+    DelegateAuthenticationSessionBase:
+      type: object
+      description: Base properties for an authentication session response.
+      additionalProperties: false
+      example:
+        authentication_session_id: "auth_session_abc123"
+        status: "pending"
+      properties:
+        authentication_session_id:
+          type: string
+          description: Session ID for subsequent requests
+        status:
+          type: string
+          enum:
+            [
+              action_required,
+              pending,
+              not_supported,
+              authenticated,
+              attempted,
+              not_authenticated,
+              rejected,
+              unavailable,
+              expired,
+              challenge_abandoned,
+            ]
+          description: |
+            Current state of the session.
+            - action_required: Browser action needed.
+            - pending: Awaiting completion.
+            - not_supported: Method not available.
+        action:
+          $ref: "#/components/schemas/Action"
+      required: [authentication_session_id, status]
+
+    DelegateAuthenticationSession:
+      description: Response object representing a standard session state.
+      example:
+        authentication_session_id: "auth_session_abc123"
+        status: "action_required"
+        action:
+          type: "fingerprint"
+          fingerprint:
+            three_ds_method_url: "https://acs.issuer.com/3dsmethod"
+            three_ds_server_trans_id: "abc-123-def"
+      allOf:
+        - $ref: "#/components/schemas/DelegateAuthenticationSessionBase"
+
+    DelegateAuthenticationSessionWithResult:
+      description: Response object containing the full session state and final result.
+      example:
+        authentication_session_id: "auth_session_abc123"
+        status: "authenticated"
+        authentication_result:
+          trans_status: "Y"
+          transaction_id: "c4e59ceb-a382-4d6a-bc87-385d591fa09d"
+          three_ds_server_trans_id: "6edcc246-23ee-4e94-ac5d-8ae620bea7d9"
+          version: "2.2.0"
+      allOf:
+        - $ref: "#/components/schemas/DelegateAuthenticationSessionBase"
+        - type: object
+          description: Extension containing the authentication result data.
+          properties:
+            authentication_result:
+              $ref: "#/components/schemas/AuthenticationResult"
+
+    # Data Models
+    PaymentMethod:
+      type: object
+      description: Card information for the authentication session.
+      additionalProperties: false
+      example:
+        type: "card"
+        number: "4917610000000000"
+        exp_month: "03"
+        exp_year: "2030"
+        name: "Jane Doe"
+      properties:
+        type:
+          type: string
+          enum: [card]
+          description: Payment method type
+        number:
+          type: string
+          description: Card number (PAN)
+        exp_month:
+          type: string
+          maxLength: 2
+          description: Expiry month (01-12)
+        exp_year:
+          type: string
+          maxLength: 4
+          description: Expiry year (4 digits)
+        name:
+          type: string
+          description: Cardholder name
+      required: [type, number, exp_month, exp_year, name]
+
+    Amount:
+      type: object
+      description: Monetary amount for the authentication request.
+      additionalProperties: false
+      example:
+        value: 1000
+        currency: "EUR"
+      properties:
+        value:
+          type: integer
+          description: Amount in minor units (e.g., 1000 = €10.00)
+        currency:
+          type: string
+          pattern: "^[A-Z]{3}$"
+          description: ISO 4217 currency code
+      required: [value, currency]
+
+    Channel:
+      type: object
+      description: Defines the platform/medium for the session.
+      additionalProperties: false
+      example:
+        type: "browser"
+        browser:
+          accept_header: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+          ip_address: "192.168.1.1"
+          javascript_enabled: true
+          language: "en-US"
+          user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)..."
+      properties:
+        type:
+          type: string
+          enum: [browser]
+          description: Channel type
+        browser:
+          $ref: "#/components/schemas/BrowserInfo"
+      required: [type, browser]
+
+    BrowserInfo:
+      type: object
+      description: Detailed browser metadata for 3DS2.
+      additionalProperties: false
+      example:
+        accept_header: "text/html"
+        ip_address: "127.0.0.1"
+        javascript_enabled: false
+        language: "en-US"
+        user_agent: "Mozilla/5.0"
+      properties:
+        accept_header:
+          type: string
+          description: HTTP Accept header from the browser
+        ip_address:
+          type: string
+          maxLength: 45
+          description: IP address of the browser
+        javascript_enabled:
+          type: boolean
+          description: Whether JavaScript is enabled
+        language:
+          type: string
+          maxLength: 35
+          description: IETF BCP 47 language tag
+        user_agent:
+          type: string
+          description: Browser user agent string
+        color_depth:
+          type: integer
+          description: Screen color depth (required if javascript_enabled is true)
+        java_enabled:
+          type: boolean
+          description: Whether Java is enabled (required if javascript_enabled is true)
+        screen_height:
+          type: integer
+          description: Screen height in pixels (required if javascript_enabled is true)
+        screen_width:
+          type: integer
+          description: Screen width in pixels (required if javascript_enabled is true)
+        timezone_offset:
+          type: integer
+          description: Timezone offset in minutes (required if javascript_enabled is true)
+      required: [accept_header, ip_address, javascript_enabled, language, user_agent]
+      allOf:
+        - if:
+            properties:
+              javascript_enabled:
+                const: true
+          then:
+            required:
+              - color_depth
+              - java_enabled
+              - screen_height
+              - screen_width
+              - timezone_offset
+
+    FlowPreference:
+      type: object
+      additionalProperties: false
+      description: |
+        Preference for the 3DS authentication flow. Clients MAY request a preference,
+        but issuers ultimately decide the actual flow.
+      example:
+        type: "challenge"
+        challenge:
+          type: "preferred"
+      properties:
+        type:
+          type: string
+          enum: [challenge, frictionless]
+          description: Type of flow requested
+        challenge:
+          type: object
+          description: Preference details for a challenge flow.
+          additionalProperties: false
+          properties:
+            type:
+              type: string
+              enum: [mandated, preferred]
+              description: Subtype of challenge preference
+        frictionless:
+          type: object
+          additionalProperties: false
+          description: Details about the requested frictionless flow
+      required: [type]
+
+    ShopperDetails:
+      type: object
+      description: Identity and contact info for the shopper.
+      additionalProperties: false
+      example:
+        name: "Jane Doe"
+        email: "jane@example.com"
+      properties:
+        name:
+          type: string
+          description: Shopper name
+        email:
+          type: string
+          format: email
+          description: Shopper email
+        phone_number:
+          type: string
+          description: Shopper phone number
+        address:
+          $ref: "#/components/schemas/Address"
+
+    Address:
+      type: object
+      description: Physical address schema for shopper or shipping.
+      additionalProperties: false
+      example:
+        name: "Jane Doe"
+        line_one: "123 Main St"
+        city: "Amsterdam"
+        state: "NH"
+        country: "NL"
+        postal_code: "1012 AB"
+      properties:
+        name:
+          type: string
+          maxLength: 256
+          description: Full name of the recipient.
+        line_one:
+          type: string
+          maxLength: 60
+          description: Street address line 1.
+        line_two:
+          type: string
+          maxLength: 60
+          description: Street address line 2.
+        city:
+          type: string
+          maxLength: 60
+          description: City name.
+        state:
+          type: string
+          description: ISO-3166-2 where applicable
+        country:
+          type: string
+          minLength: 2
+          maxLength: 2
+          description: ISO-3166-1 alpha-2
+        postal_code:
+          type: string
+          maxLength: 20
+          description: Postal code or ZIP code.
+      required: [name, line_one, city, state, country, postal_code]
+
+    Action:
+      type: object
+      additionalProperties: false
+      description: Describes browser action required
+      properties:
+        type:
+          type: string
+          enum: [fingerprint, challenge]
+          description: Category of action.
+        fingerprint:
+          $ref: "#/components/schemas/FingerprintAction"
+        challenge:
+          $ref: "#/components/schemas/ChallengeAction"
+      required: [type]
+      oneOf:
+        - properties:
+            type:
+              const: fingerprint
+          required: [fingerprint]
+        - properties:
+            type:
+              const: challenge
+          required: [challenge]
+
+    FingerprintAction:
+      type: object
+      description: Configuration for browser fingerprinting via iframe.
+      additionalProperties: false
+      example:
+        three_ds_method_url: "https://acs.issuer.com/3dsmethod"
+        three_ds_server_trans_id: "abc-123"
+      properties:
+        three_ds_method_url:
+          type: string
+          format: uri
+          description: URL to POST fingerprint data to via hidden iframe
+        three_ds_server_trans_id:
+          type: string
+          description: 3DS Server transaction ID
+      required: [three_ds_method_url, three_ds_server_trans_id]
+
+    ChallengeAction:
+      type: object
+      description: Configuration for cardholder challenge interaction.
+      additionalProperties: false
+      example:
+        acs_url: "https://acs.issuer.com/challenge"
+        acs_trans_id: "xyz-789"
+        three_ds_server_trans_id: "abc-123"
+        message_version: "2.2.0"
+      properties:
+        acs_url:
+          type: string
+          format: uri
+          description: URL to POST challenge request to
+        acs_trans_id:
+          type: string
+          description: ACS transaction identifier
+        three_ds_server_trans_id:
+          type: string
+          description: 3DS Server transaction identifier
+        message_version:
+          type: string
+          description: 3DS protocol version (e.g., "2.2.0")
+      required: [acs_url, acs_trans_id, three_ds_server_trans_id, message_version]
+
+    AuthenticationResult:
+      type: object
+      description: The finalized 3DS authentication data.
+      additionalProperties: false
+      example:
+        trans_status: "Y"
+        electronic_commerce_indicator: "05"
+        transaction_id: "dir-123"
+        three_ds_server_trans_id: "srv-456"
+        version: "2.2.0"
+      properties:
+        trans_status:
+          type: string
+          description: Transaction status (Y, N, A, U, R, etc.)
+        electronic_commerce_indicator:
+          type: string
+          description: Electronic Commerce Indicator (ECI)
+        three_ds_cryptogram:
+          type: string
+          description: Authentication cryptogram (CAVV/AAV)
+        transaction_id:
+          type: string
+          description: Directory Server transaction ID
+        three_ds_server_trans_id:
+          type: string
+          description: 3DS Server transaction ID
+        version:
+          type: string
+          description: 3DS protocol version (e.g., "2.2.0")
+        authentication_value:
+          type: string
+          description: Authentication value (CAVV)
+        trans_status_reason:
+          type: string
+          description: Reason code for trans_status
+        cardholder_info:
+          type: string
+          description: Message to display to cardholder
+      required: [trans_status, transaction_id, three_ds_server_trans_id, version]
+
+    Error:
+      type: object
+      description: Structured error response.
+      additionalProperties: false
+      example:
+        type: "invalid_request"
+        code: "invalid_card"
+        message: "The card number is invalid."
+      properties:
+        type:
+          type: string
+          enum: [invalid_request, rate_limit_exceeded, processing_error, service_unavailable]
+          description: Category of error.
+        code:
+          type: string
+          enum: [invalid_card, duplicate_request, idempotency_conflict]
+          description: Specific error sub-code.
+        message:
+          type: string
+          description: Detailed error description.
+        param:
+          type: string
+          description: RFC 9535 JSONPath (optional)
+      required: [type, code, message]


### PR DESCRIPTION
## Abstract

As proposed in SEP #79, this PR proposes a standardized **Delegated Authentication API** that enables agents to perform consumer authentication (3DS) directly with **merchant-specified authentication providers**. This extends [SEP #53](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/pull/53) by defining the REST endpoints that authentication providers SHOULD implement, allowing merchants to bring their own 3DS provider.

## Motivation

[SEP #53](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/pull/53) added 3DS support to enable compliance in regulated markets (SCA/PSD2). However, authentication execution remains coupled to the Agent's PSP.

1. **Provider Flexibility**: Enterprise merchants can retain their existing 3DS provider, contracts, and optimizations (exemption management, fraud scoring, etc.) without vendor lock-in.

2. **Architectural Consistency**: Merchants already specify `payment_provider`. A similar `authentication_provider` pattern provides consistency.

3. **Data Privacy**: Eliminates sharing sensitive acquirer BIN/MID with providers the merchant does not have a relationship with.

## Flow
```mermaid
sequenceDiagram
    participant Consumer
    participant Agent
    participant AuthProvider as Authentication Provider
    participant DS as Directory Server (Scheme)
    participant ACS as Issuer ACS

    Consumer->>Agent: Initiate Checkout
    Note over Agent: POST /checkout_sessions<br/>Returns authentication_provider

    Agent->>AuthProvider: POST /delegate_authentication
    AuthProvider-->>Agent: authentication_session_id, action: fingerprint
    Note left of AuthProvider: Includes threeDSServerTransID,<br/>threeDSMethodURL

    Agent->>ACS: 3DS Method (browser)
    Note right of Agent: POST to threeDSMethodURL with<br/>threeDSServerTransID + threeDSMethodNotificationURL
    ACS-->>Agent: POST to notification URL

    Agent->>AuthProvider: POST /delegate_authentication/{authentication_session_id}/authenticate
    AuthProvider->>DS: AReq (Authentication Request)
    DS->>ACS: AReq
    ACS-->>DS: ARes (Authentication Response)
    DS-->>AuthProvider: ARes

    alt Frictionless (transStatus: Y)
        AuthProvider-->>Agent: status: authenticated
        Agent->>AuthProvider: GET /delegate_authentication/{authentication_session_id}
        AuthProvider-->>Agent: 3DS Authentication Result (cryptogram, ECI, ...)
    else Challenge Required (transStatus: C)
        AuthProvider-->>Agent: status: action_required, action: challenge
        Agent->>ACS: CReq (browser challenge)
        ACS-->>Agent: Challenge UI
        Agent-->>Consumer: Present challenge
        ACS->>DS: RReq (Result Request)
        DS->>AuthProvider: RReq
        AuthProvider-->>DS: RRes
        DS-->>ACS: RRes
        ACS-->>Agent: CRes (challenge complete)
        Agent->>AuthProvider: GET /delegate_authentication/{authentication_session_id}
        AuthProvider-->>Agent: 3DS Authentication Result (cryptogram, ECI, ...)
    end

    Note over Agent: POST /checkout_sessions/{id}/complete<br/>with 3DS Authentication Result
    Agent-->>Consumer: Checkout complete
```

| Step   | Endpoint                                          | Purpose                                    |
|--------|---------------------------------------------------|--------------------------------------------|
| 1      | `POST /checkout_sessions`                         | Get session with `authentication_provider` |
| 2      | `POST /delegate_authentication`                   | Start 3DS, get fingerprint action          |
| 3      | Browser -> ACS                                    | 3DS Method (device fingerprint)            |
| 4      | `POST /delegate_authentication/{id}/authenticate` | Submit fingerprint, trigger AReq/ARes      |
| 5      | Browser -> ACS (if needed)                        | Challenge flow                             |
| 6      | `GET /delegate_authentication/{id}`               | Retrieve 3DS Authentication Result         |
| 7      | `POST /checkout_sessions/{id}/complete`           | Complete checkout with authentication data |

## Semantics (normative)

- Authentication providers MUST implement all three endpoints: create, authenticate, and retrieve.
- Authentication providers MUST return an `authentication_session_id` on create. Agents MUST include this ID in subsequent requests.
- When create returns `status: action_required` with `action.type: fingerprint`, agents MUST execute the 3DS Method before calling authenticate.
- When authenticate returns `status: action_required` with `action.type: challenge`, agents MUST present the challenge to the consumer before calling retrieve.
- Agents MUST call retrieve to obtain the final `authentication_result` after authentication completes.
- Authentication providers SHOULD support `Idempotency-Key` on create requests. Replays with the same key and different parameters MUST return `409 Conflict`.
- Channel data MAY be provided in create or authenticate, but MUST be provided in at least one.
- Agents SHOULD pass the `authentication_result` to the seller via `POST /checkout_sessions/{id}/complete` as defined in SEP #53.

## Compatibility

This proposal is additive and backward-compatible with SEP #53. Merchants without their own 3DS capability can continue using the Agent's PSP as a fallback.