### PR TITLE
SEP: Move extensions from capabilities to protocol

### DIFF
--- a/changelog/unreleased/discovery-well-known.md
+++ b/changelog/unreleased/discovery-well-known.md
@@ -12,10 +12,10 @@
 
 - **DiscoveryResponse**: Top-level document containing protocol metadata, API base URL, supported
   transports, and a capabilities object.
-- **DiscoveryCapabilities**: Seller capabilities wrapper containing services, extensions,
+- **DiscoveryCapabilities**: Seller capabilities wrapper containing services,
   intervention types, supported currencies, and supported locales.
 - **DiscoveryProtocol**: Protocol identification with name (`acp`), current version,
-  supported version history (chronologically ordered), and documentation URL.
+  supported version history (chronologically ordered), documentation URL, and supported extensions.
 - **DiscoveryExtension**: Lightweight extension declaration with name and optional spec URL.
 
 ## Design Notes

--- a/changelog/unreleased/move-extensions-to-protocol.md
+++ b/changelog/unreleased/move-extensions-to-protocol.md
@@ -1,0 +1,19 @@
+# Move Extensions to Protocol
+
+**Changed** -- extension declarations now live under `protocol` instead of `capabilities` in unreleased ACP checkout response and discovery payloads.
+
+## What Changed
+
+- **Checkout responses** now return active session extensions in `protocol.extensions`.
+- **Discovery** now exposes supported extensions in `protocol.extensions` instead of `capabilities.extensions`.
+- **Capabilities cleanup** keeps `capabilities` focused on negotiated payment and intervention behavior.
+
+## Files Changed
+
+- `spec/unreleased/json-schema/schema.agentic_checkout.json`
+- `spec/unreleased/openapi/openapi.agentic_checkout.yaml`
+- `spec/unreleased/json-schema/schema.extension.json`
+- `examples/unreleased/examples.agentic_checkout.json`
+- `rfcs/rfc.extensions.md`
+- `rfcs/rfc.discount_extension.md`
+- `rfcs/rfc.discovery.md`

--- a/examples/unreleased/examples.agentic_checkout.json
+++ b/examples/unreleased/examples.agentic_checkout.json
@@ -1470,19 +1470,7 @@
         "2026-01-16",
         "2026-01-30"
       ],
