### PR TITLE
Schema glob in package.json and CI workflow fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           node -p "require('ajv-formats/package.json').version"
 
       - name: Show tree (debug)
-        run: ls -la spec/json-schema || true
+        run: ls -la spec/unreleased/json-schema
 
       - name: Compile schema
         run: pnpm run compile:schema

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@agentic-commerce-protocol/specification",
   "version": "0.1.0",
   "scripts": {
-    "compile:schema": "ajv compile --spec=draft2020 -c ajv-formats -s spec/json-schema/**/*.json",
+    "compile:schema": "ajv compile --spec=draft2020 -c ajv-formats -s 'spec/unreleased/json-schema/*.json'",
     "validate:json-schema": "ajv compile --spec=draft2020 -c ajv-formats -s 'spec/**/json-schema/*.json'",
     "validate:openapi": "echo 'OpenAPI validation requires additional tooling - see scripts/validate-consistency.js'",
     "validate:examples": "node scripts/validate-consistency.js",


### PR DESCRIPTION
# Changes

## 1. package.json: compile:schema glob

**File:** `package.json`

- **Change:** Updated `compile:schema` script from `spec/json-schema/**/*.json` to `'spec/unreleased/json-schema/*.json'`.
- **Why:** The path `spec/json-schema/` does not exist; schemas live under `spec/<version>/json-schema/` and `spec/unreleased/json-schema/`. Using the unreleased path makes the compile step target the current development schemas.

---

## 2. CI workflow: debug step path

**File:** `.github/workflows/main.yml`

- **Change:** Debug step from `ls -la spec/json-schema || true` to `ls -la spec/unreleased/json-schema`.
- **Why:** `spec/json-schema` does not exist, so the step always “succeeded” only because of `|| true`. It now lists an existing path (`spec/unreleased/json-schema`).

---