### PR TITLE
Add `resolution` field to Message schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store

--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -1,6 +1,22 @@
 # Unreleased Changes
 
-No unreleased changes at this time.
+## Added
+
+### Message Resolution Field
+
+Added optional `resolution` field to `MessageInfo`, `MessageWarning`, and `MessageError` schemas. This field indicates who is responsible for resolving the message:
+
+- `recoverable`: Agent can fix via API (e.g., retry with different parameters)
+- `requires_buyer_input`: Buyer must provide information the API cannot collect programmatically (checkout incomplete)
+- `requires_buyer_review`: Buyer must authorize before order placement due to policy, regulatory, or entitlement rules (checkout complete)
+
+This enables agents to make informed decisions about whether to attempt automated recovery or escalate to the buyer.
+
+**Files changed:**
+- `spec/unreleased/openapi/openapi.agentic_checkout.yaml`
+- `spec/unreleased/json-schema/schema.agentic_checkout.json`
+- `rfcs/rfc.agentic_checkout.md`
+- `examples/discount-extension/rejected-discount-code.json`
 
 ---
 

--- a/examples/discount-extension/rejected-discount-code.json
+++ b/examples/discount-extension/rejected-discount-code.json
@@ -89,6 +89,7 @@
       {
         "type": "warning",
         "code": "discount_code_expired",
+        "resolution": "recoverable",
         "param": "$.discounts.codes[1]",
         "content_type": "plain",
         "content": "Code 'EXPIRED50' expired on December 1, 2025 and could not be applied."

--- a/rfcs/rfc.agentic_checkout.md
+++ b/rfcs/rfc.agentic_checkout.md
@@ -186,8 +186,15 @@ If a client calls `POST .../complete` while `session.status` is `authentication_
 - **PaymentHandler**: `id`, `name`, `version`, `spec`, `requires_delegate_payment`, `requires_pci_compliance`, `psp`, `config_schema`, `instrument_schemas[]`, `config` (handler-specific configuration)
 - **PaymentData**: `handler_id`, `instrument` (with `type` and `credential`), `billing_address?`
 - **Order**: `id`, `checkout_session_id`, `permalink_url`
-- **Message (info)**: `type: "info"`, `param?`, `content_type: "plain"|"markdown"`, `content`
-- **Message (error)**: `type: "error"`, `code` (`missing|invalid|out_of_stock|payment_declined|requires_sign_in|requires_3ds`), `param?`, `content_type`, `content`
+- **Message (info)**: `type: "info"`, `severity?`, `resolution?`, `param?`, `content_type: "plain"|"markdown"`, `content`
+- **Message (warning)**: `type: "warning"`, `code`, `severity?`, `resolution?`, `param?`, `content_type`, `content`
+- **Message (error)**: `type: "error"`, `code` (`missing|invalid|out_of_stock|payment_declined|requires_sign_in|requires_3ds`), `severity?`, `resolution?`, `param?`, `content_type`, `content`
+
+Message resolution values:
+- `resolution` (optional): Declares who resolves this message. Values:
+  - `recoverable`: Agent can fix via API (e.g., retry with different parameters)
+  - `requires_buyer_input`: Buyer must provide information the API cannot collect programmatically
+  - `requires_buyer_review`: Buyer must authorize before order placement (policy, regulatory, or entitlement rules)
 - **Link**: `type` (`terms_of_use|privacy_policy|return_policy`), `url`
 - **Total**: `type`, `display_text`, `amount` (**int**), `description?`
 
@@ -688,6 +695,7 @@ If a client calls `POST /checkout_sessions/{id}/complete` while `session.status 
 
 ## 11. Change Log
 
+- **2026-02-04**: Added optional `resolution` field to Message schemas (info, warning, error) to indicate who resolves the message (`recoverable`, `requires_buyer_input`, `requires_buyer_review`). This enables agents to programmatically determine appropriate error handling strategies.
 - **2026-01-12**: Breaking changes for v2:
   - Renamed `fulfillment_address` to `fulfillment_details` with nested structure (`name`, `phone_number`, `email`, `address`)
   - Replaced `fulfillment_option_id` with `selected_fulfillment_options[]` array supporting multiple selections and item mappings

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -855,6 +855,11 @@
       "properties": {
         "type": { "type": "string", "const": "info" },
         "severity": { "type": "string", "enum": ["info", "low", "medium", "high", "critical"] },
+        "resolution": {
+          "type": "string",
+          "enum": ["recoverable", "requires_buyer_input", "requires_buyer_review"],
+          "description": "Who resolves this message. 'recoverable': agent can fix via API. 'requires_buyer_input': buyer must provide info. 'requires_buyer_review': buyer must authorize."
+        },
         "param": {
           "type": "string",
           "description": "RFC 9535 JSONPath"
@@ -894,6 +899,11 @@
           ]
         },
         "severity": { "type": "string", "enum": ["info", "low", "medium", "high", "critical"] },
+        "resolution": {
+          "type": "string",
+          "enum": ["recoverable", "requires_buyer_input", "requires_buyer_review"],
+          "description": "Who resolves this message. 'recoverable': agent can fix via API. 'requires_buyer_input': buyer must provide info. 'requires_buyer_review': buyer must authorize."
+        },
         "param": {
           "type": "string",
           "description": "RFC 9535 JSONPath"
@@ -942,6 +952,11 @@
           ]
         },
         "severity": { "type": "string", "enum": ["info", "low", "medium", "high", "critical"] },
