### PR TITLE
SEP: Intervention types extension for wallet handler auth flows

### DIFF
--- a/changelog/unreleased/intervention-types-extension.md
+++ b/changelog/unreleased/intervention-types-extension.md
@@ -1,0 +1,8 @@
+### Added
+- New intervention types: `redirect`, `webview`, `otp` in `InterventionCapabilities.supported` and `InterventionCapabilities.required` enums
+- `InterventionContext` schema for structured intervention metadata on checkout session responses
+- `InterventionResponse` schema for agent submission of intervention results (OTP codes, redirect completion)
+- `intervention_context` field on `CheckoutSessionBase` for pending intervention details
+- `intervention_response` field on `CheckoutSessionUpdateRequest` for agent intervention submissions
+- Examples for OTP flow, redirect flow, and capability mismatch scenarios
+- RFC: `rfcs/rfc.intervention_types.md`

--- a/examples/unreleased/intervention-types/examples.intervention_types.json
+++ b/examples/unreleased/intervention-types/examples.intervention_types.json
@@ -1,0 +1,389 @@
+{
+  "otp_flow_create_request": {
+    "currency": "usd",
+    "line_items": [
+      {
+        "id": "item_sneakers_001"
+      }
+    ],
+    "capabilities": {
+      "interventions": {
+        "supported": ["3ds", "otp"],
+        "display_context": "native",
+        "redirect_context": "none",
+        "max_redirects": 0,
+        "max_interaction_depth": 2
+      }
+    },
+    "fulfillment_details": {
+      "name": "Jane Smith",
+      "phone_number": "15559876543",
+      "email": "jane@example.com",
+      "address": {
+        "name": "Jane Smith",
+        "line_one": "456 Commerce Ave",
+        "line_two": "Apt 12",
+        "city": "Austin",
+        "state": "TX",
+        "country": "US",
+        "postal_code": "78701"
+      }
+    }
+  },
+
+  "otp_flow_session_response_intervention_required": {
+    "id": "checkout_session_otp_001",
+    "protocol": {
+      "version": "2026-01-30"
+    },
+    "status": "authentication_required",
+    "currency": "usd",
+    "line_items": [
+      {
+        "id": "item_sneakers_001",
+        "name": "Running Sneakers",
+        "description": "Lightweight running shoes, size 10",
+        "quantity": "1",
+        "unit_price": 12999,
+        "images": [
+          {
+            "url": "https://shop.example.com/images/sneakers-001.jpg",
+            "alt_text": "Running sneakers"
+          }
+        ]
+      }
+    ],
+    "totals": [
+      {
+        "type": "subtotal",
+        "label": "Subtotal",
+        "amount": 12999
+      },
+      {
+        "type": "shipping",
+        "label": "Standard Shipping",
+        "amount": 599
+      },
+      {
+        "type": "tax",
+        "label": "Sales Tax",
+        "amount": 1072
+      },
+      {
+        "type": "total",
+        "label": "Total",
+        "amount": 14670
+      }
+    ],
+    "fulfillment_options": [
+      {
+        "type": "shipping",
+        "id": "standard_shipping",
+        "name": "Standard Shipping",
+        "description": "5-7 business days",
+        "price": 599
+      }
+    ],
+    "capabilities": {
+      "interventions": {
+        "supported": ["otp"],
+        "required": ["otp"],
+        "enforcement": "always"
+      }
+    },
+    "messages": [
+      {
+        "type": "error",
+        "code": "intervention_required",
+        "severity": "medium",
+        "resolution": "requires_buyer_input",
+        "content_type": "plain",
+        "content": "Please enter the verification code sent to your email to authenticate with Stripe Link."
+      }
+    ],
+    "intervention_context": {
+      "intervention_type": "otp",
+      "challenge_hint": "Code sent to j***@example.com",
+      "expires_at": "2026-02-17T15:35:00Z",
+      "provider": "com.stripe.link"
+    },
+    "links": [
+      {
+        "rel": "terms",
+        "href": "https://shop.example.com/terms",
+        "type": "text/html"
+      }
+    ]
+  },
+
+  "otp_flow_update_request_with_code": {
+    "intervention_response": {
+      "type": "otp",
+      "code": "847293"
+    }
+  },
+
+  "otp_flow_session_response_after_verification": {
+    "id": "checkout_session_otp_001",
+    "protocol": {
+      "version": "2026-01-30"
+    },
+    "status": "ready_for_payment",
+    "currency": "usd",
+    "line_items": [
+      {
+        "id": "item_sneakers_001",
+        "name": "Running Sneakers",
+        "description": "Lightweight running shoes, size 10",
+        "quantity": "1",
+        "unit_price": 12999,
+        "images": [
+          {
+            "url": "https://shop.example.com/images/sneakers-001.jpg",
+            "alt_text": "Running sneakers"
+          }
+        ]
+      }
+    ],
+    "totals": [
+      {
+        "type": "subtotal",
+        "label": "Subtotal",
+        "amount": 12999
+      },
+      {
+        "type": "shipping",
+        "label": "Standard Shipping",
+        "amount": 599
+      },
+      {
+        "type": "tax",
+        "label": "Sales Tax",
+        "amount": 1072
+      },
+      {
+        "type": "total",
+        "label": "Total",
+        "amount": 14670
+      }
+    ],
+    "fulfillment_options": [
+      {
+        "type": "shipping",
+        "id": "standard_shipping",
+        "name": "Standard Shipping",
+        "description": "5-7 business days",
+        "price": 599
+      }
+    ],
+    "capabilities": {
+      "interventions": {
+        "supported": ["otp"],
+        "required": ["otp"],
+        "enforcement": "always"
+      }
+    },
+    "messages": [],
+    "links": [
+      {
+        "rel": "terms",
+        "href": "https://shop.example.com/terms",
+        "type": "text/html"
+      }
+    ]
+  },
+
+  "redirect_flow_create_request": {
+    "currency": "usd",
+    "line_items": [
+      {
+        "id": "item_tablet_001"
+      }
+    ],
+    "capabilities": {
+      "interventions": {
+        "supported": ["3ds", "redirect", "otp"],
+        "display_context": "native",
+        "redirect_context": "external_browser",
+        "max_redirects": 2,
+        "max_interaction_depth": 3
+      }
+    },
+    "fulfillment_details": {
+      "name": "Alex Rivera",
+      "phone_number": "15551112222",
+      "email": "alex@example.com",
+      "address": {
+        "name": "Alex Rivera",
+        "line_one": "789 Tech Blvd",
+        "line_two": "",
+        "city": "Seattle",
+        "state": "WA",
+        "country": "US",
+        "postal_code": "98101"
+      }
+    }
+  },
+
+  "redirect_flow_session_response_intervention_required": {
+    "id": "checkout_session_redirect_001",
+    "protocol": {
+      "version": "2026-01-30"
+    },
+    "status": "authentication_required",
+    "currency": "usd",
+    "line_items": [
+      {
+        "id": "item_tablet_001",
+        "name": "Tablet Pro 12",
+        "description": "12-inch tablet with stylus",
+        "quantity": "1",
+        "unit_price": 49999,
+        "images": [
+          {
+            "url": "https://electronics.example.com/images/tablet-001.jpg",
+            "alt_text": "Tablet Pro 12"
+          }
+        ]
+      }
+    ],
+    "totals": [
+      {
+        "type": "subtotal",
+        "label": "Subtotal",
+        "amount": 49999
+      },
+      {
+        "type": "shipping",
+        "label": "Express Shipping",
+        "amount": 1499
+      },
+      {
+        "type": "tax",
+        "label": "Sales Tax",
+        "amount": 5150
+      },
+      {
+        "type": "total",
+        "label": "Total",
+        "amount": 56648
+      }
+    ],
+    "fulfillment_options": [
+      {
+        "type": "shipping",
+        "id": "express_shipping",
+        "name": "Express Shipping",
+        "description": "2-3 business days",
+        "price": 1499
+      }
+    ],
+    "capabilities": {
+      "interventions": {
+        "supported": ["redirect"],
+        "required": ["redirect"],
+        "enforcement": "always"
+      }
+    },
+    "messages": [
+      {
+        "type": "error",
+        "code": "intervention_required",
+        "severity": "medium",
+        "resolution": "requires_buyer_review",
+        "content_type": "plain",
+        "content": "Please authenticate with Google Pay to continue. You will be redirected to Google's sign-in page."
+      }
+    ],
+    "intervention_context": {
+      "intervention_type": "redirect",
+      "redirect_url": "https://pay.google.com/authenticate?session=gpay_sess_abc123&merchant=electronics_example",
+      "callback_url": "https://electronics.example.com/checkout/callback?session=checkout_session_redirect_001",
+      "expires_at": "2026-02-17T15:40:00Z",
+      "provider": "com.google.pay"
+    },
+    "links": [
+      {
+        "rel": "terms",
+        "href": "https://electronics.example.com/terms",
+        "type": "text/html"
+      }
+    ]
+  },
+
+  "redirect_flow_update_request_complete": {
+    "intervention_response": {
+      "type": "redirect_complete",
+      "callback_data": "auth_token=gpay_auth_xyz789&status=success"
+    }
+  },
+
+  "capability_negotiation_mismatch_error": {
+    "id": "checkout_session_mismatch_001",
+    "protocol": {
+      "version": "2026-01-30"
+    },
+    "status": "not_ready_for_payment",
+    "currency": "usd",
+    "line_items": [
+      {
+        "id": "item_headphones_001",
+        "name": "Wireless Headphones",
+        "description": "Noise-canceling wireless headphones",
+        "quantity": "1",
+        "unit_price": 29999,
+        "images": [
+          {
+            "url": "https://audio.example.com/images/headphones-001.jpg",
+            "alt_text": "Wireless headphones"
+          }
+        ]
+      }
+    ],
+    "totals": [
+      {
+        "type": "subtotal",
+        "label": "Subtotal",
+        "amount": 29999
+      },
+      {
+        "type": "total",
+        "label": "Total",
+        "amount": 29999
+      }
+    ],
+    "fulfillment_options": [
+      {
+        "type": "shipping",
+        "id": "free_shipping",
+        "name": "Free Shipping",
+        "description": "5-7 business days",
+        "price": 0
+      }
+    ],
+    "capabilities": {
+      "interventions": {
+        "supported": [],
+        "required": ["webview"],
+        "enforcement": "always"
+      }
+    },
+    "messages": [
+      {
+        "type": "error",
+        "code": "unsupported",
+        "severity": "high",
+        "resolution": "recoverable",
+        "content_type": "plain",
+        "content": "This payment method requires webview intervention support, which is not declared in agent capabilities. Use a different payment method or update agent capabilities."
+      }
+    ],
+    "links": [
+      {
+        "rel": "terms",
+        "href": "https://audio.example.com/terms",
+        "type": "text/html"
+      }
+    ]
+  }
+}

