### PR TITLE
SEP: Payment handler for Stripe link

### DIFF
--- a/changelog/unreleased/stripe-link-payment-handler.md
+++ b/changelog/unreleased/stripe-link-payment-handler.md
@@ -1,0 +1,12 @@
+# Stripe Link payment handler
+
+**Added** – `com.stripe.link` accelerated-checkout payment handler.
+
+Sellers can declare Stripe Link as a payment handler in `capabilities.payment.handlers`. Link handles buyer authentication and credential selection directly — the agent never handles raw payment credentials. The agent delegates the Link token via `delegate_payment` to obtain an SPT, keeping payment tracking and referral fees consistent across all handlers. Uses `requires_delegate_payment: true` and `requires_pci_compliance: false`.
+
+This is the first accelerated-checkout handler in ACP, establishing a pattern for wallet-type handlers where credential acquisition varies by wallet but delegation always flows through `delegate_payment`.
+
+**Backward compatible:** Additive only; no schema or API changes. Existing implementations ignore unknown handlers.
+
+**SEP:** `docs/SEP_STRIPE_LINK_PAYMENT_HANDLER.md`
+**Issue:** #141


### PR DESCRIPTION
# SEP: Stripe Link Payment Handler (`com.stripe.link`)

## 📋 SEP Metadata

- **Author(s)**: Prasad Wangikar / Stripe
- **Status**: `proposal`
- **Type**: [x] Major Change [ ] Process Change
- **Related Issues/RFCs**: #141, `rfcs/rfc.payment_handlers.md` (payment handlers framework), `rfcs/rfc.delegate_payment.md` (delegate payment API)

---

## 🎯 Abstract

This SEP introduces `com.stripe.link` as a new payment handler in the ACP payment handlers framework. Link is Stripe's accelerated checkout wallet that lets buyers save and reuse payment methods across any Link-enabled merchant. The handler enables a flow where agents initiate Link, the buyer authenticates and selects a saved payment method, Link returns a token, and the agent delegates the token via `delegate_payment` to obtain a Token before completing checkout. The seller never sees raw payment credentials.

This is the first **accelerated-checkout handler** in ACP — a handler where the buyer authenticates directly with a third-party wallet rather than providing credentials to the agent. It sets a pattern for future wallet-type handlers (e.g., Shop Pay, Apple Pay, Google Pay) in ACP.

---

## 💡 Motivation

### Why add Link to ACP?

1. **Higher conversion**: Link's 200M+ consumer network and one-click checkout experience increases conversion for sellers in agentic commerce, just as it does in traditional web checkout.

2. **No credential handling by agents**: Agents never see or handle raw payment credentials. The buyer authenticates with Link directly; the agent receives only a scoped token.

3. **Accelerated-checkout pattern**: ACP currently defines only `dev.acp.tokenized.*` handlers where the agent collects raw credentials. Link introduces a different acquisition pattern — the wallet handles credential collection and authentication, returning a token directly. The agent then delegates this token through the standard `delegate_payment` flow like any other handler.

4. **Already referenced in ACP**: The payment handlers RFC (section 9.1, migration example) already lists `com.stripe.link` as a handler name. This SEP formalizes its specification.

### Why the existing framework needs this handler

The `dev.acp.tokenized.*` handlers assume the agent collects credentials directly from the buyer. Link's credential acquisition is different:

1. Agent initiates Link with merchant identity
2. **Buyer authenticates directly with Link** (email + OTP)
3. Link returns a token bound to the checkout and merchant
4. Agent delegates the Link token via `delegate_payment` to obtain a Token
5. Agent submits Token to seller

The credential acquisition step is wallet-specific, but the delegation and checkout completion follow the same `delegate_payment` pattern as all other handlers. This keeps agents' payment tracking, referral fee handling, and PSP integration consistent regardless of how the credential was acquired.

---

## 📐 Specification

### Handler declaration

Sellers advertise the Link handler in `capabilities.payment.handlers[]`:

```json
{
  "id": "stripe_link",
  "name": "com.stripe.link",
  "version": "2026-01-30",
  "spec": "https://docs.stripe.com/agentic-commerce/handlers/link",
  "requires_delegate_payment": true,
  "requires_pci_compliance": false,
  "psp": "stripe",
  "config_schema": "https://acp.stripe.com/handlers/link/2026-01-30/business_config.json",
  "instrument_schemas": [
    "https://acp.stripe.com/handlers/link/2026-01-30/link_payment_instrument.json"
  ],
  "config": {
    "environment": "production",
    "merchant_id": "acct_merchant_xyz"
  }
}
```

### Handler fields

| Field | Value | Notes |
|-------|-------|-------|
| `name` | `com.stripe.link` | Reverse-DNS, Stripe-owned |
| `requires_delegate_payment` | `true` | Agent delegates the Link token via `delegate_payment` to get an Token |
| `requires_pci_compliance` | `false` | Agent never handles PCI-sensitive data |
| `psp` | `"stripe"` | Link is a Stripe product |

### Configuration schema (`business_config.json`)

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `environment` | string | Yes | `sandbox` or `production` |
| `merchant_id` | string | Yes | Seller's Stripe account identifier |

### Payment instrument schema (`link_payment_instrument.json`)

Extends `https://acp.dev/schemas/payment_instrument.json`. After delegation, the credential contains the Token.

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `type` | string | Yes | Must be `link` |
| `credential` | object | Yes | Toekn credential from `delegate_payment` |
| `billing_address` | object | No | Billing address |
| `email` | string | No | Buyer email |

