### PR TITLE
ADMIN: Add CODEOWNERS for founding maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 /.github/CODEOWNERS @agentic-commerce-protocol/founding-maintainers
-/AGENTS.md @agentic-commerce-protocol/founding-maintainers
 /CONTRIBUTING.md @agentic-commerce-protocol/founding-maintainers
 /CODE_OF_CONDUCT.md @agentic-commerce-protocol/founding-maintainers
 /MAINTAINERS.md @agentic-commerce-protocol/founding-maintainers


### PR DESCRIPTION
# ADMIN: Add CODEOWNERS

## 🔑 Admin Action
- [x] Other administrative change: adding codeowners for protected main branch.

---

## 📝 Summary
With introduction of TSC which will have more users with `maintainer` access to repos, ensuring certain legal, governance & admin files get reviewed by founding maintainers.


---

## 🔗 Reference
N/A

---

## ✅ Admin Checklist

- [x] I am an admin or authorized representative

---

**Process**: Admin PRs require approval from another admin. See [governance.md](../../docs/governance.md) and [CORPORATE_PROCESS.md](../../legal/cla/CORPORATE_PROCESS.md) for the full maintainer workflow.



