### PR TITLE
SEP: Content Citation Attribution Extension

### DIFF
--- a/changelog/unreleased/content-attribution-extension.md
+++ b/changelog/unreleased/content-attribution-extension.md
@@ -6,16 +6,18 @@ New `content_attribution` extension for ACP checkout sessions, enabling URL-base
 - New `content_attribution` extension object on `CheckoutSessionCreateRequest` and `CheckoutSessionCompleteRequest`
 - Tracks content URLs retrieved and cited by AI shopping agents during purchase conversations
 - Includes optional citation quality signals (`citation_type`, `position`, `excerpt_tokens`, `content_hash`)
-- Privacy-preserving `conversation_summary` for aggregate analytics
+- Lightweight `conversation_summary` with `turn_count` and `topics` for aggregate context
 - Write-only semantics matching `affiliate_attribution` pattern
 - Multi-touch attribution (first-touch at Create, last-touch at Complete)
+- Forward-compatible: all nested objects allow additional properties
 
 ### Files Added
 - `rfcs/rfc.content_attribution.md`
 - `spec/unreleased/json-schema/schema.content_attribution.json`
 - `examples/unreleased/content-attribution/create_checkout_with_attribution.json`
 - `examples/unreleased/content-attribution/combined_affiliate_and_content.json`
+- `changelog/unreleased/content-attribution-extension.md`
 
 ### Reference
 - SEP: #148
-- PR: #TBD
+- PR: #149

--- a/examples/unreleased/content-attribution/combined_affiliate_and_content.json
+++ b/examples/unreleased/content-attribution/combined_affiliate_and_content.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "ACP CheckoutSessionCreateRequest with both affiliate_attribution and content_attribution. The affiliate network can use content_attribution URLs to verify the affiliate_attribution claim by matching content URLs against its publisher registry.",
+  "$comment": "ACP CheckoutSessionCreateRequest with both affiliate_attribution and content_attribution. The affiliate network can use content_attribution URLs to verify the affiliate_attribution claim by matching content URLs against its publisher registry. This enables the network to confirm that the claimed publisher (pub_coffee_reviews_456) did indeed publish the content that the agent retrieved and cited during the shopping conversation.",
   "items": [
     {
       "id": "sku_breville_barista_express",
@@ -46,10 +46,7 @@
     ],
     "conversation_summary": {
       "turn_count": 4,
-      "primary_intent": "comparison",
-      "topics": ["espresso-machine", "grinder", "home-barista"],
-      "total_content_retrieved": 2,
-      "total_content_cited": 2
+      "topics": ["espresso-machine", "grinder", "home-barista"]
     }
   }
 }

