### PR TITLE
Add optional phone_number to delegate payment address

### DIFF
--- a/changelog/unreleased/add-delegate-payment-phone-number.md
+++ b/changelog/unreleased/add-delegate-payment-phone-number.md
@@ -1,0 +1,17 @@
+## Add optional phone_number to delegate payment address
+
+Add optional `phone_number` to the unreleased delegated payment `Address` schema and example payloads.
+
+### Changes
+- Add optional `phone_number` to `spec/unreleased/openapi/openapi.delegate_payment.yaml`
+- Add optional `phone_number` to `spec/unreleased/json-schema/schema.delegate_payment.json`
+- Update `examples/unreleased/examples.delegate_payment.json` to include `phone_number` in the billing address example
+
+### Files Updated
+- `spec/unreleased/openapi/openapi.delegate_payment.yaml`
+- `spec/unreleased/json-schema/schema.delegate_payment.json`
+- `examples/unreleased/examples.delegate_payment.json`
+- `changelog/unreleased/add-delegate-payment-phone-number.md`
+
+### Reference
+- PR: #<pr-number>

--- a/examples/unreleased/examples.delegate_payment.json
+++ b/examples/unreleased/examples.delegate_payment.json
@@ -34,7 +34,8 @@
       "city": "San Francisco",
       "state": "CA",
       "country": "US",
-      "postal_code": "94131"
+      "postal_code": "94131",
+      "phone_number": "+15552003434"
     },
     "risk_signals": [
       {

--- a/spec/unreleased/json-schema/schema.delegate_payment.json
+++ b/spec/unreleased/json-schema/schema.delegate_payment.json
@@ -42,6 +42,10 @@
           "type": "string",
           "maxLength": 20,
           "description": "ZIP or postal code"
+        },
+        "phone_number": {
+          "type": "string",
+          "description": "Contact phone number. E.164 format recommended (e.g., +15551234567)."
         }
       },
       "required": [
@@ -59,7 +63,8 @@
         "city": "San Francisco",
         "state": "CA",
         "country": "US",
-        "postal_code": "94102"
+        "postal_code": "94102",
+        "phone_number": "+15552003434"
       }
     },
     "PaymentMethodCard": {

--- a/spec/unreleased/openapi/openapi.delegate_payment.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_payment.yaml
@@ -73,6 +73,7 @@ paths:
                     state: CA
                     country: US
                     postal_code: "12345"
+                    phone_number: "+15552003434"
                   risk_signals:
                     - type: card_testing
                       score: 10
@@ -509,6 +510,9 @@ components:
           type: string
           maxLength: 20
           description: ZIP or postal code
+        phone_number:
+          type: string
+          description: Contact phone number. E.164 format recommended (e.g., +15551234567).
       required:
         - name
         - line_one
@@ -524,6 +528,7 @@ components:
         state: CA
         country: US
         postal_code: "94102"
+        phone_number: "+15552003434"
       description: Physical address for billing or shipping purposes
     Allowance:
       type: object


### PR DESCRIPTION
# Add optional phone_number to delegate payment address

## 🔧 Type of Change

- [ ] Documentation fix/improvement
- [ ] Bug fix (non-breaking)
- [ ] Tooling improvement
- [x] Example update
- [x] Minor data/enum addition
- [ ] Other: N/A

---

## 📝 Description

This PR adds optional `phone_number` to the delegate payment `Address` schema in the unreleased OpenAPI and JSON Schema artifacts, and updates the unreleased delegate payment example payload accordingly.

---

## 🎯 Motivation and Context

The delegated payment `Address` schema currently omits `phone_number`, while related ACP address shapes already allow it. This change aligns the unreleased delegate payment schema with existing usage where billing and shipping addresses may include an optional phone number.

Fixes/Addresses: aligns delegated payment Address with existing optional phone_number usage

---

## 🧪 Testing

- Ran `pnpm run validate:all`
- Validation passed with no errors or warnings

---

## 📸 Screenshots / Examples

Updated example payload:

```json
"billing_address": {
  "name": "Ada Lovelace",
  "line_one": "1234 Chat Road",
  "line_two": "",
  "city": "San Francisco",
  "state": "CA",
  "country": "US",
  "postal_code": "94131",
  "phone_number": "+15552003434"
}
```

---

## ✅ Checklist

Before submitting, ensure:

- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (if applicable)
- [x] I have added/updated examples (if applicable)
- [x] I have added a changelog entry file to `changelog/unreleased/your-change-description.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [x] All CI checks pass

---

## 🔍 Scope Verification

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ This is a minor, straightforward change

---

## 📚 Additional Notes

This PR updates the `unreleased` delegate payment spec artifacts, matching the ACP repo's normal process for new specification changes.