+        "resolution": {
+          "type": "string",
+          "enum": ["recoverable", "requires_buyer_input", "requires_buyer_review"],
+          "description": "Who resolves this message. 'recoverable': agent can fix via API. 'requires_buyer_input': buyer must provide info. 'requires_buyer_review': buyer must authorize."
+        },
         "param": {
           "type": "string",
           "description": "RFC 9535 JSONPath"

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -933,6 +933,10 @@ components:
       properties:
         type: { type: string, const: info }
         severity: { type: string, enum: [info, low, medium, high, critical] }
+        resolution:
+          type: string
+          enum: [recoverable, requires_buyer_input, requires_buyer_review]
+          description: "Who resolves this message. 'recoverable': agent can fix via API. 'requires_buyer_input': buyer must provide info. 'requires_buyer_review': buyer must authorize."
         param: { type: string, description: "RFC 9535 JSONPath" }
         content_type: { type: string, enum: [plain, markdown] }
         content: { type: string }
@@ -965,6 +969,10 @@ components:
               ],
           }
         severity: { type: string, enum: [info, low, medium, high, critical] }
+        resolution:
+          type: string
+          enum: [recoverable, requires_buyer_input, requires_buyer_review]
+          description: "Who resolves this message. 'recoverable': agent can fix via API. 'requires_buyer_input': buyer must provide info. 'requires_buyer_review': buyer must authorize."
         param: { type: string, description: "RFC 9535 JSONPath" }
         content_type: { type: string, enum: [plain, markdown] }
         content: { type: string }
@@ -1003,6 +1011,10 @@ components:
               ],
           }
         severity: { type: string, enum: [info, low, medium, high, critical] }
+        resolution:
+          type: string
+          enum: [recoverable, requires_buyer_input, requires_buyer_review]
+          description: "Who resolves this message. 'recoverable': agent can fix via API. 'requires_buyer_input': buyer must provide info. 'requires_buyer_review': buyer must authorize."
         param:
           { type: string, description: "RFC 9535 JSONPath", nullable: true }
         content_type: { type: string, enum: [plain, markdown] }


### PR DESCRIPTION
# Add `resolution` field to Message schemas

## 🔧 Type of Change

- [ ] Documentation fix/improvement
- [ ] Bug fix (non-breaking)
- [ ] Tooling improvement
- [ ] Example update
- [x] Minor data/enum addition
- [ ] Other: [describe]

---

## 📝 Description

Adds an optional `resolution` field to `MessageInfo`, `MessageWarning`, and `MessageError` schemas. This field indicates who is responsible for resolving the message:

- `recoverable`: Agent can fix via API (e.g., retry with different parameters)
- `requires_buyer_input`: Buyer must provide information the API cannot collect programmatically
- `requires_buyer_review`: Buyer must authorize before order placement (policy, regulatory, or entitlement rules)

---

## 🎯 Motivation and Context

Currently, ACP messages include a `severity` field indicating urgency (`info`, `low`, `medium`, `high`, `critical`), but agents lack a standardized way to determine the **resolution path** — whether to attempt automated recovery or escalate to the buyer.

The new `resolution` field enables agents to programmatically determine appropriate error handling strategies, improving automated checkout flows and reducing unnecessary buyer interruptions.

---

## 🧪 Testing

- Validated OpenAPI and JSON Schema syntax
- Updated example file (`rejected-discount-code.json`) validates against schema

---

## 📸 Screenshots / Examples

```json
{
  "type": "warning",
  "code": "discount_code_expired",
  "resolution": "recoverable",
  "param": "$.discounts.codes[1]",
  "content_type": "plain",
  "content": "Code 'EXPIRED50' expired and could not be applied."
}
```

---

## ✅ Checklist

- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (if applicable)
- [x] I have added/updated examples (if applicable)
- [x] I have added an entry to `changelog/unreleased.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [ ] All CI checks pass

---

## 🔍 Scope Verification

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ **This is a minor, straightforward change**

---

## 📚 Additional Notes

Future consideration: Merchants may want guidance on when to use each resolution value. A best practices section could be added to the RFC in a follow-up.

The field is fully optional and backward compatible — existing implementations will continue to work without changes.