--- a/examples/unreleased/content-attribution/create_checkout_with_attribution.json
+++ b/examples/unreleased/content-attribution/create_checkout_with_attribution.json
@@ -13,9 +13,6 @@
   ],
   "content_attribution": {
     "content_scope": "coffee-equipment-reviews",
-    "prior_session_ids": [
-      "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-    ],
     "content_retrieved": [
       {
         "content_url": "https://www.jameshoffmann.co.uk/reviews/breville-barista-express",
@@ -48,10 +45,7 @@
     ],
     "conversation_summary": {
       "turn_count": 4,
-      "primary_intent": "comparison",
-      "topics": ["espresso-machine", "grinder", "home-barista"],
-      "total_content_retrieved": 3,
-      "total_content_cited": 2
+      "topics": ["espresso-machine", "grinder", "home-barista"]
     }
   }
 }

--- a/rfcs/rfc.content_attribution.md
+++ b/rfcs/rfc.content_attribution.md
@@ -1,13 +1,4 @@
----
-sep: 148
-title: Content Citation Attribution Extension
-author: OpenAttribution Project <standards@openattribution.org>
-status: Proposal
-type: Standards Track
-created: 2026-02-15
----
-
-# Content Citation Attribution Extension
+# RFC: Content Citation Attribution Extension
 
 ## Abstract
 
@@ -15,7 +6,7 @@ This SEP defines a `content_attribution` extension for ACP checkout sessions. Wh
 
 The mechanism is URL-based: agents record the URIs of content they fetched and cited, and merchants forward these to their affiliate networks for publisher resolution. This complements the existing `affiliate_attribution` RFC, which handles network-level attribution through pre-wired publisher mappings. Where `affiliate_attribution` requires prior relationship setup, `content_attribution` bootstraps attribution from raw URLs -- no pre-configuration needed. The two layers can coexist in a single checkout session.
 
-The extension follows a strict write-only, privacy-preserving model. Attribution data flows from agent to merchant and is never echoed in read responses. No personally identifiable information is collected; `content_scope` values are opaque identifiers and the optional `conversation_summary` provides only aggregate signals. This design allows attribution to function without exposing the agent's reasoning or the buyer's browsing behaviour.
+The extension follows a strict write-only, privacy-preserving model. Attribution data flows from agent to merchant and is never echoed in read responses. No personally identifiable information is collected; `content_scope` values are opaque identifiers. This design allows attribution to function without exposing the agent's reasoning or the buyer's browsing behaviour.
 
 ## Motivation
 
@@ -46,8 +37,8 @@ These are complementary layers, not competing ones. A single checkout can includ
 ```json
 {
   "name": "content_attribution",
-  "schema": "https://openattribution.org/acp/schemas/content_attribution.json",
-  "spec": "https://openattribution.org/acp/rfc/content_attribution",
+  "schema": "https://agentic-commerce-protocol.com/schemas/content_attribution.json",
+  "spec": "https://agentic-commerce-protocol.com/rfcs/content_attribution",
   "extends": [
     "$.CheckoutSessionCreateRequest.content_attribution",
     "$.CheckoutSessionCompleteRequest.content_attribution"
@@ -55,7 +46,7 @@ These are complementary layers, not competing ones. A single checkout can includ
 }
 ```
 
-The extension name follows ACP convention (short names, matching `affiliate_attribution`). The schema and spec URLs are hosted under `openattribution.org` as the reference implementation provider.
+The extension name follows ACP convention (short names, matching `affiliate_attribution`). The schema and spec URLs use the ACP-controlled `agentic-commerce-protocol.com` namespace. This schema is the ACP binding of [OpenAttribution Telemetry v0.4](https://openattribution.org/telemetry); the canonical specification is protocol-independent and maintained by the OpenAttribution Project.
 
 ### The `content_attribution` Object
 
@@ -66,10 +57,9 @@ The `content_attribution` object is included in `CheckoutSessionCreateRequest` a
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `content_scope` | string | No | Opaque identifier for the content collection used by the agent |
-| `prior_session_ids` | array of UUID strings | No | Previous session IDs (UUIDs) in the user's purchase journey |
-| `content_retrieved` | array | No | Content URLs fetched during the session |
+| `content_retrieved` | array | Yes | Content URLs fetched during the session |
 | `content_cited` | array | No | Content explicitly referenced in agent responses |
-| `conversation_summary` | object | No | Privacy-preserving conversation aggregate |
+| `conversation_summary` | object | No | Lightweight conversation context (agent-reported hints) |
 
 #### `content_retrieved` Array Items
 
@@ -87,19 +77,16 @@ The `content_attribution` object is included in `CheckoutSessionCreateRequest` a
 | `citation_type` | string | No | How the content was used: `direct_quote`, `paraphrase`, `reference`, or `contradiction` |
 | `excerpt_tokens` | integer | No | Token count of the cited excerpt |
 | `position` | string | No | Prominence in the response: `primary`, `supporting`, or `mentioned` |
-| `content_hash` | string | No | SHA-256 hash for content verification (format: `sha256:{hex}`) |
+| `content_hash` | string | No | SHA-256 hash of the content the agent processed from this URL (format: `sha256:{hex}`) |
 
 #### `conversation_summary` Object
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `turn_count` | integer | Number of conversation turns (minimum 1) |
-| `primary_intent` | enum | Most frequent query intent across turns (see below) |
-| `topics` | array of strings | De-duplicated topic list from the conversation |
-| `total_content_retrieved` | integer | Total number of content items retrieved |
-| `total_content_cited` | integer | Total number of content items cited |
+| `turn_count` | integer | Number of conversation turns before checkout (minimum 1) |
+| `topics` | array of strings | De-duplicated free-form topic tags from the conversation |
 
-**`primary_intent` values:** `product_research`, `comparison`, `how_to`, `troubleshooting`, `general_question`, `purchase_intent`, `price_check`, `availability_check`, `review_seeking`, `chitchat`, `other`
+Both fields are agent-reported hints. `turn_count` provides a signal of conversation depth that is not derivable from the citation arrays. `topics` provides lightweight category tags that help merchants route attribution internally without needing to crawl the cited URLs.
 
 ### Write-Only Semantics
 
@@ -153,7 +140,7 @@ Attribution-specific errors MUST NOT prevent checkout completion. If `content_at
 
 **Field alignment with `affiliate_attribution`.** The extension intentionally mirrors the structural patterns of `affiliate_attribution` so that merchants can process both through similar pipelines. The additional fields (`citation_type`, `excerpt_tokens`, `position`, `content_hash`) provide quality signals specific to content citation that have no analogue in network-level affiliate tracking.
 
-**Conversation summary.** The `conversation_summary` provides useful aggregate signals (intent, topics, turn count) without exposing raw conversation text. This enables attribution analysis while respecting user privacy.
+**Minimal conversation context.** `conversation_summary` is limited to `turn_count` and `topics` — two signals that are genuinely not derivable from the citation arrays. Conversation depth and topic tags help merchants route attribution internally without requiring them to crawl cited URLs. Subjective classification fields were excluded to avoid inconsistency across agent implementations.
 
 ## Backward Compatibility
 
@@ -178,7 +165,7 @@ The JSON Schema for the `content_attribution` object is published alongside this
 ## Security Considerations
 
 - **Citation quality signals are agent-reported, not trusted assertions.** The `citation_type`, `position`, and `excerpt_tokens` fields reflect the agent's self-report of how it used content. Merchants and attribution systems should treat these as hints, not verified facts.
-- **`content_hash` enables content verification.** When provided, the SHA-256 hash allows the merchant or attribution system to verify that the cited content matches what was actually published at the given URL.
+- **`content_hash` provides an integrity audit trail.** The hash is a SHA-256 of the content the agent processed from the cited URL. It ties the citation to a specific version of the content the agent saw, which is useful for dispute resolution when attribution involves commission payments. The spec does not prescribe the extraction method — agents hash whatever content they fed into their context. Agents SHOULD use a consistent hashing method across citations within a session.
 - **`content_scope` MUST NOT contain PII.** Implementations must use opaque, non-identifying values for this field.
 - **Rate limiting.** Merchants should apply rate limiting to prevent abuse of the attribution channel (e.g. an agent flooding `content_retrieved` with spurious URLs to game attribution).
 - **Write-only semantics prevent data leakage.** By never echoing `content_attribution` in read responses, the extension prevents third parties from discovering which content influenced a purchase.

--- a/spec/unreleased/json-schema/schema.content_attribution.json
+++ b/spec/unreleased/json-schema/schema.content_attribution.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://openattribution.org/acp/schemas/content_attribution.json",
+  "$id": "https://agentic-commerce-protocol.com/schemas/content_attribution.json",
+  "$comment": "ACP binding of OpenAttribution Telemetry v0.4. Canonical specification: https://openattribution.org/telemetry",
   "title": "Content Attribution Extension for ACP",
   "description": "Content citation attribution data for ACP checkout sessions.",
   "type": "object",
@@ -9,17 +10,10 @@
       "type": "string",
       "description": "Opaque identifier for the content collection used by the agent."
     },
-    "prior_session_ids": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "format": "uuid"
-      },
-      "description": "Previous session IDs (UUIDs) in the user's purchase journey."
-    },
     "content_retrieved": {
       "type": "array",
       "description": "Content URLs fetched during the session.",
+      "minItems": 1,
       "maxItems": 100,
       "items": {
         "type": "object",
@@ -35,8 +29,7 @@
             "format": "date-time",
             "description": "UTC timestamp of retrieval (ISO 8601)."
           }
-        },
-        "additionalProperties": false
+        }
       }
     },
     "content_cited": {
@@ -74,59 +67,31 @@
           },
           "content_hash": {
             "type": "string",
-            "pattern": "^sha256:[a-f0-9]{64}$",
-            "description": "SHA-256 hash for content verification (format: 'sha256:abc123...')."
+            "pattern": "^sha256:[a-fA-F0-9]{64}$",
+            "description": "SHA-256 hash of the content the agent processed from this URL, for integrity audit trail in dispute resolution (format: 'sha256:abc123...')."
           }
-        },
-        "additionalProperties": false
+        }
       }
     },
     "conversation_summary": {
       "type": "object",
-      "description": "Privacy-preserving conversation aggregate.",
+      "description": "Lightweight conversation context. All fields are agent-reported hints.",
       "properties": {
         "turn_count": {
           "type": "integer",
           "minimum": 1,
-          "description": "Number of conversation turns."
-        },
-        "primary_intent": {
-          "type": "string",
-          "enum": [
-            "product_research",
-            "comparison",
-            "how_to",
-            "troubleshooting",
-            "general_question",
-            "purchase_intent",
-            "price_check",
-            "availability_check",
-            "review_seeking",
-            "chitchat",
-            "other"
-          ],
-          "description": "Most frequent query intent across turns."
+          "description": "Number of conversation turns before checkout."
         },
         "topics": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "De-duplicated topic list from the conversation."
-        },
-        "total_content_retrieved": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Total number of content items retrieved."
-        },
-        "total_content_cited": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Total number of content items cited."
+          "description": "De-duplicated free-form topic tags from the conversation."
         }
-      },
-      "additionalProperties": false
+      }
     }
   },
+  "required": ["content_retrieved"],
   "additionalProperties": true
 }


### PR DESCRIPTION
# SEP: Content Citation Attribution Extension

## 📋 SEP Metadata

- **SEP Number**: #148
- **Author(s)**: Alex Springer / OpenAttribution Project (@openattribution-org)
- **Status**: `proposal` (awaiting sponsor)
- **Type**: [x] Major Change [ ] Process Change
- **Related Issues/RFCs**: #148, [affiliate_attribution RFC](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/blob/main/rfcs/rfc.affiliate_attribution.md)

---

## 🎯 Abstract

This SEP defines a `content_attribution` extension for ACP checkout sessions. When an AI shopping agent retrieves and cites content during a purchasing conversation, the extension provides a standardised structure for recording which content URLs were accessed and referenced. This enables merchants and their affiliate networks to attribute purchases to the content that influenced the buying decision.

The mechanism is URL-based and complements the existing `affiliate_attribution` extension. Where `affiliate_attribution` requires pre-wired publisher mappings (network, publisher_id, token), `content_attribution` bootstraps attribution from raw URLs — no pre-configuration needed. The two layers can coexist in a single checkout session.

---

## 💡 Motivation

ACP's `affiliate_attribution` extension addresses network-level attribution by conveying `provider`, `publisher_id`, and cryptographic `token` fields from agent to merchant. This works well when the affiliate relationship is already established — the agent knows which network, which publisher, and has a pre-issued token.

In practice, agentic commerce breaks this assumption. An agent performing RAG-based product research:

1. Fetches `https://www.wirecutter.com/reviews/best-headphones` via its content index
2. Paraphrases the review in its recommendation to the user
3. Proceeds to checkout

At no point does the agent know that Wirecutter is `pub_123` on `impact.com`, or possess a network-issued attribution token. The agent has **URLs** — that is the primitive it naturally works with. The `affiliate_attribution` schema requires **network identifiers** — primitives the agent does not have.

`content_attribution` solves this bootstrapping problem:

1. **Agent emits URLs** — records which content it retrieved and cited
2. **Merchant's affiliate network resolves URLs to publishers** — matches content URLs against its publisher registry
3. **Standard affiliate crediting kicks in** — existing commission structures apply

These are complementary layers. `affiliate_attribution` covers known relationships; `content_attribution` bootstraps attribution for content discovered organically. Over time, as affiliate networks build agent-facing APIs that issue tokens in real time, `affiliate_attribution` becomes more viable — but `content_attribution` provides the immediate, zero-configuration path.

---

## 📐 Specification

This PR adds 5 new files (no existing files modified):

| File | Purpose |
|---|---|
| `rfcs/rfc.content_attribution.md` | Full RFC (SEP format) |
| `spec/unreleased/json-schema/schema.content_attribution.json` | JSON Schema (Draft 2020-12) |
| `examples/unreleased/content-attribution/create_checkout_with_attribution.json` | Checkout request with content attribution |
| `examples/unreleased/content-attribution/combined_affiliate_and_content.json` | Checkout with both affiliate and content attribution |
| `changelog/unreleased/content-attribution-extension.md` | Changelog entry |

### Extension Declaration

```json
{
  "name": "content_attribution",
  "schema": "https://agentic-commerce-protocol.com/schemas/content_attribution.json",
  "spec": "https://agentic-commerce-protocol.com/rfcs/content_attribution",
  "extends": [
    "$.CheckoutSessionCreateRequest.content_attribution",
    "$.CheckoutSessionCompleteRequest.content_attribution"
  ]
}
```

### The `content_attribution` Object

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `content_scope` | string | No | Opaque identifier for the content collection |
| `content_retrieved` | array (min 1, max 100) | Yes | Content URLs fetched during the session |
| `content_cited` | array (max 50) | No | Content explicitly referenced in agent responses |
| `conversation_summary` | object | No | Lightweight conversation context (`turn_count`, `topics`) |

`content_cited` items include optional quality signals: `citation_type`, `excerpt_tokens`, `position`, and `content_hash` (SHA-256 integrity audit trail).

### Key Design Points

- **Write-only semantics** — MUST NOT be echoed in read responses
- **Multi-touch attribution** — attaches to both Create and Complete requests
- **Non-blocking** — attribution errors MUST NOT prevent checkout completion
- **URL-based** — starts from what agents naturally have
- **Forward-compatible** — all nested objects allow additional properties; validators MUST NOT reject unrecognised fields

Full specification in `rfcs/rfc.content_attribution.md`.

---

## 🤔 Rationale

**URLs as the primitive.** AI agents fetch content by URL and can trivially record what they accessed. Unlike affiliate tokens or publisher IDs, URLs require no pre-configuration. The merchant's affiliate network resolves URLs to publishers after the fact.

**Complementary to `affiliate_attribution`.** Not competing. A single checkout can carry both. `affiliate_attribution` covers known affiliate relationships; `content_attribution` bootstraps attribution for organically discovered content.

**Write-only semantics.** Prevents third parties from discovering which content influences purchases. Mirrors `affiliate_attribution` pattern.

**Field alignment with `affiliate_attribution`.** Mirrors structural patterns so merchants can process both through similar pipelines. Additional fields (`citation_type`, `excerpt_tokens`, `position`, `content_hash`) provide quality signals specific to content citation.

---

## 🔄 Backward Compatibility

No breaking changes. Purely additive.

- Existing checkout sessions without `content_attribution` continue to work unchanged
- Merchants that don't declare support simply don't receive the extension data
- No new required fields on any existing schema
- Forward-compatible: validators MUST NOT reject payloads with unrecognised fields

---

## 🛠️ Reference Implementation

A Python SDK providing the `session_to_content_attribution()` bridge function is available at [openattribution-org/telemetry](https://github.com/openattribution-org/telemetry). The function converts an OpenAttribution telemetry session into a `content_attribution` dict suitable for inclusion in ACP checkout requests.

---

## 🔒 Security Implications

- **Citation quality signals are agent-reported, not trusted assertions** — merchants treat as hints
- **`content_hash`** provides SHA-256 integrity audit trail for dispute resolution; agents hash whatever content they processed
- **`content_scope` MUST NOT contain PII** — opaque identifiers only
- **Write-only semantics** prevent data leakage
- **Timestamp cross-referencing** — citation before retrieval is a fraud indicator
- **Array size limits** prevent attribution channel abuse
- **URL manipulation** — merchants SHOULD cross-reference against publisher registries

---

## ✅ Pre-Submission Checklist

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags — #148
- [x] I have linked the SEP issue number above
- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] This PR includes updates to OpenAPI/JSON schemas (if applicable)
- [x] This PR includes example requests/responses (if applicable)
- [x] This PR includes a changelog entry file in `changelog/unreleased/content-attribution-extension.md`
- [ ] I am seeking or have found a sponsor (Founding Maintainer)

---

## 📚 Additional Context

### Relationship to `affiliate_attribution`

This extension fills a specific gap in ACP's attribution story. `affiliate_attribution` assumes the agent has network-specific identifiers (publisher_id, tokens) — which requires prior setup between the agent platform and the affiliate network. In RAG-based commerce, agents discover content organically and have no such identifiers. `content_attribution` bridges this gap by starting from URLs, which agents naturally possess, and delegating publisher resolution to the merchant's existing affiliate infrastructure.

### OpenAttribution Project

The [OpenAttribution Telemetry](https://github.com/openattribution-org/telemetry) project provides an open signal format for AI content attribution (Apache 2.0). The `content_attribution` extension is derived from the OpenAttribution v0.4 schema and has a Python SDK reference implementation.

---

## 🙋 Questions for Reviewers

1. **Extension scope**: Should `content_attribution` also extend `CheckoutSessionUpdateRequest`, or are Create and Complete sufficient for first-touch / last-touch?
2. ~~**`conversation_summary` granularity**: Is the current set of `primary_intent` values appropriate, or should ACP define its own intent taxonomy?~~ Resolved: removed `primary_intent` and totals fields. `conversation_summary` now contains only `turn_count` (not derivable from citation data) and `topics` (free-form tags, expensive for merchants to derive from URLs alone). Subjective classification fields dropped per reviewer feedback.
3. ~~**Schema hosting**: The JSON Schema `$id` uses `openattribution.org`. Should this be mirrored under an ACP-controlled URL if the extension is accepted?~~ Resolved: updated to use `agentic-commerce-protocol.com` namespace per reviewer feedback.

## Changes Since Initial Submission

Addressing review feedback from @kxbnb:

- **`$id` namespace**: Changed from `openattribution.org` to `agentic-commerce-protocol.com/schemas/` to match ACP convention
- **`additionalProperties`**: Removed `additionalProperties: false` from all nested objects (`content_retrieved` items, `content_cited` items, `conversation_summary`) to match the RFC's forward-compatibility guarantee
- **`minItems`**: Added `minItems: 1` to `content_retrieved` to enforce the RFC's conformance requirement
- **`content_hash`**: Simplified to "SHA-256 of the content the agent processed from this URL" — an integrity audit trail, not a real-time verification mechanism. Relaxed regex to accept mixed-case hex.
- **`content_retrieved` required**: Added to schema's `required` array — if you're sending `content_attribution`, you must have retrieved something
- **`prior_session_ids`**: Removed from v1. Cross-session tracking risk outweighs the use case. For multi-conversation attribution, agents include all relevant content from prior conversations in the final checkout's `content_retrieved` array — timestamps on entries provide the temporal signal without session linking.
- **`conversation_summary`**: Stripped to `turn_count` + `topics` only. Removed `primary_intent` (subjective, inconsistent across agents), `total_content_retrieved`, `total_content_cited` (derivable from array lengths)
