### PR TITLE
Add intent traces examples for all reason codes

### DIFF
--- a/changelog/unreleased/intent-traces-examples.md
+++ b/changelog/unreleased/intent-traces-examples.md
@@ -1,0 +1,6 @@
+### Added
+- Intent traces examples covering all 10 reason codes: price_sensitivity, shipping_cost, shipping_speed, product_fit, trust_security, returns_policy, payment_options, comparison, timing_deferred, other
+- Cancel response example with canceled session state
+- Minimal trace example (reason_code only)
+- Empty cancel request example (backward compatibility)
+- Malformed trace error response example

--- a/changelog/unreleased/intent-traces-examples.md
+++ b/changelog/unreleased/intent-traces-examples.md
@@ -1,6 +1,5 @@
 ### Added
 - Intent traces examples covering all 10 reason codes: price_sensitivity, shipping_cost, shipping_speed, product_fit, trust_security, returns_policy, payment_options, comparison, timing_deferred, other
-- Cancel response example with canceled session state
 - Minimal trace example (reason_code only)
 - Empty cancel request example (backward compatibility)
 - Malformed trace error response example

--- a/examples/unreleased/examples.intent_traces.json
+++ b/examples/unreleased/examples.intent_traces.json
@@ -11,66 +11,6 @@
     }
   },
 
