### PR TITLE
Fix incorrect fulfillment values in complete and cancel response examples

### DIFF
--- a/changelog/unreleased/fix-complete-cancel-fulfillment-examples.md
+++ b/changelog/unreleased/fix-complete-cancel-fulfillment-examples.md
@@ -1,0 +1,15 @@
+## Fix incorrect fulfillment values in complete and cancel response examples
+
+The complete and cancel response examples incorrectly showed Standard shipping values (`fulfillment_option_123`, cost 100, total 430) after the update example switched to Express shipping (`fulfillment_option_456`, cost 500, total 830). Fixed to be consistent with the preceding update response.
+
+### Changes
+- Fixed `selected_fulfillment_options`, fulfillment amount, and total in complete response example (RFC section 9.6)
+- Fixed fulfillment amount and total in cancel response example (RFC section 9.8)
+- Applied same fixes to `examples/unreleased/examples.agentic_checkout.json`
+
+### Files Updated
+- `rfcs/rfc.agentic_checkout.md`
+- `examples/unreleased/examples.agentic_checkout.json`
+
+### Reference
+- Issue: #16

--- a/examples/unreleased/examples.agentic_checkout.json
+++ b/examples/unreleased/examples.agentic_checkout.json
@@ -518,7 +518,7 @@
     "selected_fulfillment_options": [
       {
         "type": "shipping",
-        "option_id": "fulfillment_option_123",
+        "option_id": "fulfillment_option_456",
         "item_ids": ["item_123"]
       }
     ],
@@ -541,12 +541,12 @@
       {
         "type": "fulfillment",
         "display_text": "Fulfillment",
-        "amount": 100
+        "amount": 500
       },
       {
         "type": "total",
         "display_text": "Total",
-        "amount": 430
+        "amount": 830
       }
     ],
     "fulfillment_options": [
@@ -803,7 +803,7 @@
     "selected_fulfillment_options": [
       {
         "type": "shipping",
-        "option_id": "fulfillment_option_123",
+        "option_id": "fulfillment_option_456",
         "item_ids": ["item_123"]
       }
     ],
@@ -826,12 +826,12 @@
       {
         "type": "fulfillment",
         "display_text": "Fulfillment",
-        "amount": 100
+        "amount": 500
       },
       {
         "type": "total",
         "display_text": "Total",
-        "amount": 430
+        "amount": 830
       }
     ],
     "fulfillment_options": [

--- a/rfcs/rfc.agentic_checkout.md
+++ b/rfcs/rfc.agentic_checkout.md
@@ -560,7 +560,7 @@ If the session is in `authentication_required` state, a client MUST include `aut
   "selected_fulfillment_options": [
     {
       "type": "shipping",
-      "option_id": "fulfillment_option_123",
+      "option_id": "fulfillment_option_456",
       "item_ids": ["item_456"]
     }
   ],
@@ -572,8 +572,8 @@ If the session is in `authentication_required` state, a client MUST include `aut
     },
     { "type": "subtotal", "display_text": "Subtotal", "amount": 300 },
     { "type": "tax", "display_text": "Tax", "amount": 30 },
-    { "type": "fulfillment", "display_text": "Fulfillment", "amount": 100 },
-    { "type": "total", "display_text": "Total", "amount": 430 }
+    { "type": "fulfillment", "display_text": "Fulfillment", "amount": 500 },
+    { "type": "total", "display_text": "Total", "amount": 830 }
   ],
   "fulfillment_options": [
     {
@@ -655,8 +655,8 @@ If a client calls `POST /checkout_sessions/{id}/complete` while `session.status 
     },
     { "type": "subtotal", "display_text": "Subtotal", "amount": 300 },
     { "type": "tax", "display_text": "Tax", "amount": 30 },
-    { "type": "fulfillment", "display_text": "Fulfillment", "amount": 100 },
-    { "type": "total", "display_text": "Total", "amount": 430 }
+    { "type": "fulfillment", "display_text": "Fulfillment", "amount": 500 },
+    { "type": "total", "display_text": "Total", "amount": 830 }
   ],
   "messages": [
     {


### PR DESCRIPTION
## 🔧 Type of Change

- [ ] Documentation fix/improvement
- [x] Bug fix (non-breaking)
- [ ] Tooling improvement
- [x] Example update
- [ ] Minor data/enum addition
- [ ] Other: [describe]

---

## 📝 Description

The complete (section 9.6) and cancel (section 9.8) response examples in the RFC, along with the corresponding entries in `examples/unreleased/examples.agentic_checkout.json`, show Standard shipping values after the preceding update example (section 9.3) switched to Express shipping. This is inconsistent within what is clearly a continuous session flow (all examples share `checkout_session_123`).

Fixed three values in the complete response and two in the cancel response to reflect Express shipping (`fulfillment_option_456`, cost 500, total 830) instead of Standard (`fulfillment_option_123`, cost 100, total 430).

---

## 🎯 Motivation and Context

Fixes/Addresses: #16

---

## 🧪 Testing

Verified by tracing the example flow manually:
1. Create response (9.2): Standard selected, fulfillment=100, total=430 
2. Update request (9.3): Switches to `fulfillment_option_456` (Express)
3. Update response (9.4): Express selected, fulfillment=500, total=830
4. Complete response (9.6): Now correctly shows Express, fulfillment=500, total=830 
5. Cancel response (9.8): Now correctly shows fulfillment=500, total=830

---

## 📸 Screenshots / Examples

**Before (complete response):**
```json
"option_id": "fulfillment_option_123"
{ "type": "fulfillment", "display_text": "Fulfillment", "amount": 100 }
{ "type": "total", "display_text": "Total", "amount": 430 }
```

**After (complete response):**
```json
"option_id": "fulfillment_option_456"
{ "type": "fulfillment", "display_text": "Fulfillment", "amount": 500 }
{ "type": "total", "display_text": "Total", "amount": 830 }
```

---

## ✅ Checklist

- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation 
- [x] I have added/updated examples 
- [x] I have added a changelog entry file to `changelog/unreleased/fix-complete-cancel-fulfillment-examples.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)

---

## 🔍 Scope Verification

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ **This is a minor, straightforward change** (confirm by checking this)

---

## 📚 Additional Notes

The same bug exists in older released example files (`examples/2025-09-29/`, `2025-12-12/`, `2026-01-16/`, `2026-01-30/`) but this PR only fixes `unreleased/` to avoid modifying released snapshots.
```