-      "documentation_url": "https://agenticcommerce.dev"
-    },
-    "api_base_url": "https://acp.stripe.com/api",
-    "transports": [
-      "rest",
-      "mcp"
-    ],
-    "capabilities": {
-      "services": [
-        "checkout",
-        "orders",
-        "delegate_payment"
-      ],
+      "documentation_url": "https://agenticcommerce.dev",
       "extensions": [
         {
           "name": "discount",
@@ -1494,6 +1482,18 @@
           "spec": "https://agenticcommerce.dev/specs/fulfillment",
           "schema": "https://agenticcommerce.dev/schemas/fulfillment.json"
         }
+      ]
+    },
+    "api_base_url": "https://acp.stripe.com/api",
+    "transports": [
+      "rest",
+      "mcp"
+    ],
+    "capabilities": {
+      "services": [
+        "checkout",
+        "orders",
+        "delegate_payment"
       ],
       "intervention_types": [
         "3ds",

--- a/rfcs/rfc.discount_extension.md
+++ b/rfcs/rfc.discount_extension.md
@@ -49,13 +49,13 @@ This extension introduces:
 
 ## 3. Extension Declaration
 
-Merchants advertise discount support via `capabilities.extensions` in checkout
+Merchants advertise discount support via `protocol.extensions` in checkout
 responses:
 
 ```json
 {
-  "capabilities": {
-    "payment_methods": ["card"],
+  "protocol": {
+    "version": "2026-01-30",
     "extensions": [
       {
         "name": "discount",
@@ -315,8 +315,8 @@ Applied discounts are reflected in the core checkout fields:
 ```json
 {
   "id": "checkout_session_123",
-  "capabilities": {
-    "payment_methods": ["card"],
+  "protocol": {
+    "version": "2026-01-30",
     "extensions": [
       {
         "name": "discount",
@@ -584,4 +584,3 @@ takes precedence.
 ## 13. Change Log
 
 - **2026-01-27**: Initial draft
-

--- a/rfcs/rfc.discovery.md
+++ b/rfcs/rfc.discovery.md
@@ -209,16 +209,16 @@ Cache-Control: public, max-age=3600
     "name": "acp",
     "version": "2026-01-30",
     "supported_versions": ["2025-09-29", "2025-12-12", "2026-01-16", "2026-01-30"],
-    "documentation_url": "https://agenticcommerce.dev"
+    "documentation_url": "https://agenticcommerce.dev",
+    "extensions": [
+      { "name": "discount", "spec": "https://agenticcommerce.dev/specs/discount", "schema": "https://agenticcommerce.dev/schemas/discount.json" },
+      { "name": "fulfillment", "spec": "https://agenticcommerce.dev/specs/fulfillment", "schema": "https://agenticcommerce.dev/schemas/fulfillment.json" }
+    ]
   },
   "api_base_url": "https://acp.stripe.com/api",
   "transports": ["rest", "mcp"],
   "capabilities": {
     "services": ["checkout", "orders", "delegate_payment"],
-    "extensions": [
-      { "name": "discount", "spec": "https://agenticcommerce.dev/specs/discount", "schema": "https://agenticcommerce.dev/schemas/discount.json" },
-      { "name": "fulfillment", "spec": "https://agenticcommerce.dev/specs/fulfillment", "schema": "https://agenticcommerce.dev/schemas/fulfillment.json" }
-    ],
     "intervention_types": ["3ds", "biometric", "address_verification"],
     "supported_currencies": ["usd", "eur", "gbp"],
     "supported_locales": ["en-US", "fr-FR", "de-DE"]
@@ -253,7 +253,7 @@ An agent uses discovery to bootstrap its interaction with a seller:
 4. Agent reads `api_base_url` to learn where to send API requests.
 5. Agent checks `protocol.supported_versions` to confirm its preferred API version is listed.
 6. Agent checks `capabilities.services` to confirm `"checkout"` is available.
-7. Agent checks `capabilities.extensions` to see if `"discount"` is supported, informing whether to include discount codes in the checkout request.
+7. Agent checks `protocol.extensions` to see if `"discount"` is supported, informing whether to use discount extension fields in checkout requests.
 8. Agent checks `transports` to determine whether to use REST or MCP.
 9. Agent proceeds to `POST {api_base_url}/checkout_sessions` with its inline capabilities for session-level negotiation.
 
@@ -269,7 +269,7 @@ Discovery and capability negotiation are complementary mechanisms at different s
 |---|---|---|
 | **Scope** | Seller's capabilities | Session-specific capabilities |
 | **Authentication** | None required | Bearer token required |
-| **Content** | Protocol version, services, extensions, transports | Payment methods, payment handlers, intervention intersection |
+| **Content** | Protocol version, protocol extensions, services, transports | Payment methods, payment handlers, intervention intersection |
 | **Variability** | Stable across sessions | Varies per session, per rollout state |
 | **Cacheability** | Cacheable (hours to days) | Per-session only |
 | **Purpose** | "Can I use ACP here? Where is the API?" | "What works for this transaction?" |
@@ -340,7 +340,7 @@ Agents that do not use discovery continue to work exactly as before. Discovery i
 **SHOULD requirements:**
 
 - [ ] SHOULD include a `Cache-Control` response header with at least `public, max-age=3600`
-- [ ] SHOULD include `extensions` when the seller supports extensions
+- [ ] SHOULD include `protocol.extensions` when the seller supports extensions
 - [ ] SHOULD include `intervention_types` when the seller supports interventions
 - [ ] SHOULD include `supported_currencies` and `supported_locales` when known
 - [ ] SHOULD apply rate limiting to the document

--- a/rfcs/rfc.extensions.md
+++ b/rfcs/rfc.extensions.md
@@ -6,9 +6,8 @@
 
 This RFC defines the **ACP Extensions Framework**, a mechanism that enables
 merchants to advertise and platforms to discover optional capabilities that
-extend the core checkout specification. Extensions integrate with the existing
-capability negotiation system. The first extension defined under this framework
-is the **Discount Extension**.
+extend the core checkout specification. The first extension defined under this
+framework is the **Discount Extension**.
 
 ---
 
@@ -16,8 +15,8 @@ is the **Discount Extension**.
 
 - Provide a **standardized extension mechanism** for ACP that enables optional
   capabilities without breaking backward compatibility.
-- Integrate with the existing **capability negotiation** pattern, using the
-  unified `capabilities` object for discovery.
+- Integrate with ACP response and discovery metadata so platforms can determine
+  which extensions are active or available.
 - Enable **schema clarity** so platforms know which parts of the API each
   extension affects.
 - Define a **Discount Extension** as the first implementation, delivering
@@ -43,16 +42,13 @@ standardized patterns for:
 - Platforms to **discover and negotiate** capabilities before checkout
 - New capabilities to be **added composably** without modifying the core specification
 
-### 2.2 Integration with Capability Negotiation
+### 2.2 Integration with ACP Metadata
 
-Extensions integrate with the existing capability negotiation system (see
-[RFC: Capability Negotiation](./rfc.capability_negotiation.md)):
+Extensions integrate with ACP protocol metadata:
 
-- Agents declare supported extensions in request `capabilities.extensions`
-- Merchants respond with active extensions in response `capabilities.extensions`
-
-The same `capabilities` object is used for both requests and responses; context
-determines which party is declaring.
+- Merchants advertise supported extensions in discovery `protocol.extensions`
+- Merchants respond with active extensions in checkout response
+  `protocol.extensions`
 
 ### 2.3 Discount Extension
 
@@ -70,14 +66,14 @@ The Discount Extension enhances the existing `coupons` array with:
 ### 3.1 Response Format
 
 Merchants advertise extension support in the checkout response via
-`capabilities.extensions`:
+`protocol.extensions`:
 
 ```json
 {
   "id": "checkout_session_123",
   "status": "ready_for_payment",
-  "capabilities": {
-    "payment_methods": ["card"],
+  "protocol": {
+    "version": "2026-01-30",
     "extensions": [
       {
         "name": "discount",
@@ -92,25 +88,9 @@ Merchants advertise extension support in the checkout response via
 }
 ```
 
-### 3.2 Request Format
-
-Agents **MAY** indicate which extensions they support in the request:
-
-```json
-{
-  "line_items": [{"id": "item_123", "quantity": 1}],
-  "capabilities": {
-    "extensions": ["discount", "loyalty"]
-  }
-}
-```
-
-When an agent declares supported extensions, merchants **SHOULD** activate
-those extensions if available.
-
 ### 3.3 Extension Object
 
-Each extension in the response `capabilities.extensions` is an object:
+Each extension in the response `protocol.extensions` is an object:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -248,22 +228,22 @@ Third-party extensions **SHOULD** use reverse-domain naming to avoid conflicts:
 
 ## 4. Extension Negotiation
 
-Extension negotiation follows the same pattern as capability negotiation:
+Extension activation is communicated through discovery and checkout responses:
 
 ```mermaid
 sequenceDiagram
     participant Agent
     participant Merchant
     
-    Agent->>Merchant: POST /checkout_sessions<br/>capabilities.extensions: ["discount"]
-    Merchant->>Agent: 201 Created<br/>capabilities.extensions: [{name: "discount", extends: [...]}]
+    Agent->>Merchant: POST /checkout_sessions
+    Merchant->>Agent: 201 Created<br/>protocol.extensions: [{name: "discount", extends: [...]}]
     Note over Agent: Agent now knows discount<br/>extension is active
 ```
 
-1. **Agent Request**: Agent sends `capabilities.extensions` listing
-   extensions it understands.
+1. **Discovery**: Agent reads discovery `protocol.extensions` to determine
+   whether an extension is supported.
 
-2. **Merchant Response**: Merchant includes `capabilities.extensions`
+2. **Merchant Response**: Merchant includes `protocol.extensions`
    with active extension objects for this session.
 
 3. **Schema Resolution**: Agent interprets response using base schema
@@ -271,7 +251,7 @@ sequenceDiagram
 
 ### 4.1 Backward Compatibility
 
-- The `extensions` array in `capabilities` is **OPTIONAL**
+- The `extensions` array in `protocol` is **OPTIONAL**
 - Merchants not supporting extensions omit the array
 - Agents **MUST** handle responses with or without extensions
 - Extension-specific fields are ignored by clients that don't support them
@@ -343,7 +323,8 @@ use the same YYYY-MM-DD format:
 
 ```json
 {
-  "capabilities": {
+  "protocol": {
+    "version": "2026-01-30",
     "extensions": [
       {
         "name": "discount@2026-01-27",
@@ -383,9 +364,9 @@ See the following files for the reference implementation:
 
 ## 9. Conformance Checklist
 
-- [ ] Supports `capabilities.extensions` array in checkout responses
+- [ ] Supports `protocol.extensions` array in checkout responses
 - [ ] Returns extension objects with `name` and optional `extends` field
-- [ ] Handles `capabilities.extensions` in requests (optional)
+- [ ] Uses discovery `protocol.extensions` to determine extension support
 - [ ] Ignores unknown extension fields gracefully
 - [ ] Validates extension-specific inputs
 - [ ] Returns extension-specific error codes in `messages[]`
@@ -395,4 +376,3 @@ See the following files for the reference implementation:
 ## 10. Change Log
 
 - **2026-01-27**: Initial draft defining extensions framework
-

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -639,28 +639,6 @@
         },
         "interventions": {
           "$ref": "#/$defs/InterventionCapabilities"
-        },
-        "extensions": {
-          "oneOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "description": "Extension identifier string"
-              },
-              "uniqueItems": true,
-              "description": "Extensions the agent understands (request). Simple identifiers like 'discount'."
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/$defs/ExtensionDeclaration"
-              },
-              "uniqueItems": true,
-              "description": "Active extensions for this session (response). Objects with name, extends, schema, spec."
-            }
-          ],
-          "description": "Extensions supported by the party. Requests: array of extension identifiers. Responses: array of extension declaration objects."
         }
       },
       "example": {
@@ -669,17 +647,13 @@
             "3ds"
           ],
           "display_context": "native"
-        },
-        "extensions": [
-          "discount",
-          "affiliate_attribution"
-        ]
+        }
       }
     },
     "ExtensionDeclaration": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Extension declaration in capabilities.extensions (response). Describes an active extension and which schema fields it adds.",
+      "description": "Extension declaration in protocol.extensions (response). Describes an active extension and which schema fields it adds.",
       "required": [
         "name"
       ],
@@ -2126,23 +2100,55 @@
         "token": "vt_01J8Z3WXYZ9ABC123"
       }
     },
-    "ProtocolVersion": {
+    "Protocol": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Protocol metadata included in checkout responses. Indicates the ACP version.",
+      "description": "Protocol metadata included in checkout responses. Carries the ACP version and active protocol extensions for the session.",
       "properties": {
         "version": {
           "type": "string",
           "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
           "example": "2026-01-27",
           "description": "ACP protocol version in YYYY-MM-DD format."
+        },
+        "extensions": {
+          "oneOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9_-]*(@\\d{4}-\\d{2}-\\d{2})?$|^[a-z][a-z0-9]*(?:\\.[a-z][a-z0-9_-]*)+(@\\d{4}-\\d{2}-\\d{2})?$",
+                "description": "Extension identifier string"
+              },
+              "uniqueItems": true,
+              "description": "Extensions the agent understands for this request."
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ExtensionDeclaration"
+              },
+              "uniqueItems": true,
+              "description": "Active protocol extensions for this session."
+            }
+          ],
+          "description": "Protocol extensions. Requests use identifiers; responses use extension declaration objects."
         }
       },
-      "required": [
-        "version"
-      ],
       "example": {
-        "version": "2026-01-30"
+        "version": "2026-01-30",
+        "extensions": [
+          {
+            "name": "discount",
+            "extends": [
+              "$.CheckoutSessionCreateRequest.discounts",
+              "$.CheckoutSessionUpdateRequest.discounts",
+              "$.CheckoutSession.discounts"
+            ],
+            "schema": "https://agenticcommerce.dev/schemas/discount/2026-01-27.json",
+            "spec": "https://agenticcommerce.dev/specs/discount"
+          }
+        ]
       }
     },
     "DiscountAllocation": {
@@ -3140,7 +3146,7 @@
           "description": "Unique identifier for the checkout session"
         },
         "protocol": {
-          "$ref": "#/$defs/ProtocolVersion",
+          "$ref": "#/$defs/Protocol",
           "description": "Protocol version metadata"
         },
         "capabilities": {
@@ -3716,13 +3722,6 @@
           "uniqueItems": true,
           "description": "Services available from this seller. Indicates which ACP operations are implemented. This enum is closed per API version; new values are introduced in new API versions. Agents MAY treat the set as exhaustive for a given version."
         },
-        "extensions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/DiscoveryExtension"
-          },
-          "description": "Extensions the seller supports. Whether a specific extension is active for a given session is determined during checkout session creation."
-        },
         "intervention_types": {
           "type": "array",
           "items": {
@@ -3755,7 +3754,6 @@
       "required": ["services"],
       "example": {
         "services": ["checkout", "orders", "delegate_payment"],
-        "extensions": [{ "name": "discount", "spec": "https://agenticcommerce.dev/specs/discount", "schema": "https://agenticcommerce.dev/schemas/discount.json" }],
         "intervention_types": ["3ds"],
         "supported_currencies": ["usd", "eur"],
         "supported_locales": ["en-US"]
@@ -3790,6 +3788,13 @@
           "type": "string",
           "format": "uri",
           "description": "URL to the seller's ACP documentation."
+        },
+        "extensions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DiscoveryExtension"
+          },
+          "description": "Protocol extensions the seller supports. Whether a specific extension is active for a given session is determined during checkout session creation."
         }
       },
       "required": ["name", "version", "supported_versions"],
@@ -3797,7 +3802,14 @@
         "name": "acp",
         "version": "2026-01-30",
         "supported_versions": ["2025-09-29", "2026-01-30"],
-        "documentation_url": "https://agenticcommerce.dev"
+        "documentation_url": "https://agenticcommerce.dev",
+        "extensions": [
+          {
+            "name": "discount",
+            "spec": "https://agenticcommerce.dev/specs/discount",
+            "schema": "https://agenticcommerce.dev/schemas/discount.json"
+          }
+        ]
       }
     },
     "DiscoveryExtension": {

--- a/spec/unreleased/json-schema/schema.extension.json
+++ b/spec/unreleased/json-schema/schema.extension.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://agentic-commerce-protocol.com/schemas/extension.json",
   "title": "ACP Extension Schema",
-  "description": "Schema definitions for the ACP Extensions Framework. Extensions are optional, composable capabilities declared in capabilities.extensions.",
+  "description": "Schema definitions for the ACP Extensions Framework. Extensions are optional, composable capabilities declared in protocol.extensions.",
   "$defs": {
     "extension_identifier": {
       "type": "string",
@@ -18,7 +18,7 @@
     },
     "extension_declaration": {
       "type": "object",
-      "description": "Extension declaration in capabilities.extensions (response). Describes an active extension and which schema fields it adds.",
+      "description": "Extension declaration in protocol.extensions (response). Describes an active extension and which schema fields it adds.",
       "required": [
         "name"
       ],
@@ -63,7 +63,7 @@
         "$ref": "#/$defs/extension_identifier"
       },
       "uniqueItems": true,
-      "description": "Extensions the agent understands. Sent in request capabilities.extensions.",
+      "description": "Extensions the agent understands. Sent in request protocol.extensions.",
       "example": [
         "discount",
         "affiliate_attribution"
@@ -75,7 +75,7 @@
         "$ref": "#/$defs/extension_declaration"
       },
       "uniqueItems": true,
-      "description": "Active extensions for this session. Returned in response capabilities.extensions.",
+      "description": "Active extensions for this session. Returned in response protocol.extensions.",
       "example": [
         {
           "name": "discount",

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -879,35 +879,15 @@ components:
           $ref: "#/components/schemas/Payment"
         interventions:
           $ref: "#/components/schemas/InterventionCapabilities"
-        extensions:
-          oneOf:
-            - type: array
-              items:
-                type: string
-                description: Extension identifier string
-              uniqueItems: true
-              description: Extensions the agent understands (request). Simple identifiers like 'discount'.
-            - type: array
-              items:
-                $ref: "#/components/schemas/ExtensionDeclaration"
-              uniqueItems: true
-              description: Active extensions for this session (response). Objects with name, extends, schema, spec.
-          description: |
-            Extensions supported by the party.
-            Requests: array of extension identifiers.
-            Responses: array of extension declaration objects.
       example:
         interventions:
           supported:
             - 3ds
           display_context: native
-        extensions:
-          - discount
-          - affiliate_attribution
     ExtensionDeclaration:
       type: object
       additionalProperties: false
-      description: Extension declaration in capabilities.extensions (response). Describes an active extension and which schema fields it adds.
+      description: Extension declaration in protocol.extensions (response). Describes an active extension and which schema fields it adds.
       required:
         - name
       properties:
@@ -2479,20 +2459,41 @@ components:
         currency: usd
         reason: Customer request
         created_at: "2026-02-14T10:00:00Z"
-    ProtocolVersion:
+    Protocol:
       type: object
       additionalProperties: false
-      description: Protocol metadata included in checkout responses. Indicates the ACP version.
+      description: Protocol metadata included in checkout responses. Carries the ACP version and active protocol extensions for the session.
       properties:
         version:
           type: string
           pattern: ^\d{4}-\d{2}-\d{2}$
           example: "2026-01-27"
           description: ACP protocol version in YYYY-MM-DD format.
-      required:
-        - version
+        extensions:
+          oneOf:
+            - type: array
+              items:
+                type: string
+                pattern: ^[a-z][a-z0-9_-]*(@\d{4}-\d{2}-\d{2})?$|^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_-]*)+(@\d{4}-\d{2}-\d{2})?$
+                description: Extension identifier string
+              uniqueItems: true
+              description: Extensions the agent understands for this request.
+            - type: array
+              items:
+                $ref: "#/components/schemas/ExtensionDeclaration"
+              uniqueItems: true
+              description: Active protocol extensions for this session.
+          description: Protocol extensions. Requests use identifiers; responses use extension declaration objects.
       example:
         version: "2026-01-30"
+        extensions:
+          - name: discount
+            extends:
+              - $.CheckoutSessionCreateRequest.discounts
+              - $.CheckoutSessionUpdateRequest.discounts
+              - $.CheckoutSession.discounts
+            schema: https://agenticcommerce.dev/schemas/discount/2026-01-27.json
+            spec: https://agenticcommerce.dev/specs/discount
     DiscountAllocation:
       type: object
       additionalProperties: false
@@ -2725,8 +2726,6 @@ components:
         id:
           type: string
           description: Unique identifier for the checkout session
-        protocol:
-          $ref: "#/components/schemas/ProtocolVersion"
         capabilities:
           $ref: "#/components/schemas/Capabilities"
         buyer:


### PR DESCRIPTION
# SEP: Move extensions from capabilities to protocol

## 📋 SEP Metadata

- **SEP Number**: #177 
- **Author(s)**: Aravind Rao
- **Status**: `proposal`
- **Type**: [X] Major Change [ ] Process Change

---

## 🎯 Abstract

This PR proposes moving ACP extension declarations from `capabilities.extensions` to `protocol.extensions`.

The updated model is:

* Discovery advertises supported extensions in `protocol.extensions`
* Checkout responses return active session extensions in `protocol.extensions`

This keeps extension declarations in protocol metadata, where they fit conceptually, while keeping `capabilities` focused on negotiated commerce behavior such as interventions and payment handling.

---

## 💡 Motivation

`capabilities` and `extensions` represent different kinds of information.

Capabilities describe transactional behavior for a session, for example:

* intervention support
* payment handler availability
* other negotiated runtime behavior

Extensions describe how to interpret the payload and schema, for example:

* which extension-defined fields may appear
* which schema locations are extended
* which extension schemas and specs apply

That makes `protocol` a better home for extensions than `capabilities`.

---

## 📐 Specification

This proposal makes the following normative changes in unreleased ACP:

1. Remove `extensions` from `Capabilities`
2. Add `extensions` to checkout response `Protocol`
3. Add `extensions` to `DiscoveryProtocol`

Example checkout response:

```json
{
  "id": "checkout_session_123",
  "protocol": {
    "version": "2026-01-30",
    "extensions": [
      {
        "name": "discount",
        "extends": [
          "$.CheckoutSessionCreateResoponse.discounts",
        ],
        "schema": "https://example.com/schemas/discount.json",
        "spec": "https://example.com/specs/discount"
      }
    ]
  },
  "capabilities": {
    "payment": {
      "handlers": []
    },
    "interventions": {
      "supported": ["3ds"],
      "required": [],
      "enforcement": "conditional"
    }
  }
}
```

Example discovery document:

```json
{
  "protocol": {
    "name": "acp",
    "version": "2026-01-30",
    "supported_versions": ["2025-09-29", "2026-01-30"],
    "extensions": [
      {
        "name": "discount",
        "spec": "https://example.com/specs/discount",
        "schema": "https://example.com/schemas/discount.json"
      }
    ]
  },
  "api_base_url": "https://merchant.example.com/api",
  "transports": ["rest"],
  "capabilities": {
    "services": ["checkout"]
  }
}
```

---

## 🤔 Rationale

This structure gives ACP a cleaner split:

* `protocol` for versioning and extension metadata
* `capabilities` for negotiated runtime behavior

That is a simpler and more defensible contract for implementers, SDK authors, and schema tooling.

---

## 🔄 Backward Compatibility

This is a breaking change for unreleased implementations that currently read or write `capabilities.extensions`.

Migration path:

* discovery: `capabilities.extensions` -> `protocol.extensions`
* checkout response: `capabilities.extensions` -> `protocol.extensions`

Implementations should:

* read extension support from discovery `protocol.extensions`
* read active extensions from checkout response `protocol.extensions`

---

## 🛠️ Reference Implementation

This PR updates the unreleased specification and related examples/docs in:

* `spec/unreleased/json-schema/schema.agentic_checkout.json`
* `spec/unreleased/openapi/openapi.agentic_checkout.yaml`
* `spec/unreleased/json-schema/schema.extension.json`
* `examples/unreleased/examples.agentic_checkout.json`
* `examples/unreleased/examples.mcp.agentic_checkout.json`
* `rfcs/rfc.extensions.md`
* `rfcs/rfc.discount_extension.md`
* `rfcs/rfc.discovery.md`
* `changelog/unreleased/move-extensions-to-protocol.md`

---

## 🔒 Security Implications

This proposal does not introduce new authentication, authorization, or payment flows.

The main effect is clearer protocol interpretation:

* extension metadata is surfaced explicitly in protocol metadata
* agents can make extension decisions from discovery before constructing requests

No new sensitive data is introduced by this change.

---

## 📚 Additional Context

N/A

---

## 🙋 Questions for Reviewers

N/A

---

## ✅ Pre-Submission Checklist

Before submitting this SEP PR, ensure:

* [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
* [x] I have linked the SEP issue number above
* [x] I have discussed this proposal in the community (Discord/GitHub Discussions)
* [x] I have signed the Contributor License Agreement (CLA)
* [x] This PR includes updates to OpenAPI/JSON schemas (if applicable)
* [x] This PR includes example requests/responses (if applicable)
* [x] This PR includes a changelog entry file in `changelog/unreleased/your-change-description.md`
* [x] I am seeking or have found a sponsor (Founding Maintainer)


---