### PR TITLE
Clarify order status semantics (shipped, fulfilled, delivered) and fulfillment options (fixes #22)

### DIFF
--- a/rfcs/rfc.orders.md
+++ b/rfcs/rfc.orders.md
@@ -126,10 +126,12 @@ The existing `Order` schema gains optional fields:
 - `created` — Order received but not yet confirmed
 - `confirmed` — Order placed successfully
 - `manual_review` — Order held for fraud or manual review
-- `processing` — Being prepared
-- `shipped` — All items handed to carrier
-- `delivered` — All items delivered
+- `shipped` — Physical shipping only: order handed off to carrier, in transit
+- `fulfilled` — Fulfillment completed (terminal). For shipping: delivered or picked up; for digital: delivered or provisioned
+- `delivered` — Equivalent to `fulfilled` for physical shipping (accepted for backward compatibility)
 - `canceled` — Order canceled
+
+**Notes:** `fulfilled` means fulfillment completed (execution done), not "order information is complete" (that is reflected by e.g. `confirmed`). `shipped` MUST NOT be used for digital-only orders. Typical progressions: shipping `confirmed` -> `shipped` -> `fulfilled` (or `delivered`); digital `confirmed` -> `fulfilled`.
 
 ### 4.2 OrderLineItem
 

--- a/spec/2026-01-16/openapi/openapi.agentic_checkout.yaml
+++ b/spec/2026-01-16/openapi/openapi.agentic_checkout.yaml
@@ -817,6 +817,11 @@ components:
           items: { $ref: "#/components/schemas/LineItem" }
         fulfillment_details: { $ref: "#/components/schemas/FulfillmentDetails" }
         fulfillment_options:
+          description: |
+            Available fulfillment options for this checkout/order (e.g., shipping, digital).
+            These are the options offered to the buyer, not necessarily the final selection.
+            The order.status in webhook events reflects the actual fulfillment progress; e.g.,
+            shipped is only applicable when the order is fulfilled via physical shipping.
           type: array
           items:
             oneOf:

--- a/spec/2026-01-16/openapi/openapi.agentic_checkout_webhook.yaml
+++ b/spec/2026-01-16/openapi/openapi.agentic_checkout_webhook.yaml
@@ -63,6 +63,26 @@ paths:
                     refunds:
                       - type: original_payment
                         amount: "1.00"
+              order_updated_shipping_fulfilled:
+                summary: "Shipping flow - order delivered (confirmed -> shipped -> fulfilled)"
+                value:
+                  type: order_update
+                  data:
+                    type: order
+                    checkout_session_id: "checkout_session_123"
+                    permalink_url: "https://example.com/orders/123"
+                    status: fulfilled
+                    refunds: []
+              order_updated_digital_fulfilled:
+                summary: "Digital flow - order provisioned (confirmed -> fulfilled, no shipped)"
+                value:
+                  type: order_update
+                  data:
+                    type: order
+                    checkout_session_id: "checkout_session_456"
+                    permalink_url: "https://example.com/orders/456"
+                    status: fulfilled
+                    refunds: []
       responses:
         "200":
           description: Event accepted
@@ -115,7 +135,17 @@ components:
         status:
           type: string
           enum:
-            [created, manual_review, confirmed, canceled, shipped, fulfilled]
+            [created, manual_review, confirmed, canceled, shipped, delivered, fulfilled]
+          description: |
+            Order lifecycle status.
+            - shipped: Physical shipping only. The order has been handed off to a carrier and is in transit.
+            - fulfilled: Fulfillment completed (terminal). For shipping: delivered or picked up. For digital: delivered or provisioned.
+            - delivered: Equivalent to fulfilled for physical shipping (accepted for backward compatibility).
+            Notes:
+            - fulfilled means fulfillment completed (execution done), not "order information is complete"; the latter is reflected by statuses such as confirmed.
+            - shipped MUST NOT be used for digital-only orders.
+            - For shipping orders the typical progression is confirmed -> shipped -> fulfilled (or delivered).
+            - For digital orders the typical progression is confirmed -> fulfilled.
         refunds:
           type: array
           items: { $ref: "#/components/schemas/Refund" }


### PR DESCRIPTION
## Summary

- Clarifies the semantics of `shipped`, `fulfilled`, and `delivered` in the webhook order status.
- Documents how these statuses apply to shipping vs digital fulfillments.
- Explains that `fulfillment_options` are available options, while `order.status` reflects actual fulfillment progress.
- Aligns the RFC order status documentation with the OpenAPI specs.

## Details

- **Webhook spec (`openapi.agentic_checkout_webhook.yaml`)**
  - Adds a normative description for `status`:
    - `shipped`: physical shipping only, handed off to carrier, in transit.
    - `fulfilled`: terminal status meaning fulfillment completed. For shipping: delivered or picked up. For digital: delivered or provisioned.
    - `delivered`: equivalent to `fulfilled` for physical shipping (backwards compatible).
  - Clarifies that `fulfilled` means execution completed, not merely "order information is complete" (the latter is represented by statuses such as `confirmed`).
  - Adds examples for:
    - Shipping flow: `confirmed -> shipped -> fulfilled`.
    - Digital flow: `confirmed -> fulfilled` (no `shipped`).

- **Checkout spec (`openapi.agentic_checkout.yaml`)**
  - Adds a description to `fulfillment_options` explaining that:
    - It lists available fulfillment options (e.g., shipping, digital), not necessarily the final choice.
    - `order.status` in webhook events reflects the actual fulfillment progress, and `shipped` is only applicable for physical shipping.

- **RFC (`rfc.orders.md`)**
  - Updates the "Order status values" section to match the OpenAPI definitions for `shipped`, `fulfilled`, and `delivered`.
  - States explicitly that `fulfilled` means fulfillment completed (execution done), not just "order information is complete".
  - Notes that `shipped` MUST NOT be used for digital-only orders and documents the typical status progressions.

## Motivation

These changes resolve the ambiguity discussed in [#22](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/issues/22) by providing normative, protocol-level definitions for `shipped` and `fulfilled`, and by clarifying their relationship to fulfillment types and `fulfillment_options`.

Fixes #22.