### PR TITLE
docs: document all 11 session states in RFC and schemas

### DIFF
--- a/changelog/unreleased/document-session-states.md
+++ b/changelog/unreleased/document-session-states.md
@@ -1,0 +1,7 @@
+# Document all 11 session states
+
+**Fixed** – added §5.1 Session Status Reference to `rfc.agentic_checkout.md` documenting all 11 `CheckoutSessionBase.status` values. Previously only 6 were documented; `incomplete`, `requires_escalation`, `pending_approval`, `complete_in_progress`, and `expired` had no semantic documentation.
+
+Also fixes stale inline status enums in §4.1 and §8 that listed only 5 values, and adds `description` fields to the status enum in both OpenAPI and JSON Schema.
+
+**Files changed:** `rfcs/rfc.agentic_checkout.md`, `spec/unreleased/openapi/openapi.agentic_checkout.yaml`, `spec/unreleased/json-schema/schema.agentic_checkout.json`

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -3150,7 +3150,7 @@
             "in_progress",
             "expired"
           ],
-          "description": "Current status of the checkout session"
+          "description": "Session lifecycle state. incomplete: missing required fields. not_ready_for_payment: has items but not payable. in_progress: server processing. requires_escalation: needs non-programmatic intervention. authentication_required: auth (e.g. 3DS) needed. ready_for_payment: all requirements met. pending_approval: awaiting async approval. complete_in_progress: payment/order processing underway. completed: finalized, order created (terminal). canceled: canceled (terminal). expired: server timeout (terminal)."
         },
         "currency": {
           "type": "string",

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -2730,6 +2730,19 @@ components:
           $ref: "#/components/schemas/Buyer"
         status:
           type: string
+          description: |
+            Session lifecycle state.
+            - incomplete: Missing required fields, server cannot compute totals.
+            - not_ready_for_payment: Has items but not payable (missing address, fulfillment, or has errors).
+            - in_progress: Server is processing (computing totals, validating inventory).
+            - requires_escalation: Needs intervention the agent cannot perform programmatically.
+            - authentication_required: Authentication (e.g., 3DS) must complete before finalization.
+            - ready_for_payment: All requirements met, agent may call complete.
+            - pending_approval: Completion requested, awaiting async approval.
+            - complete_in_progress: Completion requested, payment/order processing underway.
+            - completed: Finalized, order created. Terminal.
+            - canceled: Canceled via cancel endpoint. Terminal.
+            - expired: Server-enforced timeout. Terminal.
           enum:
             - incomplete
             - not_ready_for_payment
@@ -2742,7 +2755,6 @@ components:
             - canceled
             - in_progress
             - expired
-          description: Current status of the checkout session
         currency:
           type: string
           description: ISO 4217 settlement currency code


### PR DESCRIPTION
# docs: document all 11 session states in RFC and schemas

## 🔧 Type of Change

- [x] Documentation fix/improvement
- [ ] Bug fix (non-breaking)
- [ ] Tooling improvement
- [ ] Example update
- [ ] Minor data/enum addition
- [ ] Other: [describe]

---

## 📝 Description

The OpenAPI spec defines 11 `CheckoutSessionBase.status` values but the RFC only documented 6. Five states had zero semantic documentation:
- `incomplete`
- `requires_escalation`
- `pending_approval`
- `complete_in_progress`
- `expired`

On top of that, the inline status enums in §4.1 (response body) and §8 (validation rules) were stale — they listed only 5 values and didn't even include `authentication_required`, which IS documented elsewhere in the same RFC.

This PR:
- Adds §5.1 "Session Status Reference" — a table with all 11 states, their descriptions, and which are terminal
- Fixes the stale inline enums (§4.1 now points to §5.1, §8 lists all 11)
- Adds `description` to the status enum in both OpenAPI and JSON Schema (the enum was bare, no descriptions on any value)

**Note for reviewers:** The descriptions for `incomplete`, `requires_escalation`, `pending_approval`, `complete_in_progress`, and `expired` are inferred from the state names and standard checkout patterns. These states had no prior documentation anywhere in the repo. Please verify the semantics match the intended behavior.

---

## 🎯 Motivation and Context

Without documentation, implementers have to guess what these states mean. The issue specifically calls out `in_progress` vs `complete_in_progress` — are they interchangeable? Does one imply payment is authorized? The RFC was silent on this.

Addresses: #96

---

## 🧪 Testing

- `pnpm run validate:all` — all pass
- `pnpm run compile:schema` — all valid
- No enum values added or removed — only documentation changes

---

## 📸 Screenshots / Examples

N/A — documentation changes only.

---

## ✅ Checklist

- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (if applicable)
- [ ] I have added/updated examples (if applicable)
- [x] I have added a changelog entry file to `changelog/unreleased/your-change-description.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [x] All CI checks pass

---

## 🔍 Scope Verification

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ **This is a minor, straightforward change** (confirm by checking this)

---

## 📚 Additional Notes

The 2026-01-30 versioned spec has the same bare enum. This PR only touches `unreleased/` since modifying a released version would be a different conversation.