--- a/rfcs/rfc.intervention_types.md
+++ b/rfcs/rfc.intervention_types.md
@@ -1,0 +1,379 @@
+# RFC: Intervention Types Extension
+
+**Status:** Proposal
+**Version:** 2026-02-17
+**Scope:** Extend intervention type vocabulary for wallet authentication and interactive checkout flows
+**Depends on:** RFC: Capability Negotiation
+
+This RFC extends the intervention type vocabulary in
+`InterventionCapabilities` to cover interactive authentication flows
+required by wallet-style payment handlers (Stripe Link, Apple Pay,
+Google Pay, Shop Pay). It also introduces an `InterventionContext`
+object for `intervention_required` error payloads so agents can
+determine what action to take.
+
+---
+
+## 1. Motivation
+
+The current `intervention_types` enum covers three values: `3ds`,
+`biometric`, and `address_verification`. All three are inline flows
+where the agent or buyer completes a step within the existing checkout
+session context.
+
+Wallet handlers introduce interactive authentication patterns that
+don't fit this model:
+
+- **Stripe Link** (#141): Buyer receives an email or SMS with a
+  one-time code, enters it to authenticate, then selects a saved
+  payment method.
+- **Google Pay**: Buyer may be redirected to Google's authentication
+  page, then returned to the checkout flow.
+- **Apple Pay**: Buyer completes a biometric prompt on-device (already
+  partially covered by `biometric`) or interacts with a system dialog.
+- **Shop Pay**: Buyer receives an SMS code to verify identity.
+
+Without intervention types for these patterns, each wallet handler
+will invent its own workaround. Since SEP #141 (Stripe Link) is the
+first wallet handler being specified, whatever pattern it sets will be
+copied. Sorting this out before that handler lands avoids
+inconsistency.
+
+### 1.1 Why not reuse `display_context`?
+
+`display_context` describes *how the agent renders* an intervention UI
+(native, webview, modal, redirect). Intervention types describe *what
+kind of authentication or verification* the buyer needs to complete.
+A `3ds` intervention might be displayed via `webview` or `redirect`.
+An `otp` intervention might be displayed via `native` (inline text
+input) or `modal`. These are orthogonal dimensions.
+
+### 1.2 Gap in error payloads
+
+When a seller returns `intervention_required` in `messages[]`, the
+agent currently has no structured way to determine *which* intervention
+is needed or *how* to initiate it. The agent gets the error code but
+not the intervention type, redirect URL, or challenge details. This
+RFC addresses that gap with an `InterventionContext` object.
+
+---
+
+## 2. Goals and non-goals
+
+### 2.1 Goals
+
+1. Add `redirect`, `webview`, and `otp` to the intervention type
+   vocabulary.
+2. Define clear semantics for each type so agents can accurately
+   declare capabilities and sellers can set requirements.
+3. Introduce `InterventionContext` for `intervention_required` error
+   payloads.
+4. Maintain backward compatibility — existing `3ds`, `biometric`,
+   and `address_verification` types are unchanged.
+
+### 2.2 Non-goals
+
+- Defining wallet-specific authentication flows (that belongs in
+  each wallet handler's SEP).
+- Changing the capability negotiation mechanism itself.
+- Specifying how agents render specific intervention UIs (that's
+  the agent's implementation detail).
+
+---
+
+## 3. Specification
+
+### 3.1 New intervention types
+
+Three new values are added to the `supported` and `required`
+intervention type enums:
+
+| Type | Description | Agent capability required |
+|------|-------------|-------------------------|
+| `redirect` | Buyer completes authentication at an external URL (OAuth-style). The seller provides a URL; the buyer navigates to it, authenticates, and is returned via callback. | Agent can navigate the buyer to an external URL and handle a return callback. |
+| `webview` | Buyer interacts with an embedded UI component rendered by a payment provider's SDK or iframe. | Agent can render embedded web content within the checkout context. |
+| `otp` | Buyer enters a one-time code delivered via email or SMS. The seller triggers code delivery; the agent prompts the buyer for the code and relays it back. | Agent can prompt the buyer for text input and submit it to the seller. |
+
+The `supported` enum becomes:
+```
+["3ds", "biometric", "address_verification", "redirect", "webview", "otp"]
+```
+
+The `required` enum becomes:
+```
+["3ds", "biometric", "redirect", "webview", "otp"]
+```
+
+`address_verification` remains excluded from `required` since it is
+a passive check that doesn't block checkout completion.
+
+### 3.2 Capability negotiation
+
+The negotiation flow is unchanged. Agents declare supported
+intervention types in requests; sellers return the intersection in
+responses and list required types.
+
+**Agent request example:**
+```json
+{
+  "capabilities": {
+    "interventions": {
+      "supported": ["3ds", "otp", "redirect"],
+      "display_context": "native",
+      "redirect_context": "external_browser",
+      "max_redirects": 2
+    }
+  }
+}
+```
+
+**Seller response (Stripe Link checkout):**
+```json
+{
+  "capabilities": {
+    "interventions": {
+      "supported": ["otp"],
+      "required": ["otp"],
+      "enforcement": "always"
+    }
+  }
+}
+```
+
+If the agent does not declare `otp` in `supported` but the seller
+requires it, the existing mismatch error handling applies — the
+seller returns a capability mismatch error per the Capability
+Negotiation RFC.
+
+### 3.3 InterventionContext
+
+A new `InterventionContext` object is added to the schema. It appears
+on the `CheckoutSession` response when the session status indicates
+an intervention is pending.
+
+```json
+{
+  "type": "object",
+  "additionalProperties": true,
+  "description": "Context for a pending intervention. Present on the session when an intervention_required message is active.",
+  "properties": {
+    "intervention_type": {
+      "type": "string",
+      "enum": ["3ds", "biometric", "address_verification", "redirect", "webview", "otp"],
+      "description": "The type of intervention the buyer needs to complete."
+    },
+    "redirect_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL the buyer should be directed to (redirect and webview types)."
+    },
+    "callback_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL the buyer returns to after completing the redirect flow."
+    },
+    "challenge_hint": {
+      "type": "string",
+      "description": "Human-readable hint about where the challenge was sent (e.g., 'Code sent to k***@gmail.com'). For otp type."
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "When this intervention context expires."
+    },
+    "provider": {
+      "type": "string",
+      "description": "The payment handler or provider that triggered this intervention."
+    }
+  },
+  "required": ["intervention_type"]
+}
+```
+
+**Fields by intervention type:**
+
+| Field | redirect | webview | otp | 3ds | biometric |
+|-------|----------|---------|-----|-----|-----------|
+| `intervention_type` | required | required | required | required | required |
+| `redirect_url` | required | required | — | — | — |
+| `callback_url` | required | optional | — | — | — |
+| `challenge_hint` | — | — | recommended | — | — |
+| `expires_at` | recommended | recommended | recommended | recommended | — |
+| `provider` | optional | optional | optional | optional | optional |
+
+For `3ds` interventions, agents should continue using the existing
+`authentication_metadata` field. `InterventionContext` provides
+the type signal; `authentication_metadata` provides the 3DS-specific
+parameters.
+
+### 3.4 Session-level placement
+
+`intervention_context` is added as an optional field on
+`CheckoutSession`, alongside the existing `authentication_metadata`:
+
+```json
+{
+  "intervention_context": {
+    "$ref": "#/$defs/InterventionContext",
+    "description": "Context for a pending buyer intervention. Present when an intervention is needed to proceed."
+  }
+}
+```
+
+This field is set by the seller when intervention is required and
+cleared when the intervention is completed or the session moves past
+the intervention state.
+
+### 3.5 OTP submission
+
+For `otp` interventions, the agent collects the code from the buyer
+and submits it via the existing `update_checkout_session` endpoint.
+The OTP value is passed in a new optional field on the update request:
+
+```json
+{
+  "intervention_response": {
+    "type": "otp",
+    "code": "123456"
+  }
+}
+```
+
+The `InterventionResponse` object:
+
+```json
+{
+  "type": "object",
+  "additionalProperties": true,
+  "description": "Agent's response to a pending intervention.",
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": ["otp", "redirect_complete", "webview_complete"],
+      "description": "The intervention type being responded to."
+    },
+    "code": {
+      "type": "string",
+      "description": "One-time code entered by the buyer (otp type)."
+    },
+    "callback_data": {
+      "type": "string",
+      "description": "Data received from the redirect callback (redirect_complete type)."
+    }
+  },
+  "required": ["type"]
+}
+```
+
+For `redirect` and `webview` interventions, the agent signals
+completion by sending an update with `intervention_response.type`
+set to `redirect_complete` or `webview_complete`, optionally
+including any callback data.
+
+---
+
+## 4. Rationale
+
+### 4.1 Mechanism-based vs provider-specific types
+
+We considered provider-specific types (`stripe_link_auth`,
+`apple_pay_auth`, `google_pay_auth`) but rejected them because:
+
+- New providers would require enum additions each time.
+- Agents would need per-provider logic rather than per-mechanism logic.
+- Mechanism-based types are composable — Stripe Link and Shop Pay
+  both use `otp`, so an agent that supports `otp` handles both.
+
+### 4.2 Why `redirect` is a separate type from `webview`
+
+While both involve rendering web content, they require different agent
+capabilities:
+
+- `redirect` navigates away from the current context. The agent must
+  handle a full navigation + callback flow. This may not be possible
+  in all environments (e.g., a CLI agent).
+- `webview` embeds content inline. The agent must render an iframe or
+  equivalent. This may not be possible in environments without a
+  rendering engine.
+
+An agent might support one but not the other, so they must be declared
+separately for accurate capability negotiation.
+
+### 4.3 InterventionContext vs extending MessageError
+
+We considered adding intervention fields directly to `MessageError`
+but chose a separate session-level object because:
+
+- Intervention context persists across multiple API calls (the buyer
+  may take time to complete the flow). Tying it to a single error
+  message creates lifecycle issues.
+- Other API calls during the intervention (e.g., polling for status)
+  need access to the context without re-triggering the error.
+- Session-level placement aligns with how `authentication_metadata`
+  already works for 3DS.
+
+### 4.4 Why `address_verification` stays out of `required`
+
+Address verification is a passive check against buyer-provided data.
+It doesn't require an interactive flow — the seller validates the
+address in the background. Including it in `required` would imply the
+buyer must take an action, which doesn't match the semantics.
+
+---
+
+## 5. Backward compatibility
+
+This change is additive:
+
+- New enum values are added to existing arrays. Agents and sellers
+  that don't support the new types simply don't include them in
+  `supported`/`required`.
+- `InterventionContext` and `intervention_response` are new optional
+  fields. Existing implementations ignore them.
+- The capability negotiation mechanism is unchanged.
+- Existing `3ds`, `biometric`, and `address_verification` types
+  continue to work identically.
+
+Implementations MUST NOT reject payloads containing unrecognized
+intervention types, per the forward-compatibility requirements in the
+Capability Negotiation RFC.
+
+---
+
+## 6. Security considerations
+
+### 6.1 Redirect URL validation
+
+Agents MUST validate `redirect_url` before navigating the buyer.
+At minimum:
+
+- The URL must use HTTPS.
+- The domain should match the seller's known domain or a recognized
+  payment provider.
+- Agents should warn buyers before navigating to external URLs.
+
+### 6.2 OTP handling
+
+- Agents MUST NOT log or persist OTP codes.
+- OTP codes should be transmitted only via the
+  `intervention_response.code` field, never in free-text fields.
+- `challenge_hint` MUST be partially redacted (e.g., `k***@gmail.com`,
+  not `karthik@gmail.com`).
+
+### 6.3 Intervention context expiration
+
+Sellers SHOULD set `expires_at` on intervention contexts.
+Agents SHOULD treat expired contexts as failed and re-request
+the intervention or cancel the session.
+
+---
+
+## 7. Examples
+
+See `examples/unreleased/intervention-types/` for complete
+request/response examples covering:
+
+- OTP flow (Stripe Link style)
+- Redirect flow (Google Pay style)
+- Capability negotiation with new types
+- Intervention context on session response

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -531,7 +531,10 @@
             "enum": [
               "3ds",
               "biometric",
-              "address_verification"
+              "address_verification",
+              "redirect",
+              "webview",
+              "otp"
             ]
           },
           "description": "Intervention types supported. Agent request: Interventions the agent can handle. Seller response: Intersection of supported interventions."
@@ -542,7 +545,10 @@
             "type": "string",
             "enum": [
               "3ds",
-              "biometric"
+              "biometric",
+              "redirect",
+              "webview",
+              "otp"
             ]
           },
           "description": "Intervention methods required for this session (seller only)."
@@ -2656,6 +2662,78 @@
         }
       ]
     },
