### PR TITLE
Consistency fixes and documentation corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ For substantial changes to the protocol, you may need to submit a SEP:
 
 Every PR **must** include, as appropriate:
 
-- [ ] **OpenAPI / JSON Schema**: Update or add to `spec/openapi/` and `spec/json-schema/` as needed.
+- [ ] **OpenAPI / JSON Schema**: Update or add under `spec/unreleased/openapi/` and `spec/unreleased/json-schema/` (or the appropriate version directory) as needed.
 - [ ] **Examples**: Add or update sample requests/responses in `examples/`.
 - [ ] **Changelog**: Add a changelog entry file to `changelog/unreleased/` describing your change.
   - Create a new file: `changelog/unreleased/your-change-description.md`

--- a/changelog/unreleased/iin-max-length-8.md
+++ b/changelog/unreleased/iin-max-length-8.md
@@ -3,6 +3,6 @@
 **Delegate Payment API – Changed**
 
 - **IIN field length**: Updated `iin` field `maxLength` from 6 to 8 characters in `PaymentMethodCard` schema to support extended IIN ranges (ISO/IEC 7812-1).
-  - `spec/openapi/openapi.delegate_payment.yaml`
-  - `spec/json-schema/schema.delegate_payment_schema.json`
+  - `spec/unreleased/openapi/openapi.delegate_payment.yaml`
+  - `spec/unreleased/json-schema/schema.delegate_payment.json`
   - `rfcs/rfc.delegate_payment.md`

--- a/spec/2026-01-30/openapi/openapi.agentic_checkout.yaml
+++ b/spec/2026-01-30/openapi/openapi.agentic_checkout.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Agentic Checkout API
-  version: "2025-12-12"
+  version: "2026-01-30"
   description: |
     Merchant-implemented REST API for ChatGPT-driven checkout.
     Implements create, update (POST), retrieve (GET), complete, and cancel of checkout sessions.
@@ -344,7 +344,7 @@ components:
       name: API-Version
       in: header
       required: true
-      schema: { type: string, example: "2026-01-16" }
+      schema: { type: string, example: "2026-01-30" }
 
   schemas:
     Address:

--- a/spec/2026-01-30/openapi/openapi.agentic_checkout_webhook.yaml
+++ b/spec/2026-01-30/openapi/openapi.agentic_checkout_webhook.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Agentic Checkout Webhooks API
-  version: "unreleased"
+  version: "2026-01-30"
   description: |
     Webhook receiver hosted by OpenAI to accept merchant order lifecycle events.
 servers:

--- a/spec/2026-01-30/openapi/openapi.delegate_payment.yaml
+++ b/spec/2026-01-30/openapi/openapi.delegate_payment.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Agentic Commerce — Delegate Payment API
-  version: "unreleased"
+  version: "2026-01-30"
   description: |
     Delegate a payment using a provided payment method and allowance.
 servers:

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Agentic Checkout API
-  version: "2025-12-12"
+  version: "unreleased"
   description: |
     Merchant-implemented REST API for ChatGPT-driven checkout.
     Implements create, update (POST), retrieve (GET), complete, and cancel of checkout sessions.


### PR DESCRIPTION
**Fix spec version consistency, validation coverage, and contributor docs**

---

## Description

While testing my last PR I noticed a few inconsistencies and wanted to clean them up. The main ones: our "latest stable" release (2026-01-30) wasn’t actually being validated in CI, some OpenAPI version fields were still pointing at older versions or "unreleased", and the contributor docs were referring to spec paths that don’t exist. I’ve fixed those and also added a short review doc that lists everything I found—including a couple of things I’ve left for follow-up rather than changing in this PR.

### Changes

#### 1. Validation script includes 2026-01-30

- **File:** `scripts/validate-consistency.js`
- **Change:** Added `'2026-01-30'` to the `VERSIONS` array.
- **Why:** The README says 2026-01-30 is latest stable, but the validator was never running against it—only the older versions and unreleased. Now CI and `pnpm run validate:all` cover 2026-01-30 too.

#### 2. OpenAPI `info.version` and API-Version example for 2026-01-30

- **Files:**
  - `spec/2026-01-30/openapi/openapi.agentic_checkout.yaml`
  - `spec/2026-01-30/openapi/openapi.delegate_payment.yaml`
  - `spec/2026-01-30/openapi/openapi.agentic_checkout_webhook.yaml`
- **Change:**
  - Set `info.version` to `"2026-01-30"` in all three files (was `"2025-12-12"` in checkout, `"unreleased"` in delegate_payment and webhook).
  - In `openapi.agentic_checkout.yaml`, set the API-Version header parameter example from `"2026-01-16"` to `"2026-01-30"`.
- **Why:** That folder is the 2026-01-30 release snapshot, so the OpenAPI files and the header example should say 2026-01-30 otherwise people would copy the wrong version from the examples.

#### 3. Unreleased checkout OpenAPI version

- **File:** `spec/unreleased/openapi/openapi.agentic_checkout.yaml`
- **Change:** Set `info.version` from `"2025-12-12"` to `"unreleased"`.
- **Why:** The other unreleased OpenAPI files already use `"unreleased"`; checkout was still on an old date, which was confusing.

#### 4. CONTRIBUTING.md spec paths

- **File:** `CONTRIBUTING.md`
- **Change:** In “Required Updates for All Changes,” updated the checklist from “Update or add to `spec/openapi/` and `spec/json-schema/`” to “Update or add under `spec/unreleased/openapi/` and `spec/unreleased/json-schema/` (or the appropriate version directory).”
- **Why:** We use versioned dirs (`spec/<version>/...` and `spec/unreleased/...`), so the old paths in the checklist don't actually exist. Easy to fix and avoids sending people to the wrong place.

#### 5. Changelog entry paths and typo (IIN max length)

- **File:** `changelog/unreleased/iin-max-length-8.md`
- **Change:**
  - Replaced `spec/openapi/openapi.delegate_payment.yaml` with `spec/unreleased/openapi/openapi.delegate_payment.yaml`.
  - Replaced `spec/json-schema/schema.delegate_payment_schema.json` with `spec/unreleased/json-schema/schema.delegate_payment.json`.
- **Why:** The paths were wrong (no version in them) and there was a typo in the schema filename `schema.delegate_payment_schema.json` → `schema.delegate_payment.json`.

### Testing

Ran `pnpm run validate:all` locally—everything passes, including 2026-01-30. No behaviour or schema semantics changed, just version strings, paths, and what gets validated.

### Type of change

Documentation/tooling fixes, non-breaking. No SEP needed.