### Agent flow

1. **Discover handler** — Agent reads `capabilities.payment.handlers[]`, identifies `com.stripe.link`
2. **Initiate Link** — Agent starts Link with seller's `merchant_id` and checkout context
3. **Buyer authenticates** — Buyer authenticates with Link (email + OTP), selects payment method, Link returns token
4. **Delegate payment** — Agent calls `delegate_payment` with the Link token to obtain a Token
5. **Complete checkout** — Agent submits Token in a payment instrument to the seller

### Files changed in this PR

- `docs/SEP_STRIPE_LINK_PAYMENT_HANDLER.md` — Full SEP document
- `spec/unreleased/json-schema/schema.delegate_payment.json` — Added `PaymentMethodLink` definition; `payment_method` now uses `oneOf` (card or link)
- `spec/unreleased/openapi/openapi.delegate_payment.yaml` — Added `PaymentMethodLink` schema and Link request example
- `examples/unreleased/examples.agentic_checkout.json` — Link handler in checkout session, Link complete checkout example
- `examples/unreleased/examples.delegate_payment.json` — Link delegate_payment request and response examples
- `changelog/unreleased/stripe-link-payment-handler.md` — Changelog entry

---

## 🤔 Rationale

### Why `requires_delegate_payment: true`?

Even though Link returns a token directly, requiring `delegate_payment` provides:

1. **Consistent payment tracking** — All handlers flow through `delegate_payment`, giving agents a single integration point for tracking payments and referral fees.
2. **PSP flexibility** — If an agent's PSP is not Stripe, they can still delegate the Link token through their own PSP.
3. **Allowance enforcement** — `delegate_payment` enforces `max_amount`, `currency`, and `expires_at` constraints.
4. **Pattern for all wallet handlers** — By requiring delegation for Link, all handlers follow the same flow, simplifying agent implementations for future wallets.

### Why `requires_pci_compliance: false`?

The agent never handles raw card numbers, bank accounts, or any PCI-sensitive data. Link's UI handles all credential presentation and selection.

### Why `com.stripe.link` and not `dev.acp.tokenized.link`?

The `dev.acp.tokenized.*` pattern implies the agent collects a credential directly from the buyer. Link's credential acquisition is fundamentally different — the wallet handles it. Using the provider-owned namespace (`com.stripe.link`) follows the convention that wallet providers own their handler namespace.

---

## 🔄 Backward Compatibility

**This is a backward-compatible, additive change.**

- **No schema changes**: The `PaymentHandler` schema already supports arbitrary handler names. `com.stripe.link` is a new handler instance, not a schema change.
- **No API changes**: No new endpoints. `delegate_payment` is used as-is with a new `payment_method.type` of `link`.
- **Existing implementations unaffected**: Agents that don't support Link ignore the handler. Sellers that don't support Link won't advertise it.
- **No migration needed**: Sellers add the handler to `capabilities.payment.handlers[]`. Agents that support Link process it; others skip it.

---

## 🛠️ Reference Implementation

- **ACP schema hosting**: JSON schemas to be hosted at `acp.stripe.com/handlers/link/2026-01-30/`
- **Stripe integration**: Stripe's Agentic Commerce SDK will support Link as a handler

---

## 🔒 Security Implications

### Token security

- **Single-use**: Link tokens and resulting Tokens are single-use.
- **Time-limited**: Tokens have limited validity and should be used promptly.
- **Checkout-scoped**: Tokens are bound to the checkout session and merchant via `delegate_payment` allowance constraints.
- **Secure transmission**: All token exchanges must occur over TLS 1.2+.

### Agent authorization

Agents must register with Stripe to obtain a `merchant_id` before initiating Link flows. The `merchant_id` identifies the agent and enables proper authorization tracking.

### No credential exposure

- Agents never handle raw payment credentials.
- Link handles all PCI-sensitive operations internally.
- The buyer authenticates directly with Link, not through the agent.

### Delegation provides consistent security boundary

Because the Link token flows through `delegate_payment`:
- The PSP enforces allowance constraints (`max_amount`, `currency`, `expires_at`)
- The Token is scoped to a specific `checkout_session_id` and `merchant_id`
- The agent has a consistent audit trail across all handler types

---

## ✅ Pre-Submission Checklist

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags — #141
- [x] I have linked the SEP issue number above
- [x] This PR includes updates to OpenAPI/JSON schemas
- [x] This PR includes example requests/responses
- [x] This PR includes a changelog entry in `changelog/unreleased/stripe-link-payment-handler.md`

---

## 📚 Additional Context

### Related specifications

- **Stripe Link docs**: [docs.stripe.com/payments/link](https://docs.stripe.com/payments/link)

### Pattern for future wallet handlers

This SEP establishes the accelerated-checkout / wallet handler pattern in ACP. Credential *acquisition* varies by wallet, but credential *delegation* always goes through `delegate_payment`.

| Property | Tokenized handlers (`dev.acp.tokenized.*`) | Wallet handlers (`com.stripe.link`, etc.) |
|----------|---------------------------------------------|-------------------------------------------|
| Credential acquisition | Agent collects from buyer | Wallet UI collects from buyer |
| `requires_delegate_payment` | `true` | `true` |
| `requires_pci_compliance` | `false` (tokenized) | `false` (wallet handles) |
| Delegation | Agent delegates raw credential | Agent delegates wallet token |
| Checkout submission | Token | Token |
| Agent sees raw credentials | Briefly (before vaulting) | Never |

---