+    "InterventionContext": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Context for a pending buyer intervention. Present on the session when an intervention_required message is active. The intervention_type field is always present; other fields depend on the type.",
+      "properties": {
+        "intervention_type": {
+          "type": "string",
+          "enum": [
+            "3ds",
+            "biometric",
+            "address_verification",
+            "redirect",
+            "webview",
+            "otp"
+          ],
+          "description": "The type of intervention the buyer needs to complete."
+        },
+        "redirect_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL the buyer should be directed to (redirect and webview types)."
+        },
+        "callback_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL the buyer returns to after completing the redirect flow."
+        },
+        "challenge_hint": {
+          "type": "string",
+          "description": "Human-readable hint about where the challenge was sent (e.g., 'Code sent to k***@gmail.com'). For otp type."
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When this intervention context expires."
+        },
+        "provider": {
+          "type": "string",
+          "description": "The payment handler or provider that triggered this intervention."
+        }
+      },
+      "required": [
+        "intervention_type"
+      ]
+    },
+    "InterventionResponse": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Agent's response to a pending intervention. Submitted via update_checkout_session when the buyer completes an intervention flow.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "otp",
+            "redirect_complete",
+            "webview_complete"
+          ],
+          "description": "The intervention type being responded to."
+        },
+        "code": {
+          "type": "string",
+          "description": "One-time code entered by the buyer (otp type)."
+        },
+        "callback_data": {
+          "type": "string",
+          "description": "Data received from the redirect callback (redirect_complete type)."
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
     "CheckoutSessionBase": {
       "type": "object",
       "additionalProperties": false,
@@ -2796,6 +2874,10 @@
         "authentication_metadata": {
           "$ref": "#/$defs/AuthenticationMetadata",
           "description": "Authentication metadata for payment interventions (e.g., 3DS)"
+        },
+        "intervention_context": {
+          "$ref": "#/$defs/InterventionContext",
+          "description": "Context for a pending buyer intervention. Present when an intervention is needed to proceed."
         },
         "created_at": {
           "type": "string",
@@ -2994,6 +3076,10 @@
         "discounts": {
           "$ref": "#/$defs/DiscountsRequest",
           "description": "Discount codes to apply. Replaces previously submitted codes."
+        },
+        "intervention_response": {
+          "$ref": "#/$defs/InterventionResponse",
+          "description": "Agent's response to a pending intervention (e.g., OTP code, redirect completion signal)."
         }
       }
     },


### PR DESCRIPTION
# SEP: Intervention Types Extension

## 📋 SEP Metadata

- **SEP Number**: #142
- **Author(s)**: Karthik / kxbnb
- **Status**: `proposal` (awaiting sponsor)
- **Type**: [x] Major Change [ ] Process Change
- **Related Issues/RFCs**: #142 (feature request), #141 (Stripe Link handler), #137 (Discovery Capabilities), #98 (intervention_required error), RFC: Capability Negotiation

---

## 🎯 Abstract

The current `intervention_types` enum covers `3ds`, `biometric`, and `address_verification`. These are all inline flows. Wallet handlers like Stripe Link, Google Pay, and Shop Pay require interactive auth flows that don't fit: email/SMS OTP, redirect-based login, and embedded webview auth.

This SEP adds three new intervention types (`redirect`, `webview`, `otp`), introduces `InterventionContext` so agents know what to do when they get an `intervention_required` error, and adds `InterventionResponse` so agents can submit OTP codes and redirect completion signals via the existing update endpoint.

---

## 💡 Motivation

SEP #141 (Stripe Link) is the first wallet handler being specified. Link requires email + OTP authentication. There's currently no way to express "this checkout requires the buyer to enter a one-time code" in the intervention vocabulary.

Without these types, each wallet handler will work around the gap differently. Stripe Link might stuff OTP info into the error message text. Google Pay might invent a custom field for redirect URLs. By the time we have four wallet handlers, we'd have four incompatible approaches.

The `intervention_required` error code already exists in the schema but has no structured payload -- the agent gets the error but not the intervention type, redirect URL, or challenge details. This makes it hard for agents to handle interventions programmatically.

---

## 📐 Specification

See `rfcs/rfc.intervention_types.md` for the full spec. The changes:

**Schema additions:**
- `redirect`, `webview`, `otp` added to `InterventionCapabilities.supported` and `.required` enums
- `InterventionContext` type with `intervention_type`, `redirect_url`, `callback_url`, `challenge_hint`, `expires_at`, `provider`
- `InterventionResponse` type with `type` (otp/redirect_complete/webview_complete), `code`, `callback_data`
- `intervention_context` field on `CheckoutSessionBase`
- `intervention_response` field on `CheckoutSessionUpdateRequest`

**Examples:**
- OTP flow (Stripe Link style): create → intervention_required with context → update with code → ready_for_payment
- Redirect flow (Google Pay style): create → intervention_required with redirect URL → update with completion signal
- Capability mismatch: agent doesn't support required intervention type

---

## 🤔 Rationale

**Mechanism-based vs provider-specific types:** We went with mechanism-based (`redirect`, `webview`, `otp`) over provider-specific (`stripe_link_auth`, `google_pay_auth`). New providers map to existing types instead of requiring enum additions each time. Stripe Link and Shop Pay both use `otp`, so one capability covers both.

**`redirect` separate from `webview`:** Different agent capabilities. A CLI agent can open an external browser for a redirect but can't render an iframe. These need separate capability declarations.

**Session-level `InterventionContext` instead of extending `MessageError`:** Intervention state persists across API calls while the buyer completes the flow. Tying it to a single error message creates lifecycle issues. Session-level placement matches how `authentication_metadata` already works for 3DS.

**`address_verification` stays out of `required`:** It's a passive check, not an interactive flow. Including it in `required` would imply buyer action.

---

## 🔄 Backward Compatibility

All changes are additive -- nothing breaks.

- New enum values in existing arrays. Agents/sellers that don't use them just omit them.
- New optional fields on existing objects. Existing implementations ignore them.
- Negotiation mechanism unchanged.
- Existing types (`3ds`, `biometric`, `address_verification`) work identically.

---

## 🛠️ Reference Implementation

Not yet available. This PR includes the RFC, schema changes, and examples.

---

## 🔒 Security Implications

- **Redirect URLs:** Agents must validate redirect URLs are HTTPS and match known payment providers. Arbitrary redirects could be used for phishing.
- **OTP handling:** Agents must not log or persist codes. Codes go only through `intervention_response.code`, never in free-text fields.
- **Challenge hints:** Must be partially redacted (`k***@gmail.com`, not full email).
- **Expiration:** Sellers should set `expires_at`. Agents should treat expired contexts as failed.

---

## ✅ Pre-Submission Checklist

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags (#142)
- [x] I have linked the SEP issue number above
- [ ] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [x] I have signed the Contributor License Agreement (CLA)
- [x] This PR includes updates to OpenAPI/JSON schemas
- [x] This PR includes example requests/responses
- [x] This PR includes a changelog entry file in `changelog/unreleased/intervention-types-extension.md`
- [ ] I am seeking or have found a sponsor (Founding Maintainer)

---

## 📚 Additional Context

This SEP was motivated by the discussion in #142 and the arrival of SEP #141 (Stripe Link). The three types map to distinct agent capabilities, which is what capability negotiation (#137) actually cares about. An agent that handles redirects isn't necessarily capable of rendering a webview, and that distinction needs to be declarable at discovery time.

The `InterventionContext` object is related to the gap in #98 about how `intervention_required` errors surface in responses -- this SEP provides the structured payload that #98 identified as missing.

---

## 🙋 Questions for Reviewers

1. Should `webview` carry additional metadata (SDK URL, required dimensions, sandbox flags)?
2. Is `redirect` underspecified for the popup/modal vs full-navigation distinction? Should there be sub-types or should `display_context` handle that?
3. Should `InterventionResponse` be on the complete request too, or just update?
4. Does the Stripe Link team (cc @prasad-stripe) see `otp` as sufficient for the Link flow, or does Link need additional fields?