-  "cancel_with_price_sensitivity_checkout_session_response": {
-    "id": "cs_price_001",
-    "protocol": {
-      "version": "2026-01-30"
-    },
-    "capabilities": {
-      "payment": { "handlers": [] },
-      "interventions": { "supported": [], "required": [], "enforcement": "optional" }
-    },
-    "status": "canceled",
-    "currency": "usd",
-    "line_items": [
-      {
-        "id": "li_headphones_001",
-        "item": { "id": "item_headphones_001" },
-        "quantity": 1,
-        "name": "Wireless Noise-Canceling Headphones",
-        "description": "Over-ear headphones with ANC and 30hr battery",
-        "images": [
-          "https://audio-shop.example.com/products/headphones-001/main.jpg"
-        ],
-        "unit_amount": 19999,
-        "totals": [
-          { "type": "items_base_amount", "display_text": "Base Amount", "amount": 19999 },
-          { "type": "subtotal", "display_text": "Subtotal", "amount": 19999 },
-          { "type": "tax", "display_text": "Tax", "amount": 1650 },
-          { "type": "total", "display_text": "Total", "amount": 21649 }
-        ]
-      }
-    ],
-    "totals": [
-      { "type": "subtotal", "display_text": "Subtotal", "amount": 19999 },
-      { "type": "fulfillment", "display_text": "Shipping", "amount": 799 },
-      { "type": "tax", "display_text": "Tax", "amount": 1650 },
-      { "type": "total", "display_text": "Total", "amount": 22448 }
-    ],
-    "fulfillment_options": [
-      {
-        "type": "shipping",
-        "id": "ship_standard",
-        "title": "Standard Shipping",
-        "description": "5-7 business days",
-        "totals": [
-          { "type": "total", "display_text": "Shipping", "amount": 799 }
-        ]
-      }
-    ],
-    "messages": [
-      {
-        "type": "info",
-        "content_type": "plain",
-        "content": "Session canceled."
-      }
-    ],
-    "links": [
-      { "type": "terms_of_use", "url": "https://audio-shop.example.com/terms" },
-      { "type": "return_policy", "url": "https://audio-shop.example.com/returns" }
-    ]
-  },
-
   "cancel_with_shipping_cost_request": {
     "intent_trace": {
       "reason_code": "shipping_cost",

--- a/examples/unreleased/examples.intent_traces.json
+++ b/examples/unreleased/examples.intent_traces.json
@@ -1,0 +1,176 @@
+{
+  "cancel_with_price_sensitivity_request": {
+    "intent_trace": {
+      "reason_code": "price_sensitivity",
+      "trace_summary": "Found same headphones at Best Buy for $30 less with member pricing.",
+      "metadata": {
+        "max_budget": 17999,
+        "competitor_source": "bestbuy.com",
+        "competitor_price": 16999
+      }
+    }
+  },
+
+  "cancel_with_price_sensitivity_checkout_session_response": {
+    "id": "cs_price_001",
+    "protocol": {
+      "version": "2026-01-30"
+    },
+    "capabilities": {
+      "payment": { "handlers": [] },
+      "interventions": { "supported": [], "required": [], "enforcement": "optional" }
+    },
+    "status": "canceled",
+    "currency": "usd",
+    "line_items": [
+      {
+        "id": "li_headphones_001",
+        "item": { "id": "item_headphones_001" },
+        "quantity": 1,
+        "name": "Wireless Noise-Canceling Headphones",
+        "description": "Over-ear headphones with ANC and 30hr battery",
+        "images": [
+          "https://audio-shop.example.com/products/headphones-001/main.jpg"
+        ],
+        "unit_amount": 19999,
+        "totals": [
+          { "type": "items_base_amount", "display_text": "Base Amount", "amount": 19999 },
+          { "type": "subtotal", "display_text": "Subtotal", "amount": 19999 },
+          { "type": "tax", "display_text": "Tax", "amount": 1650 },
+          { "type": "total", "display_text": "Total", "amount": 21649 }
+        ]
+      }
+    ],
+    "totals": [
+      { "type": "subtotal", "display_text": "Subtotal", "amount": 19999 },
+      { "type": "fulfillment", "display_text": "Shipping", "amount": 799 },
+      { "type": "tax", "display_text": "Tax", "amount": 1650 },
+      { "type": "total", "display_text": "Total", "amount": 22448 }
+    ],
+    "fulfillment_options": [
+      {
+        "type": "shipping",
+        "id": "ship_standard",
+        "title": "Standard Shipping",
+        "description": "5-7 business days",
+        "totals": [
+          { "type": "total", "display_text": "Shipping", "amount": 799 }
+        ]
+      }
+    ],
+    "messages": [
+      {
+        "type": "info",
+        "content_type": "plain",
+        "content": "Session canceled."
+      }
+    ],
+    "links": [
+      { "type": "terms_of_use", "url": "https://audio-shop.example.com/terms" },
+      { "type": "return_policy", "url": "https://audio-shop.example.com/returns" }
+    ]
+  },
+
+  "cancel_with_shipping_cost_request": {
+    "intent_trace": {
+      "reason_code": "shipping_cost",
+      "trace_summary": "$12.99 shipping on a $25 order. Amazon has same item with free Prime shipping.",
+      "metadata": {
+        "shipping_amount": 1299,
+        "order_subtotal": 2500,
+        "target_shipping_cost": 0,
+        "competitor_reference": "amazon_prime"
+      }
+    }
+  },
+
+  "cancel_with_shipping_speed_request": {
+    "intent_trace": {
+      "reason_code": "shipping_speed",
+      "trace_summary": "Earliest delivery is 8 days out. Need this by Friday for a birthday.",
+      "metadata": {
+        "earliest_delivery_days": 8,
+        "needed_by": "2026-02-21"
+      }
+    }
+  },
+
+  "cancel_with_comparison_request": {
+    "intent_trace": {
+      "reason_code": "comparison",
+      "trace_summary": "Checking two other stores before deciding. This is the second of three.",
+      "metadata": {
+        "comparison_count": 3,
+        "current_position": 2
+      }
+    }
+  },
+
+  "cancel_with_timing_deferred_request": {
+    "intent_trace": {
+      "reason_code": "timing_deferred",
+      "trace_summary": "Buyer wants to wait for next month's paycheck. Plans to purchase after March 1.",
+      "metadata": {
+        "intended_purchase_after": "2026-03-01"
+      }
+    }
+  },
+
+  "cancel_with_payment_options_request": {
+    "intent_trace": {
+      "reason_code": "payment_options",
+      "trace_summary": "Buyer wants to pay with Afterpay (buy-now-pay-later). Merchant only accepts card and PayPal.",
+      "metadata": {
+        "desired_payment_method": "afterpay",
+        "available_methods": "card,paypal"
+      }
+    }
+  },
+
+  "cancel_with_trust_security_request": {
+    "intent_trace": {
+      "reason_code": "trust_security",
+      "trace_summary": "No HTTPS padlock on checkout page. No visible reviews or ratings for this merchant.",
+      "metadata": {
+        "concern": "merchant_credibility"
+      }
+    }
+  },
+
+  "cancel_with_returns_policy_request": {
+    "intent_trace": {
+      "reason_code": "returns_policy",
+      "trace_summary": "Final sale, no returns. Buyer unsure about sizing for this brand.",
+      "metadata": {
+        "return_window_days": 0,
+        "reason": "sizing_uncertainty"
+      }
+    }
+  },
+
+  "cancel_with_product_fit_request": {
+    "intent_trace": {
+      "reason_code": "product_fit",
+      "trace_summary": "Laptop specs don't match what buyer needs. 8GB RAM, buyer needs 16GB minimum for development work.",
+      "metadata": {
+        "required_spec": "ram_16gb",
+        "offered_spec": "ram_8gb"
+      }
+    }
+  },
+
+  "cancel_with_minimal_trace_request": {
+    "intent_trace": {
+      "reason_code": "other"
+    }
+  },
+
+  "cancel_without_trace_request": {},
+
+  "cancel_malformed_trace_error": {
+    "type": "invalid_request",
+    "code": "invalid_type",
+    "message": "metadata values must be strings, numbers, or booleans. Found object at $.intent_trace.metadata.nested_object",
+    "param": "$.intent_trace.metadata.nested_object"
+  }
+}


### PR DESCRIPTION
# Add intent traces examples for all reason codes

## 🔧 Type of Change

- [ ] Documentation fix/improvement
- [ ] Bug fix (non-breaking)
- [ ] Tooling improvement
- [x] Example update
- [ ] Minor data/enum addition
- [ ] Other

---

## 📝 Description

Adds examples for the intent traces cancel flow (RFC `rfc.intent_traces.md`). The RFC defines 10 `reason_code` values but had no machine-readable examples. This PR provides cancel request examples for all 10 reason codes with realistic metadata, plus a minimal trace, empty request, and error response.

The cancel *response* (a `CheckoutSession` with `status: "canceled"`) was originally included but removed since `examples.agentic_checkout.json` already has `cancel_checkout_session_response` covering that.

---

## 🎯 Motivation and Context

The intent traces RFC has been in the spec since December 2025 but the `examples/unreleased/` directory has no coverage for it. Agents implementing the cancel flow have to read the RFC prose to figure out what payloads look like. JSON examples are easier to build against than prose.

---

## 🧪 Testing

- `pnpm run compile:schema` -- passes
- `pnpm run validate:examples` -- passes (all validations green)
- Cancel request examples aren't schema-validated by the consistency script (no mapping for `CancelSessionRequest`) but they match the `IntentTrace` schema structure

---

## 📸 Screenshots / Examples

**Cancel with price_sensitivity (request):**
```json
{
  "intent_trace": {
    "reason_code": "price_sensitivity",
    "trace_summary": "Found same headphones at Best Buy for $30 less with member pricing.",
    "metadata": {
      "max_budget": 17999,
      "competitor_source": "bestbuy.com",
      "competitor_price": 16999
    }
  }
}
```

**Cancel with minimal trace (request):**
```json
{
  "intent_trace": {
    "reason_code": "other"
  }
}
```

**Cancel without trace (backward compat):**
```json
{}
```

---

## ✅ Checklist

- [x] I have signed the Contributor License Agreement (CLA)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (if applicable)
- [x] I have added/updated examples
- [x] I have added a changelog entry file to `changelog/unreleased/intent-traces-examples.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [x] All CI checks pass

---

## 🔍 Scope Verification

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ **This is a minor, straightforward change**

---

## 📚 Additional Notes

Covers all 10 reason codes from the RFC:
- `price_sensitivity` -- competitor pricing with budget metadata
- `shipping_cost` -- shipping fees vs free Prime shipping
- `shipping_speed` -- delivery too slow for a deadline
- `product_fit` -- specs don't match requirements
- `trust_security` -- merchant credibility concerns
- `returns_policy` -- final sale with sizing uncertainty
- `payment_options` -- desired BNPL method not available
- `comparison` -- actively shopping across merchants
- `timing_deferred` -- buyer wants to purchase later
- `other` -- minimal trace with just the reason code

Also includes edge cases: empty request body (backward compat) and malformed metadata error response.