### PR TITLE
SEP: Add Cart Capability

### DIFF
--- a/changelog/unreleased/cart.md
+++ b/changelog/unreleased/cart.md
@@ -13,15 +13,8 @@
 
 - **Cart**: Response object with `id`, `line_items`, `buyer`, `currency`, `totals`, `messages`,
   `continue_url`, and `expires_at`. Reuses existing ACP types (LineItem, Buyer, Total, Message).
-- **CartCreateRequest**: `line_items` (required), `buyer`, `locale`, `discounts`, `metadata`.
-- **CartUpdateRequest**: `line_items` (required), `buyer`, `discounts`.
-
-## Cart-to-Checkout Conversion
-
-- **`cart_id`** added as an optional field on `CheckoutSessionCreateRequest`. When present,
-  the seller initializes the checkout session from the cart's line items and buyer information.
-- Conversion is idempotent: if an incomplete checkout already exists for the given `cart_id`,
-  the seller returns the existing session.
+- **CartCreateRequest**: `line_items` (required), `buyer`, `locale`.
+- **CartUpdateRequest**: `line_items` (required), `buyer`.
 
 ## Discovery Integration
 
@@ -30,16 +23,17 @@
 
 ## Design Notes
 
+- Carts are scoped to a single seller.
 - Carts have no status lifecycle — they either exist or return 404.
 - Carts have no capability negotiation — that occurs at checkout creation time.
 - Carts have no payment data — payment is a checkout concern.
 - Totals on carts are estimates (e.g., tax may be omitted if address is unknown).
-- Carts support the discount extension for applying codes during browsing.
+- Cart-to-checkout conversion (via `cart_id`) and extension support (e.g., discounts) are deferred to follow-up SEPs.
 
 **Files changed:**
 
 - `spec/unreleased/json-schema/schema.cart.json` (new)
 - `spec/unreleased/openapi/openapi.cart.yaml` (new)
-- `spec/unreleased/json-schema/schema.agentic_checkout.json` (cart_id on checkout create, carts in discovery services)
+- `spec/unreleased/json-schema/schema.agentic_checkout.json` (carts in discovery services enum)
 - `rfcs/rfc.cart.md` (new)
 - `rfcs/rfc.discovery.md` (carts in services enum)

--- a/changelog/unreleased/cart.md
+++ b/changelog/unreleased/cart.md
@@ -6,7 +6,7 @@
 
 - **`POST /carts`** -- Create a new cart with line items and optional buyer information.
 - **`GET /carts/{id}`** -- Retrieve the current state of a cart.
-- **`POST /carts/{id}`** -- Update a cart (full replacement of line items).
+- **`PUT /carts/{id}`** -- Update a cart (full replacement of line items).
 - **`POST /carts/{id}/cancel`** -- Cancel a cart and return its final state.
 
 ## New Schemas

--- a/changelog/unreleased/cart.md
+++ b/changelog/unreleased/cart.md
@@ -1,0 +1,45 @@
+# Cart Capability
+
+**Added** -- pre-checkout cart management for incremental basket building.
+
+## New Endpoints
+
+- **`POST /carts`** -- Create a new cart with line items and optional buyer information.
+- **`GET /carts/{id}`** -- Retrieve the current state of a cart.
+- **`POST /carts/{id}`** -- Update a cart (full replacement of line items).
+- **`POST /carts/{id}/cancel`** -- Cancel a cart and return its final state.
+
+## New Schemas
+
+- **Cart**: Response object with `id`, `line_items`, `buyer`, `currency`, `totals`, `messages`,
+  `continue_url`, and `expires_at`. Reuses existing ACP types (LineItem, Buyer, Total, Message).
+- **CartCreateRequest**: `line_items` (required), `buyer`, `locale`, `discounts`, `metadata`.
+- **CartUpdateRequest**: `line_items` (required), `buyer`, `discounts`.
+
+## Cart-to-Checkout Conversion
+
+- **`cart_id`** added as an optional field on `CheckoutSessionCreateRequest`. When present,
+  the seller initializes the checkout session from the cart's line items and buyer information.
+- Conversion is idempotent: if an incomplete checkout already exists for the given `cart_id`,
+  the seller returns the existing session.
+
+## Discovery Integration
+
+- **`"carts"`** added to the `capabilities.services` enum in the discovery document
+  (`/.well-known/acp.json`). Agents check for `"carts"` before attempting cart operations.
+
+## Design Notes
+
+- Carts have no status lifecycle — they either exist or return 404.
+- Carts have no capability negotiation — that occurs at checkout creation time.
+- Carts have no payment data — payment is a checkout concern.
+- Totals on carts are estimates (e.g., tax may be omitted if address is unknown).
+- Carts support the discount extension for applying codes during browsing.
+
+**Files changed:**
+
+- `spec/unreleased/json-schema/schema.cart.json` (new)
+- `spec/unreleased/openapi/openapi.cart.yaml` (new)
+- `spec/unreleased/json-schema/schema.agentic_checkout.json` (cart_id on checkout create, carts in discovery services)
+- `rfcs/rfc.cart.md` (new)
+- `rfcs/rfc.discovery.md` (carts in services enum)

--- a/docs/sep-cart-capability.md
+++ b/docs/sep-cart-capability.md
@@ -1,0 +1,149 @@
+# SEP: Cart Capability for Pre-Checkout Basket Building
+
+## SEP Metadata
+
+- **SEP Number**: #187
+- **Status**: `proposal`
+- **Type**: [x] Major Change [ ] Process Change
+- **Related Issues/RFCs**: `rfcs/rfc.cart.md`
+
+---
+
+## Abstract
+
+This SEP introduces a **Cart** capability to ACP -- a lightweight CRUD interface for pre-checkout basket building. Agents frequently build baskets incrementally ("add this, remove that, what's the total?") before the buyer expresses purchase intent. Today, ACP requires creating a full checkout session for this, which triggers capability negotiation, payment handler configuration, and status lifecycle management -- all unnecessary overhead for browsing.
+
+The cart provides four endpoints (`POST /carts`, `GET /carts/{id}`, `PUT /carts/{id}`, `POST /carts/{id}/cancel`) with estimated pricing and session persistence. No new domain types are introduced; carts reuse existing ACP types (LineItem, Buyer, Total, Message).
+
+---
+
+## Motivation
+
+ACP's checkout session is designed for purchase finalization, but agents need a pre-purchase exploration phase. Without a cart:
+
+* **Agents must create heavyweight checkout sessions for browsing** -- triggering capability negotiation, payment handler setup, and status lifecycle for what is essentially adding items to a basket.
+* **Agents must track items client-side** -- meaning the seller has no visibility into browsing behavior, cannot provide estimated pricing, and cannot validate item availability until checkout.
+* **No session persistence** -- there's no way to save a basket across agent sessions or share it via a URL for human-in-the-loop flows.
+* **No incremental building** -- the common pattern of "add this... add that... remove that... check out" doesn't map cleanly to checkout session semantics.
+
+Carts solve these by providing a binary-state (exists / not found) resource with estimated totals, no payment configuration, and no status lifecycle. The typical flow becomes: cart (browsing) -> checkout session (purchasing) -> order.
+
+---
+
+## Specification
+
+This PR includes the following spec changes:
+
+**New files:**
+
+* `rfcs/rfc.cart.md` -- Full RFC with design, operations, schema, and conformance checklist
+* `spec/unreleased/json-schema/schema.cart.json` -- Cart, CartCreateRequest, CartUpdateRequest schemas (all referencing existing ACP types via `$ref`)
+* `spec/unreleased/openapi/openapi.cart.yaml` -- OpenAPI 3.1 for 4 REST endpoints
+* `changelog/unreleased/cart.md` -- Changelog entry
+
+**Modified files:**
+
+* `spec/unreleased/json-schema/schema.agentic_checkout.json` -- Added `"carts"` to discovery services enum
+* `rfcs/rfc.discovery.md` -- Added `"carts"` to services enum table and example
+
+**Key design decisions:**
+
+* **4 operations**: Create (`POST /carts`), Get (`GET /carts/{id}`), Update (`PUT /carts/{id}`), Cancel (`POST /carts/{id}/cancel`)
+* **Full replacement on update** -- matches existing ACP checkout update semantics
+* **Estimated (non-authoritative) pricing** -- totals on a cart are estimates; authoritative pricing comes at checkout
+* **Session persistence** -- carts survive across agent sessions and can be shared via `continue_url`
+* **No capabilities, no payment, no status lifecycle** -- these are checkout concerns
+* **Binary state** -- a cart either exists or returns 404; there is no status machine
+
+**Cart response object fields:**
+
+* `id` (required) -- server-generated unique identifier
+* `line_items` (required) -- reuses existing ACP LineItem type
+* `buyer` (optional) -- reuses existing ACP Buyer type
+* `currency` (required) -- ISO 4217 currency code, determined by seller
+* `totals` (required) -- estimated cost breakdown (subtotal, tax if calculable, total)
+* `messages` (optional) -- MessageInfo, MessageWarning, MessageError
+* `continue_url` (optional) -- URI for cart handoff/session recovery
+* `expires_at` (optional) -- RFC 3339 expiry timestamp
+
+**Deferred to follow-up SEPs:**
+
+* **Cart-to-checkout conversion** via a `cart_id` field on `CheckoutSessionCreateRequest` -- agents currently convert carts to checkouts manually by reading the cart and creating a checkout session with the retrieved items
+* **Extension support** (e.g., discount codes during browsing) -- agents can apply discounts at checkout time instead
+
+This SEP establishes the core cart resource; conversion and extension semantics will build on it additively.
+
+---
+
+## Rationale
+
+**Why a separate resource instead of a "lightweight checkout"?**
+Overloading checkout with a "pre-payment" mode would complicate the status lifecycle and capability negotiation contract. A separate cart resource with no status machine is simpler for both implementers and agents.
+
+**Why full replacement instead of partial updates (add/remove item)?**
+Consistent with ACP's existing checkout update pattern. Full replacement is simpler to implement and avoids the complexity of item-level CRUD operations (add, remove, change quantity as separate calls). The agent always has the full desired state and sends it.
+
+**Why reuse existing types instead of cart-specific types?**
+Carts and checkouts share the same commerce domain (items, buyers, totals). Reusing types via `$ref` ensures consistency and reduces the schema surface area.
+
+**Why is `currency` not required on cart create (unlike checkout)?**
+Carts are lightweight. The seller determines currency from context (locale, buyer location) or defaults. Requiring currency upfront adds friction for browsing. Currency is always present on the response (determined by the seller).
+
+**Why defer cart-to-checkout conversion?**
+Keeping the initial SEP focused on the core CRUD resource reduces scope and implementation complexity. The manual conversion path (read cart, create checkout with items) works today. A `cart_id` field on checkout create can be added additively in a follow-up SEP without breaking changes.
+
+---
+
+## Backward Compatibility
+
+This is a purely additive change with no breaking changes:
+
+* New endpoints (`/carts/*`) do not conflict with existing paths.
+* `"carts"` in the discovery services enum is a new value; existing values are unaffected.
+* Cart is an optional service; sellers that don't implement it simply omit `"carts"` from their discovery document.
+
+No deprecation or migration is needed.
+
+---
+
+## Reference Implementation
+
+Not yet available. The RFC and schema definitions in this PR serve as the specification from which implementations can be built.
+
+---
+
+## Security Implications
+
+* **Authentication**: Cart endpoints use the same `Authorization: Bearer` mechanism as checkout. No new auth flows are introduced.
+* **Data privacy**: Carts carry buyer email and item data, same sensitivity as checkout sessions. No additional PII exposure.
+* **Cart enumeration**: Cart IDs are server-generated opaque strings. Sequential or predictable IDs SHOULD be avoided to prevent enumeration.
+* **Expiry**: Carts support `expires_at` to prevent indefinite data retention. Sellers SHOULD set reasonable TTLs.
+
+---
+
+## Pre-Submission Checklist
+
+- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
+- [x] I have linked the SEP issue number above
+- [x] I have discussed this proposal in the community (Discord/GitHub Discussions)
+- [x] I have signed the Contributor License Agreement (CLA)
+- [x] This PR includes updates to OpenAPI/JSON schemas
+- [x] This PR includes example requests/responses (in the RFC and OpenAPI)
+- [x] This PR includes a changelog entry file in `changelog/unreleased/cart.md`
+- [x] I am seeking or have found a sponsor (Founding Maintainer)
+
+---
+
+## Additional Context
+
+The cart capability was designed based on common agent interaction patterns observed in early ACP implementations, where agents frequently needed to build baskets incrementally before committing to a purchase. The design prioritizes simplicity and reuse of existing ACP types to minimize the implementation surface area for sellers.
+
+The scope was intentionally narrowed to focus on the core cart CRUD resource. Cart-to-checkout conversion (`cart_id` on checkout create) and extension support (e.g., discounts on carts) are deferred to follow-up SEPs that will build on this foundation additively.
+
+---
+
+## Questions for Reviewers
+
+1. **Update semantics**: Should cart update be `POST` (matching checkout) or `PUT` (more RESTful for full replacement)? The current proposal uses `POST` for consistency with ACP's existing patterns.
+2. **Cart expiry defaults**: Should the spec recommend a default TTL (e.g., 24 hours, 7 days), or leave this entirely to the seller?
+3. **Conversion path**: Is the manual cart-to-checkout conversion (read cart, create checkout) sufficient for the initial release, or should `cart_id` conversion be included in this SEP?

--- a/rfcs/rfc.cart.md
+++ b/rfcs/rfc.cart.md
@@ -263,6 +263,8 @@ Future extensions MAY declare cart support by extending the `Cart` type, followi
 
 A follow-up SEP will also define cart-to-checkout conversion via a `cart_id` field on `CheckoutSessionCreateRequest`, including conversion rules, idempotency semantics, and post-conversion cart lifecycle.
 
+Future SEPs may also define `continue_url` as an input on `CartCreateRequest`, enabling agents to reference existing merchant-created carts by URL without requiring knowledge of individual product IDs.
+
 ---
 
 ## 6. Discovery Integration

--- a/rfcs/rfc.cart.md
+++ b/rfcs/rfc.cart.md
@@ -1,7 +1,7 @@
 # RFC: Agentic Commerce — Cart
 
-**Status:** Proposal  
-**Version:** unreleased  
+**Status:** Proposal
+**Version:** unreleased
 **Scope:** Pre-checkout basket building for the Agentic Commerce Protocol
 
 This RFC introduces a **Cart** capability for the Agentic Commerce Protocol (ACP). Carts provide a lightweight CRUD interface for item collection before purchase intent is established, enabling incremental basket building, estimated pricing, and session persistence without the overhead of a full checkout lifecycle.
@@ -44,10 +44,10 @@ Neither approach serves agents or sellers well.
 
 1. **Simple CRUD**: Create, read, update, and cancel carts with minimal required fields.
 2. **Reuse existing types**: Cart line items, buyer, totals, and messages reuse existing ACP types — no new domain concepts.
-3. **Cart-to-checkout conversion**: A single `cart_id` field on checkout create converts a cart into a checkout session, carrying over items, buyer info, and context.
-4. **Estimated totals**: Sellers provide best-effort pricing estimates. Totals are explicitly non-authoritative until checkout.
-5. **Optional capability**: Cart is an optional ACP service. Sellers MAY implement it. Agents MUST NOT assume cart support.
-6. **Extension support**: Carts support the discount extension, enabling agents to apply discount codes during browsing.
+3. **Estimated totals**: Sellers provide best-effort pricing estimates. Totals are explicitly non-authoritative until checkout.
+4. **Optional capability**: Cart is an optional ACP service. Sellers MAY implement it. Agents MUST NOT assume cart support.
+
+> **Deferred to follow-up SEPs:** Cart-to-checkout conversion via a `cart_id` field on `CheckoutSessionCreateRequest`, and extension support (e.g., discount codes during browsing) are intentionally deferred. This SEP establishes the core cart resource; conversion and extension semantics will build on it additively.
 
 ### 2.2 Non-Goals
 
@@ -55,11 +55,14 @@ Neither approach serves agents or sellers well.
 - **Status lifecycle**: Carts do not have a status state machine. A cart either exists or it does not.
 - **Capability negotiation**: Carts do not carry a `capabilities` object. Capability negotiation occurs at checkout creation time.
 - **Fulfillment option selection**: Carts do not support fulfillment option selection. Fulfillment options are presented and selected during checkout.
-- **Order creation**: Carts cannot be completed or converted to orders directly. They must first be converted to a checkout session.
+- **Order creation**: Carts cannot be completed or converted to orders directly.
+- **Cart-to-checkout bridge**: Automatic conversion of carts to checkout sessions via a `cart_id` field is deferred to a follow-up SEP. Agents can manually create checkout sessions using cart contents retrieved via `GET /carts/{id}`.
 
 ---
 
 ## 3. Design
+
+**Scope:** Carts are scoped to a single seller. Each cart is hosted under the seller's `api_base_url`. Agents managing cross-merchant shopping SHOULD maintain separate carts per seller.
 
 ### 3.1 Cart vs Checkout
 
@@ -77,14 +80,13 @@ Neither approach serves agents or sellers well.
 ### 3.2 Lifecycle
 
 ```
-Cart (browsing) ──cart_id──▶ Checkout Session (purchasing) ──complete──▶ Order
+Cart (browsing) ──agent reads cart──▶ Checkout Session (purchasing) ──complete──▶ Order
 ```
 
 1. Agent creates a cart with one or more items.
 2. Agent updates the cart as the buyer adds, removes, or changes items.
-3. When the buyer is ready to purchase, the agent creates a checkout session with `cart_id` referencing the cart.
-4. The seller initializes the checkout session from the cart contents.
-5. The checkout proceeds through its normal lifecycle (capability negotiation, payment, completion).
+3. When the buyer is ready to purchase, the agent retrieves the cart via `GET /carts/{id}` and creates a checkout session using the cart's contents.
+4. The checkout proceeds through its normal lifecycle (capability negotiation, payment, completion).
 
 ### 3.3 Cart Schema
 
@@ -102,36 +104,6 @@ A `Cart` response contains the following fields:
 | `expires_at` | string (date-time) | No | RFC 3339 timestamp when the cart expires. |
 
 All types (`LineItem`, `Buyer`, `Total`, `Message`) reuse existing ACP definitions from the checkout schema. No new domain types are introduced.
-
-### 3.4 Cart-to-Checkout Conversion
-
-When an agent is ready to proceed to checkout, it creates a checkout session with the optional `cart_id` field:
-
-```json
-POST /checkout_sessions
-{
-  "cart_id": "cart_abc123",
-  "line_items": [],
-  "currency": "usd",
-  "capabilities": { ... }
-}
-```
-
-**Conversion rules:**
-
-1. Seller MUST use the cart's `line_items` and `buyer` to initialize the checkout session.
-2. Seller MUST ignore `line_items` and `buyer` fields in the checkout request body when `cart_id` is present. The `line_items` field may be sent as an empty array to satisfy schema validation.
-3. Seller MUST apply discount codes from the cart, if the discount extension was used.
-4. `currency` and `capabilities` are still required on the checkout create request (they are not cart fields).
-
-**Idempotency:**
-
-If an incomplete checkout session already exists for the given `cart_id`, the seller MUST return the existing checkout session rather than creating a new one. This ensures a single active checkout per cart and prevents conflicting sessions.
-
-**Cart lifecycle after conversion:**
-
-- **During active checkout**: Seller SHOULD maintain the cart and reflect relevant checkout modifications (quantity changes, item removals) back to the cart. This supports back-to-browsing flows where buyers transition between checkout and the storefront.
-- **After checkout completion**: Seller MAY clear the cart based on TTL, completion of the checkout, or other business logic. Subsequent operations on a cleared cart return `not_found`; the agent can start a new cart with `POST /carts`.
 
 ---
 
@@ -165,7 +137,8 @@ All endpoints follow ACP's existing HTTP conventions:
 | `line_items` | `Item[]` | Yes | Items to add to the cart. |
 | `buyer` | `Buyer` | No | Buyer information for personalized estimates. |
 | `locale` | string | No | Locale code for content localization. |
-| `discounts` | `DiscountsRequest` | No | Discount codes to apply (discount extension). |
+
+**Currency resolution:** The `currency` field is not required on the create request. The seller determines currency from available context (buyer locale, buyer address, storefront default, or seller default). If the seller cannot determine a currency, it SHOULD return `422 Unprocessable Entity` with a message requesting the agent provide a `locale` or `buyer` with sufficient context.
 
 **Response:** `201 Created` with `Cart` object.
 
@@ -263,9 +236,12 @@ Full replacement of the cart. The agent MUST send the complete desired cart stat
 |---|---|---|---|
 | `line_items` | `Item[]` | Yes | Complete list of items (replaces existing). |
 | `buyer` | `Buyer` | No | Updated buyer information. |
-| `discounts` | `DiscountsRequest` | No | Discount codes to apply (replaces existing). |
 
 **Response:** `200 OK` with updated `Cart` object.
+
+**Design rationale — full replacement:** Full replacement is intentional and consistent with ACP's checkout update pattern. While partial update operations (add item, remove item, change quantity) would reduce per-request payload, they significantly increase the API surface area and introduce new failure modes (concurrent add/remove, quantity delta ambiguity, item-level addressing). Agents maintain client-side cart state from the previous response and can trivially reconstruct the full items array. Future protocol versions MAY introduce optimistic concurrency (e.g., `If-Match` / ETag) if race conditions prove problematic in practice.
+
+**Cart expiry:** Sellers SHOULD refresh `expires_at` on any successful update. If a cart has expired, subsequent operations return `404 Not Found`; the agent MAY create a new cart with the previously-known items.
 
 ### 4.5 Cancel Cart
 
@@ -279,17 +255,11 @@ Cancels a cart. The seller MUST return the cart state before deletion. Subsequen
 
 ---
 
-## 5. Extension Support
+## 5. Future Extensions
 
-### 5.1 Discount Extension
+Future extensions MAY declare cart support by extending the `Cart` type, following the same `extends` pattern used for checkout extensions (see `rfc.extensions.md`). Extension integration with carts (e.g., discount codes during browsing, fulfillment previews) is deferred to follow-up SEPs.
 
-Carts support the discount extension. Agents MAY include `discounts.codes` in cart create and update requests. The seller applies discount codes and returns `discounts.applied` and `discounts.rejected` in the cart response.
-
-When a cart with applied discounts is converted to a checkout session via `cart_id`, the seller MUST carry the discount state forward to the checkout session.
-
-### 5.2 Other Extensions
-
-Future extensions MAY declare cart support by extending the `Cart` type, following the same `extends` pattern used for checkout extensions (see `rfc.extensions.md`).
+A follow-up SEP will also define cart-to-checkout conversion via a `cart_id` field on `CheckoutSessionCreateRequest`, including conversion rules, idempotency semantics, and post-conversion cart lifecycle.
 
 ---
 
@@ -321,8 +291,8 @@ Agents SHOULD check the discovery document for `"carts"` in `capabilities.servic
 This is a purely additive change:
 
 - **New endpoints**: `/carts`, `/carts/{id}`, `/carts/{id}/cancel` are new paths that do not conflict with existing endpoints.
-- **New optional field**: `cart_id` on `CheckoutSessionCreateRequest` is optional and does not change existing checkout behavior when absent.
 - **New service value**: `"carts"` in the discovery services enum does not affect existing service values.
+- **No changes to existing schemas**: No fields are added to or modified on existing ACP types. The checkout session schema is unchanged.
 - **No changes to existing flows**: Checkout session lifecycle, capability negotiation, and payment flows are unchanged.
 
 Agents that do not use carts continue to work exactly as before.
@@ -333,7 +303,7 @@ Agents that do not use carts continue to work exactly as before.
 
 - [ ] `spec/unreleased/json-schema/schema.cart.json` — New schema defining `Cart`, `CartCreateRequest`, `CartUpdateRequest`
 - [ ] `spec/unreleased/openapi/openapi.cart.yaml` — New OpenAPI defining cart REST endpoints
-- [ ] `spec/unreleased/json-schema/schema.agentic_checkout.json` — Add `cart_id` to `CheckoutSessionCreateRequest`
+- [ ] `spec/unreleased/json-schema/schema.agentic_checkout.json` — Add `"carts"` to discovery services enum
 - [ ] `rfcs/rfc.discovery.md` — Add `"carts"` to services enum documentation
 - [ ] `changelog/unreleased/cart.md` — Changelog entry
 
@@ -349,22 +319,17 @@ Agents that do not use carts continue to work exactly as before.
 - [ ] MUST implement `POST /carts/{id}/cancel` returning `200 OK` with the final cart state
 - [ ] MUST return `404 Not Found` for expired, canceled, or nonexistent carts
 - [ ] MUST return `id`, `line_items`, `currency`, and `totals` in every cart response
-- [ ] MUST use cart contents (line_items, buyer) when `cart_id` is provided on checkout create
-- [ ] MUST ignore `line_items` and `buyer` in the checkout request body when `cart_id` is present
-- [ ] MUST return an existing incomplete checkout session if one already exists for the given `cart_id` (idempotent conversion)
-- [ ] MUST carry discount state from cart to checkout when converting via `cart_id`
 
 **SHOULD requirements:**
 
 - [ ] SHOULD provide `continue_url` for cart handoff and session recovery
 - [ ] SHOULD provide estimated totals when calculable
 - [ ] SHOULD return informational messages for validation warnings (low stock, price changes)
-- [ ] SHOULD maintain the link between cart and checkout during active checkout (reflecting modifications back)
+- [ ] SHOULD refresh `expires_at` on successful cart updates
 - [ ] SHOULD advertise `"carts"` in `capabilities.services` in the discovery document
 
 **MAY requirements:**
 
-- [ ] MAY omit tax totals until checkout when address is unknown
+- [ ] MAY omit tax totals when address is unknown
 - [ ] MAY set cart expiry via `expires_at`
-- [ ] MAY clear the cart after checkout completion
 - [ ] MAY return an error response instead of creating a cart when all items are unavailable

--- a/rfcs/rfc.cart.md
+++ b/rfcs/rfc.cart.md
@@ -64,6 +64,8 @@ Neither approach serves agents or sellers well.
 
 **Scope:** Carts are scoped to a single seller. Each cart is hosted under the seller's `api_base_url`. Agents managing cross-merchant shopping SHOULD maintain separate carts per seller.
 
+**Origin:** Carts MAY originate outside the ACP API — for example, from a merchant's existing storefront or native app. Sellers that support externally-created carts SHOULD make them retrievable via `GET /carts/{id}` and updatable via `POST /carts/{id}` using standard ACP authentication. This allows agents to pick up carts started by human buyers, enabling hybrid flows where product discovery happens on the merchant's storefront and checkout is handled by the agent.
+
 ### 3.1 Cart vs Checkout
 
 | Aspect | Cart | Checkout Session |

--- a/rfcs/rfc.cart.md
+++ b/rfcs/rfc.cart.md
@@ -1,0 +1,370 @@
+# RFC: Agentic Commerce — Cart
+
+**Status:** Proposal  
+**Version:** unreleased  
+**Scope:** Pre-checkout basket building for the Agentic Commerce Protocol
+
+This RFC introduces a **Cart** capability for the Agentic Commerce Protocol (ACP). Carts provide a lightweight CRUD interface for item collection before purchase intent is established, enabling incremental basket building, estimated pricing, and session persistence without the overhead of a full checkout lifecycle.
+
+---
+
+## 1. Motivation
+
+ACP's checkout session (`POST /checkout_sessions`) is designed for purchase finalization: it triggers capability negotiation, payment handler configuration, status lifecycle management, and authoritative pricing. This is the right model once a buyer has expressed purchase intent, but it is heavyweight for the common agent interaction pattern of incremental basket building.
+
+Agents frequently build baskets iteratively:
+
+1. "Add the blue running shoes to my cart"
+2. "Also add two pairs of socks"
+3. "Actually, remove the socks"
+4. "What's my estimated total?"
+5. "Okay, let's check out"
+
+Without a cart, the agent must either:
+
+- **Create a checkout session on the first item** — which triggers full capability negotiation, payment handler setup, and status lifecycle for what is essentially a browsing action. Every item change is a checkout update that returns authoritative (not estimated) totals.
+- **Track items client-side** — which means the seller has no visibility into browsing behavior, cannot provide estimated pricing, and cannot validate item availability until checkout.
+
+Neither approach serves agents or sellers well.
+
+### What a Cart provides
+
+- **Lightweight item management**: CRUD operations on a basket without payment configuration or status lifecycle.
+- **Estimated pricing**: Sellers return estimated totals (subtotal, tax where calculable, total) without requiring full address or payment information.
+- **Session persistence**: Carts survive across agent sessions, enabling "save for later" and multi-session shopping.
+- **Sharing and handoff**: A `continue_url` enables cart sharing between agents and human-in-the-loop flows.
+- **Seller visibility**: Sellers see browsing behavior (items added/removed) before checkout, enabling analytics and personalization.
+- **Clean separation of concerns**: Cart handles basket building; checkout handles purchase finalization. The boundary is explicit.
+
+---
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+1. **Simple CRUD**: Create, read, update, and cancel carts with minimal required fields.
+2. **Reuse existing types**: Cart line items, buyer, totals, and messages reuse existing ACP types — no new domain concepts.
+3. **Cart-to-checkout conversion**: A single `cart_id` field on checkout create converts a cart into a checkout session, carrying over items, buyer info, and context.
+4. **Estimated totals**: Sellers provide best-effort pricing estimates. Totals are explicitly non-authoritative until checkout.
+5. **Optional capability**: Cart is an optional ACP service. Sellers MAY implement it. Agents MUST NOT assume cart support.
+6. **Extension support**: Carts support the discount extension, enabling agents to apply discount codes during browsing.
+
+### 2.2 Non-Goals
+
+- **Payment handling**: Carts do not carry payment data or payment handlers. Payment is a checkout concern.
+- **Status lifecycle**: Carts do not have a status state machine. A cart either exists or it does not.
+- **Capability negotiation**: Carts do not carry a `capabilities` object. Capability negotiation occurs at checkout creation time.
+- **Fulfillment option selection**: Carts do not support fulfillment option selection. Fulfillment options are presented and selected during checkout.
+- **Order creation**: Carts cannot be completed or converted to orders directly. They must first be converted to a checkout session.
+
+---
+
+## 3. Design
+
+### 3.1 Cart vs Checkout
+
+| Aspect | Cart | Checkout Session |
+|---|---|---|
+| **Purpose** | Pre-purchase exploration | Purchase finalization |
+| **Payment** | None | Required (handlers, instruments) |
+| **Status** | Binary (exists / not found) | Lifecycle (`incomplete` → `completed`) |
+| **Complete operation** | No | Yes |
+| **Capability negotiation** | No | Yes (inline `capabilities` object) |
+| **Totals** | Estimates (may be partial) | Authoritative pricing |
+| **Fulfillment options** | Not available | Available after address provided |
+| **Required fields (create)** | `line_items` | `line_items`, `currency`, `capabilities` |
+
+### 3.2 Lifecycle
+
+```
+Cart (browsing) ──cart_id──▶ Checkout Session (purchasing) ──complete──▶ Order
+```
+
+1. Agent creates a cart with one or more items.
+2. Agent updates the cart as the buyer adds, removes, or changes items.
+3. When the buyer is ready to purchase, the agent creates a checkout session with `cart_id` referencing the cart.
+4. The seller initializes the checkout session from the cart contents.
+5. The checkout proceeds through its normal lifecycle (capability negotiation, payment, completion).
+
+### 3.3 Cart Schema
+
+A `Cart` response contains the following fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Unique cart identifier, server-generated. |
+| `line_items` | `LineItem[]` | Yes | Cart line items. Same structure as checkout line items. |
+| `buyer` | `Buyer` | No | Buyer information, if provided. |
+| `currency` | string | Yes | ISO 4217 currency code. Determined by the seller based on context or request. |
+| `totals` | `Total[]` | Yes | Estimated cost breakdown. May be partial (e.g., tax omitted if address unknown). |
+| `messages` | `Message[]` | No | Validation messages, warnings, or informational notices (e.g., low stock, price changes). |
+| `continue_url` | string (URI) | No | URL for cart handoff, sharing, or session recovery. |
+| `expires_at` | string (date-time) | No | RFC 3339 timestamp when the cart expires. |
+
+All types (`LineItem`, `Buyer`, `Total`, `Message`) reuse existing ACP definitions from the checkout schema. No new domain types are introduced.
+
+### 3.4 Cart-to-Checkout Conversion
+
+When an agent is ready to proceed to checkout, it creates a checkout session with the optional `cart_id` field:
+
+```json
+POST /checkout_sessions
+{
+  "cart_id": "cart_abc123",
+  "line_items": [],
+  "currency": "usd",
+  "capabilities": { ... }
+}
+```
+
+**Conversion rules:**
+
+1. Seller MUST use the cart's `line_items` and `buyer` to initialize the checkout session.
+2. Seller MUST ignore `line_items` and `buyer` fields in the checkout request body when `cart_id` is present. The `line_items` field may be sent as an empty array to satisfy schema validation.
+3. Seller MUST apply discount codes from the cart, if the discount extension was used.
+4. `currency` and `capabilities` are still required on the checkout create request (they are not cart fields).
+
+**Idempotency:**
+
+If an incomplete checkout session already exists for the given `cart_id`, the seller MUST return the existing checkout session rather than creating a new one. This ensures a single active checkout per cart and prevents conflicting sessions.
+
+**Cart lifecycle after conversion:**
+
+- **During active checkout**: Seller SHOULD maintain the cart and reflect relevant checkout modifications (quantity changes, item removals) back to the cart. This supports back-to-browsing flows where buyers transition between checkout and the storefront.
+- **After checkout completion**: Seller MAY clear the cart based on TTL, completion of the checkout, or other business logic. Subsequent operations on a cleared cart return `not_found`; the agent can start a new cart with `POST /carts`.
+
+---
+
+## 4. HTTP Interface
+
+### 4.1 Operations
+
+| Operation | Method | Endpoint | Description |
+|---|---|---|---|
+| Create Cart | `POST` | `/carts` | Create a new cart with items. |
+| Get Cart | `GET` | `/carts/{id}` | Retrieve current cart state. |
+| Update Cart | `POST` | `/carts/{id}` | Update cart (full replacement). |
+| Cancel Cart | `POST` | `/carts/{id}/cancel` | Cancel a cart. |
+
+All endpoints follow ACP's existing HTTP conventions:
+
+- HTTPS required, JSON request/response bodies.
+- `Authorization: Bearer <token>` required.
+- `API-Version` header required.
+- `Idempotency-Key` required on all POST requests.
+- Amounts in minor currency units (cents).
+
+### 4.2 Create Cart
+
+`POST /carts`
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `line_items` | `Item[]` | Yes | Items to add to the cart. |
+| `buyer` | `Buyer` | No | Buyer information for personalized estimates. |
+| `locale` | string | No | Locale code for content localization. |
+| `discounts` | `DiscountsRequest` | No | Discount codes to apply (discount extension). |
+
+**Response:** `201 Created` with `Cart` object.
+
+**Example:**
+
+Request:
+
+```json
+POST /carts HTTP/1.1
+Authorization: Bearer <token>
+API-Version: 2026-01-30
+Idempotency-Key: idk_abc123
+Content-Type: application/json
+
+{
+  "line_items": [
+    { "id": "item_123", "quantity": 2 },
+    { "id": "item_456", "quantity": 1 }
+  ],
+  "buyer": {
+    "email": "buyer@example.com"
+  }
+}
+```
+
+Response:
+
+```json
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+  "id": "cart_abc123",
+  "line_items": [
+    {
+      "id": "li_1",
+      "item": { "id": "item_123", "name": "Blue Running Shoes", "unit_amount": 12000 },
+      "quantity": 2,
+      "totals": [
+        { "type": "subtotal", "amount": 24000 }
+      ]
+    },
+    {
+      "id": "li_2",
+      "item": { "id": "item_456", "name": "Athletic Socks (3-pack)", "unit_amount": 1500 },
+      "quantity": 1,
+      "totals": [
+        { "type": "subtotal", "amount": 1500 }
+      ]
+    }
+  ],
+  "buyer": {
+    "email": "buyer@example.com"
+  },
+  "currency": "usd",
+  "totals": [
+    { "type": "subtotal", "amount": 25500 },
+    { "type": "total", "amount": 25500 }
+  ],
+  "continue_url": "https://seller.example.com/cart/cart_abc123",
+  "expires_at": "2026-04-01T12:00:00Z"
+}
+```
+
+**Error handling:**
+
+When all requested items are unavailable, the seller MAY return an error instead of creating a cart:
+
+```json
+HTTP/1.1 422 Unprocessable Entity
+Content-Type: application/json
+
+{
+  "type": "invalid_request",
+  "code": "out_of_stock",
+  "message": "All requested items are currently unavailable."
+}
+```
+
+### 4.3 Get Cart
+
+`GET /carts/{id}`
+
+Returns the current cart state. Returns `404 Not Found` if the cart does not exist, has expired, or was canceled.
+
+### 4.4 Update Cart
+
+`POST /carts/{id}`
+
+Full replacement of the cart. The agent MUST send the complete desired cart state. The provided `line_items` replace the existing cart contents.
+
+**Request:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `line_items` | `Item[]` | Yes | Complete list of items (replaces existing). |
+| `buyer` | `Buyer` | No | Updated buyer information. |
+| `discounts` | `DiscountsRequest` | No | Discount codes to apply (replaces existing). |
+
+**Response:** `200 OK` with updated `Cart` object.
+
+### 4.5 Cancel Cart
+
+`POST /carts/{id}/cancel`
+
+Cancels a cart. The seller MUST return the cart state before deletion. Subsequent operations on this cart ID SHOULD return `404 Not Found`.
+
+**Request body:** Empty or `{}`.
+
+**Response:** `200 OK` with the final `Cart` object.
+
+---
+
+## 5. Extension Support
+
+### 5.1 Discount Extension
+
+Carts support the discount extension. Agents MAY include `discounts.codes` in cart create and update requests. The seller applies discount codes and returns `discounts.applied` and `discounts.rejected` in the cart response.
+
+When a cart with applied discounts is converted to a checkout session via `cart_id`, the seller MUST carry the discount state forward to the checkout session.
+
+### 5.2 Other Extensions
+
+Future extensions MAY declare cart support by extending the `Cart` type, following the same `extends` pattern used for checkout extensions (see `rfc.extensions.md`).
+
+---
+
+## 6. Discovery Integration
+
+The cart service is advertised in the discovery document (`/.well-known/acp.json`) as a value in the `capabilities.services` array:
+
+```json
+{
+  "protocol": {
+    "name": "acp",
+    "version": "2026-01-30",
+    "supported_versions": ["2026-01-30"]
+  },
+  "api_base_url": "https://seller.example.com/api",
+  "transports": ["rest"],
+  "capabilities": {
+    "services": ["checkout", "orders", "carts"]
+  }
+}
+```
+
+Agents SHOULD check the discovery document for `"carts"` in `capabilities.services` before attempting to create a cart. If cart is not advertised, agents SHOULD fall back to creating checkout sessions directly.
+
+---
+
+## 7. Backward Compatibility
+
+This is a purely additive change:
+
+- **New endpoints**: `/carts`, `/carts/{id}`, `/carts/{id}/cancel` are new paths that do not conflict with existing endpoints.
+- **New optional field**: `cart_id` on `CheckoutSessionCreateRequest` is optional and does not change existing checkout behavior when absent.
+- **New service value**: `"carts"` in the discovery services enum does not affect existing service values.
+- **No changes to existing flows**: Checkout session lifecycle, capability negotiation, and payment flows are unchanged.
+
+Agents that do not use carts continue to work exactly as before.
+
+---
+
+## 8. Required Spec Updates
+
+- [ ] `spec/unreleased/json-schema/schema.cart.json` — New schema defining `Cart`, `CartCreateRequest`, `CartUpdateRequest`
+- [ ] `spec/unreleased/openapi/openapi.cart.yaml` — New OpenAPI defining cart REST endpoints
+- [ ] `spec/unreleased/json-schema/schema.agentic_checkout.json` — Add `cart_id` to `CheckoutSessionCreateRequest`
+- [ ] `rfcs/rfc.discovery.md` — Add `"carts"` to services enum documentation
+- [ ] `changelog/unreleased/cart.md` — Changelog entry
+
+---
+
+## 9. Conformance Checklist
+
+**MUST requirements:**
+
+- [ ] MUST implement `POST /carts` returning `201 Created` with a valid `Cart` object
+- [ ] MUST implement `GET /carts/{id}` returning `200 OK` with the current cart state
+- [ ] MUST implement `POST /carts/{id}` accepting a full replacement of the cart
+- [ ] MUST implement `POST /carts/{id}/cancel` returning `200 OK` with the final cart state
+- [ ] MUST return `404 Not Found` for expired, canceled, or nonexistent carts
+- [ ] MUST return `id`, `line_items`, `currency`, and `totals` in every cart response
+- [ ] MUST use cart contents (line_items, buyer) when `cart_id` is provided on checkout create
+- [ ] MUST ignore `line_items` and `buyer` in the checkout request body when `cart_id` is present
+- [ ] MUST return an existing incomplete checkout session if one already exists for the given `cart_id` (idempotent conversion)
+- [ ] MUST carry discount state from cart to checkout when converting via `cart_id`
+
+**SHOULD requirements:**
+
+- [ ] SHOULD provide `continue_url` for cart handoff and session recovery
+- [ ] SHOULD provide estimated totals when calculable
+- [ ] SHOULD return informational messages for validation warnings (low stock, price changes)
+- [ ] SHOULD maintain the link between cart and checkout during active checkout (reflecting modifications back)
+- [ ] SHOULD advertise `"carts"` in `capabilities.services` in the discovery document
+
+**MAY requirements:**
+
+- [ ] MAY omit tax totals until checkout when address is unknown
+- [ ] MAY set cart expiry via `expires_at`
+- [ ] MAY clear the cart after checkout completion
+- [ ] MAY return an error response instead of creating a cart when all items are unavailable

--- a/rfcs/rfc.cart.md
+++ b/rfcs/rfc.cart.md
@@ -220,6 +220,51 @@ Content-Type: application/json
 }
 ```
 
+**Partial availability:** When some but not all requested items are unavailable, the seller SHOULD still create the cart and return `201 Created`. The response SHOULD include `messages` indicating which items have availability issues. This keeps the agent in control — it can choose to remove unavailable items, substitute them, or keep them in the cart. Sellers MUST NOT silently drop unavailable items from the cart without a corresponding message.
+
+Example response with partial availability:
+
+```json
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+  "id": "cart_def456",
+  "line_items": [
+    {
+      "id": "li_1",
+      "item": { "id": "item_123", "name": "Blue Running Shoes", "unit_amount": 12000 },
+      "quantity": 2,
+      "totals": [
+        { "type": "subtotal", "amount": 24000 }
+      ]
+    },
+    {
+      "id": "li_2",
+      "item": { "id": "item_456", "name": "Athletic Socks (3-pack)", "unit_amount": 1500 },
+      "quantity": 1,
+      "totals": [
+        { "type": "subtotal", "amount": 1500 }
+      ]
+    }
+  ],
+  "currency": "usd",
+  "totals": [
+    { "type": "subtotal", "amount": 25500 },
+    { "type": "total", "amount": 25500 }
+  ],
+  "messages": [
+    {
+      "type": "warning",
+      "code": "out_of_stock",
+      "message": "item_456 (Athletic Socks 3-pack) is currently out of stock."
+    }
+  ],
+  "continue_url": "https://seller.example.com/cart/cart_def456",
+  "expires_at": "2026-04-15T12:00:00Z"
+}
+```
+
 ### 4.3 Get Cart
 
 `GET /carts/{id}`
@@ -240,6 +285,8 @@ Full replacement of the cart. The agent MUST send the complete desired cart stat
 | `buyer` | `Buyer` | No | Updated buyer information. |
 
 **Response:** `200 OK` with updated `Cart` object.
+
+**Partial availability on update:** When some items in the replacement payload are unavailable, the seller SHOULD accept the update and return `200 OK` with `messages` indicating which items have availability issues. Rejecting the entire update would leave the cart in its previous state, which is confusing when the agent may have been changing quantities or removing other items at the same time. As with cart creation, sellers MUST NOT silently drop unavailable items without a corresponding message.
 
 **Design rationale — full replacement:** Full replacement is intentional and consistent with ACP's checkout update pattern. While partial update operations (add item, remove item, change quantity) would reduce per-request payload, they significantly increase the API surface area and introduce new failure modes (concurrent add/remove, quantity delta ambiguity, item-level addressing). Agents maintain client-side cart state from the previous response and can trivially reconstruct the full items array. Future protocol versions MAY introduce optimistic concurrency (e.g., `If-Match` / ETag) if race conditions prove problematic in practice.
 

--- a/rfcs/rfc.cart.md
+++ b/rfcs/rfc.cart.md
@@ -64,7 +64,7 @@ Neither approach serves agents or sellers well.
 
 **Scope:** Carts are scoped to a single seller. Each cart is hosted under the seller's `api_base_url`. Agents managing cross-merchant shopping SHOULD maintain separate carts per seller.
 
-**Origin:** Carts MAY originate outside the ACP API — for example, from a merchant's existing storefront or native app. Sellers that support externally-created carts SHOULD make them retrievable via `GET /carts/{id}` and updatable via `POST /carts/{id}` using standard ACP authentication. This allows agents to pick up carts started by human buyers, enabling hybrid flows where product discovery happens on the merchant's storefront and checkout is handled by the agent.
+**Origin:** Carts MAY originate outside the ACP API — for example, from a merchant's existing storefront or native app. Sellers that support externally-created carts SHOULD make them retrievable via `GET /carts/{id}` and updatable via `PUT /carts/{id}` using standard ACP authentication. This allows agents to pick up carts started by human buyers, enabling hybrid flows where product discovery happens on the merchant's storefront and checkout is handled by the agent.
 
 ### 3.1 Cart vs Checkout
 
@@ -117,7 +117,7 @@ All types (`LineItem`, `Buyer`, `Total`, `Message`) reuse existing ACP definitio
 |---|---|---|---|
 | Create Cart | `POST` | `/carts` | Create a new cart with items. |
 | Get Cart | `GET` | `/carts/{id}` | Retrieve current cart state. |
-| Update Cart | `POST` | `/carts/{id}` | Update cart (full replacement). |
+| Update Cart | `PUT` | `/carts/{id}` | Update cart (full replacement). |
 | Cancel Cart | `POST` | `/carts/{id}/cancel` | Cancel a cart. |
 
 All endpoints follow ACP's existing HTTP conventions:
@@ -228,7 +228,7 @@ Returns the current cart state. Returns `404 Not Found` if the cart does not exi
 
 ### 4.4 Update Cart
 
-`POST /carts/{id}`
+`PUT /carts/{id}`
 
 Full replacement of the cart. The agent MUST send the complete desired cart state. The provided `line_items` replace the existing cart contents.
 
@@ -319,7 +319,7 @@ Agents that do not use carts continue to work exactly as before.
 
 - [ ] MUST implement `POST /carts` returning `201 Created` with a valid `Cart` object
 - [ ] MUST implement `GET /carts/{id}` returning `200 OK` with the current cart state
-- [ ] MUST implement `POST /carts/{id}` accepting a full replacement of the cart
+- [ ] MUST implement `PUT /carts/{id}` accepting a full replacement of the cart
 - [ ] MUST implement `POST /carts/{id}/cancel` returning `200 OK` with the final cart state
 - [ ] MUST return `404 Not Found` for expired, canceled, or nonexistent carts
 - [ ] MUST return `id`, `line_items`, `currency`, and `totals` in every cart response

--- a/rfcs/rfc.discovery.md
+++ b/rfcs/rfc.discovery.md
@@ -149,6 +149,7 @@ The document is a `DiscoveryResponse` object containing the following fields:
 | `checkout` | Checkout session management (`POST /checkout_sessions` and related endpoints). |
 | `orders` | Post-purchase order lifecycle management. |
 | `delegate_payment` | Payment credential delegation (`POST /delegate_payment`). |
+| `carts` | Pre-checkout cart management (`POST /carts` and related endpoints). |
 
 The `services` enum is closed per API version. New values are introduced in new API versions. Agents MAY treat the set as exhaustive for a given version.
 
@@ -214,7 +215,7 @@ Cache-Control: public, max-age=3600
   "api_base_url": "https://acp.stripe.com/api",
   "transports": ["rest", "mcp"],
   "capabilities": {
-    "services": ["checkout", "orders", "delegate_payment"],
+    "services": ["checkout", "orders", "delegate_payment", "carts"],
     "extensions": [
       { "name": "discount", "spec": "https://agenticcommerce.dev/specs/discount", "schema": "https://agenticcommerce.dev/schemas/discount.json" },
       { "name": "fulfillment", "spec": "https://agenticcommerce.dev/specs/fulfillment", "schema": "https://agenticcommerce.dev/schemas/fulfillment.json" }

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -3415,9 +3415,13 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "cart_id": {
+          "type": "string",
+          "description": "Cart ID to convert to a checkout session. When present, the seller MUST use the cart's line_items and buyer to initialize the checkout session and MUST ignore the line_items and buyer fields in this request body. If an incomplete checkout already exists for this cart_id, the seller MUST return the existing checkout session (idempotent conversion)."
+        },
         "buyer": {
           "$ref": "#/$defs/Buyer",
-          "description": "Buyer information"
+          "description": "Buyer information. Ignored when cart_id is present."
         },
         "line_items": {
           "type": "array",
@@ -3711,7 +3715,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["checkout", "orders", "delegate_payment"]
+            "enum": ["checkout", "orders", "delegate_payment", "carts"]
           },
           "uniqueItems": true,
           "description": "Services available from this seller. Indicates which ACP operations are implemented. This enum is closed per API version; new values are introduced in new API versions. Agents MAY treat the set as exhaustive for a given version."
@@ -3754,7 +3758,7 @@
       },
       "required": ["services"],
       "example": {
-        "services": ["checkout", "orders", "delegate_payment"],
+        "services": ["checkout", "orders", "delegate_payment", "carts"],
         "extensions": [{ "name": "discount", "spec": "https://agenticcommerce.dev/specs/discount", "schema": "https://agenticcommerce.dev/schemas/discount.json" }],
         "intervention_types": ["3ds"],
         "supported_currencies": ["usd", "eur"],

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -3415,13 +3415,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "cart_id": {
-          "type": "string",
-          "description": "Cart ID to convert to a checkout session. When present, the seller MUST use the cart's line_items and buyer to initialize the checkout session and MUST ignore the line_items and buyer fields in this request body. If an incomplete checkout already exists for this cart_id, the seller MUST return the existing checkout session (idempotent conversion)."
-        },
         "buyer": {
           "$ref": "#/$defs/Buyer",
-          "description": "Buyer information. Ignored when cart_id is present."
+          "description": "Buyer information"
         },
         "line_items": {
           "type": "array",

--- a/spec/unreleased/json-schema/schema.cart.json
+++ b/spec/unreleased/json-schema/schema.cart.json
@@ -24,6 +24,7 @@
           "$ref": "schema.agentic_checkout.json#/$defs/Buyer",
           "description": "Buyer information, if provided."
         },
+      }, 
         "currency": {
           "type": "string",
           "description": "ISO 4217 currency code. Determined by the seller based on context or request."
@@ -34,10 +35,6 @@
             "$ref": "schema.agentic_checkout.json#/$defs/Total"
           },
           "description": "Estimated cost breakdown. May be partial (e.g., tax omitted if address is unknown). Totals are estimates until checkout."
-        },
-        "discounts": {
-          "$ref": "schema.agentic_checkout.json#/$defs/DiscountsResponse",
-          "description": "Applied and rejected discounts (discount extension)."
         },
         "messages": {
           "type": "array",
@@ -108,15 +105,6 @@
         "locale": {
           "type": "string",
           "description": "Locale code for content localization (e.g., 'en-US')."
-        },
-        "discounts": {
-          "$ref": "schema.agentic_checkout.json#/$defs/DiscountsRequest",
-          "description": "Discount codes to apply (discount extension)."
-        },
-        "metadata": {
-          "type": "object",
-          "additionalProperties": true,
-          "description": "Arbitrary metadata for seller use."
         }
       },
       "example": {
@@ -147,10 +135,6 @@
         "buyer": {
           "$ref": "schema.agentic_checkout.json#/$defs/Buyer",
           "description": "Updated buyer information."
-        },
-        "discounts": {
-          "$ref": "schema.agentic_checkout.json#/$defs/DiscountsRequest",
-          "description": "Discount codes to apply (replaces existing)."
         }
       },
       "example": {

--- a/spec/unreleased/json-schema/schema.cart.json
+++ b/spec/unreleased/json-schema/schema.cart.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/cart/bundle.schema.json",
+  "title": "Cart — Schema Bundle",
+  "$defs": {
+    "Cart": {
+      "description": "A shopping cart with estimated pricing. Carts provide a lightweight pre-checkout phase for item collection without payment configuration or status lifecycle.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "line_items", "currency", "totals"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique cart identifier, server-generated."
+        },
+        "line_items": {
+          "type": "array",
+          "items": {
+            "$ref": "schema.agentic_checkout.json#/$defs/LineItem"
+          },
+          "description": "Cart line items. Same structure as checkout line items."
+        },
+        "buyer": {
+          "$ref": "schema.agentic_checkout.json#/$defs/Buyer",
+          "description": "Buyer information, if provided."
+        },
+        "currency": {
+          "type": "string",
+          "description": "ISO 4217 currency code. Determined by the seller based on context or request."
+        },
+        "totals": {
+          "type": "array",
+          "items": {
+            "$ref": "schema.agentic_checkout.json#/$defs/Total"
+          },
+          "description": "Estimated cost breakdown. May be partial (e.g., tax omitted if address is unknown). Totals are estimates until checkout."
+        },
+        "discounts": {
+          "$ref": "schema.agentic_checkout.json#/$defs/DiscountsResponse",
+          "description": "Applied and rejected discounts (discount extension)."
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "$ref": "schema.agentic_checkout.json#/$defs/MessageInfo" },
+              { "$ref": "schema.agentic_checkout.json#/$defs/MessageWarning" },
+              { "$ref": "schema.agentic_checkout.json#/$defs/MessageError" }
+            ]
+          },
+          "description": "Validation messages, warnings, or informational notices (e.g., low stock, price changes)."
+        },
+        "continue_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL for cart handoff, sharing, or session recovery."
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 timestamp when the cart expires."
+        }
+      },
+      "example": {
+        "id": "cart_abc123",
+        "line_items": [
+          {
+            "id": "li_1",
+            "item": {
+              "id": "item_123",
+              "name": "Blue Running Shoes",
+              "unit_amount": 12000
+            },
+            "quantity": 2,
+            "totals": [
+              { "type": "subtotal", "amount": 24000 }
+            ]
+          }
+        ],
+        "currency": "usd",
+        "totals": [
+          { "type": "subtotal", "amount": 24000 },
+          { "type": "total", "amount": 24000 }
+        ],
+        "continue_url": "https://seller.example.com/cart/cart_abc123",
+        "expires_at": "2026-04-01T12:00:00Z"
+      }
+    },
+
+    "CartCreateRequest": {
+      "description": "Request to create a new cart.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["line_items"],
+      "properties": {
+        "line_items": {
+          "type": "array",
+          "items": {
+            "$ref": "schema.agentic_checkout.json#/$defs/Item"
+          },
+          "minItems": 1,
+          "description": "Items to add to the cart."
+        },
+        "buyer": {
+          "$ref": "schema.agentic_checkout.json#/$defs/Buyer",
+          "description": "Buyer information for personalized estimates."
+        },
+        "locale": {
+          "type": "string",
+          "description": "Locale code for content localization (e.g., 'en-US')."
+        },
+        "discounts": {
+          "$ref": "schema.agentic_checkout.json#/$defs/DiscountsRequest",
+          "description": "Discount codes to apply (discount extension)."
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Arbitrary metadata for seller use."
+        }
+      },
+      "example": {
+        "line_items": [
+          { "id": "item_123", "quantity": 2 },
+          { "id": "item_456", "quantity": 1 }
+        ],
+        "buyer": {
+          "email": "buyer@example.com"
+        }
+      }
+    },
+
+    "CartUpdateRequest": {
+      "description": "Request to update a cart. Full replacement — the agent MUST send the complete desired cart state.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["line_items"],
+      "properties": {
+        "line_items": {
+          "type": "array",
+          "items": {
+            "$ref": "schema.agentic_checkout.json#/$defs/Item"
+          },
+          "minItems": 1,
+          "description": "Complete list of items (replaces existing cart contents)."
+        },
+        "buyer": {
+          "$ref": "schema.agentic_checkout.json#/$defs/Buyer",
+          "description": "Updated buyer information."
+        },
+        "discounts": {
+          "$ref": "schema.agentic_checkout.json#/$defs/DiscountsRequest",
+          "description": "Discount codes to apply (replaces existing)."
+        }
+      },
+      "example": {
+        "line_items": [
+          { "id": "item_123", "quantity": 3 },
+          { "id": "item_789", "quantity": 1 }
+        ]
+      }
+    }
+  }
+}

--- a/spec/unreleased/json-schema/schema.cart.json
+++ b/spec/unreleased/json-schema/schema.cart.json
@@ -24,7 +24,6 @@
           "$ref": "schema.agentic_checkout.json#/$defs/Buyer",
           "description": "Buyer information, if provided."
         },
-      }, 
         "currency": {
           "type": "string",
           "description": "ISO 4217 currency code. Determined by the seller based on context or request."

--- a/spec/unreleased/openapi/openapi.cart.yaml
+++ b/spec/unreleased/openapi/openapi.cart.yaml
@@ -1,0 +1,336 @@
+openapi: 3.1.0
+info:
+  title: Agentic Commerce — Cart API
+  version: unreleased
+  description: |
+    Seller-implemented REST API for pre-checkout cart management.
+    Implements create, retrieve (GET), update (POST), and cancel of cart sessions.
+
+    Carts provide a lightweight pre-checkout phase for item collection without
+    payment configuration or status lifecycle. See rfc.cart.md for the full specification.
+servers:
+  - url: https://seller.example.com
+security:
+  - bearerAuth: []
+tags:
+  - name: Carts
+    description: Create and manage shopping carts
+
+paths:
+  /carts:
+    post:
+      tags: [Carts]
+      summary: Create a cart
+      operationId: createCart
+      description: |
+        Creates a new cart with line items and optional buyer information.
+        Returns estimated pricing. No payment configuration or capability negotiation occurs.
+
+        When all requested items are unavailable, the seller MAY return a 422 error
+        instead of creating a cart.
+      parameters:
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/ContentType"
+        - $ref: "#/components/parameters/AcceptLanguage"
+        - $ref: "#/components/parameters/IdempotencyKey"
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/APIVersion"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CartCreateRequest"
+            examples:
+              minimal:
+                summary: Single item
+                value:
+                  line_items:
+                    - id: item_123
+                      quantity: 1
+              with_buyer:
+                summary: Multiple items with buyer
+                value:
+                  line_items:
+                    - id: item_123
+                      quantity: 2
+                    - id: item_456
+                      quantity: 1
+                  buyer:
+                    email: buyer@example.com
+              with_discounts:
+                summary: With discount code
+                value:
+                  line_items:
+                    - id: item_123
+                      quantity: 1
+                  discounts:
+                    codes:
+                      - SAVE20
+      responses:
+        "201":
+          description: Cart created successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cart"
+              examples:
+                created:
+                  value:
+                    id: cart_abc123
+                    line_items:
+                      - id: li_1
+                        item:
+                          id: item_123
+                          name: Blue Running Shoes
+                          unit_amount: 12000
+                        quantity: 2
+                        totals:
+                          - type: subtotal
+                            amount: 24000
+                      - id: li_2
+                        item:
+                          id: item_456
+                          name: Athletic Socks (3-pack)
+                          unit_amount: 1500
+                        quantity: 1
+                        totals:
+                          - type: subtotal
+                            amount: 1500
+                    currency: usd
+                    totals:
+                      - type: subtotal
+                        amount: 25500
+                      - type: total
+                        amount: 25500
+                    continue_url: https://seller.example.com/cart/cart_abc123
+                    expires_at: "2026-04-01T12:00:00Z"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "422":
+          description: Unprocessable — all items unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                out_of_stock:
+                  value:
+                    type: invalid_request
+                    code: out_of_stock
+                    message: All requested items are currently unavailable.
+
+  /carts/{id}:
+    get:
+      tags: [Carts]
+      summary: Get a cart
+      operationId: getCart
+      description: |
+        Retrieves the current state of a cart. Returns 404 if the cart does not
+        exist, has expired, or was canceled.
+      parameters:
+        - $ref: "#/components/parameters/CartId"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/AcceptLanguage"
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/APIVersion"
+      responses:
+        "200":
+          description: Cart retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cart"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/CartNotFound"
+
+    post:
+      tags: [Carts]
+      summary: Update a cart
+      operationId: updateCart
+      description: |
+        Full replacement of the cart. The agent MUST send the complete desired
+        cart state. The provided line_items replace the existing cart contents.
+      parameters:
+        - $ref: "#/components/parameters/CartId"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/ContentType"
+        - $ref: "#/components/parameters/AcceptLanguage"
+        - $ref: "#/components/parameters/IdempotencyKey"
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/APIVersion"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CartUpdateRequest"
+            examples:
+              update_quantity:
+                summary: Change quantity and add item
+                value:
+                  line_items:
+                    - id: item_123
+                      quantity: 3
+                    - id: item_789
+                      quantity: 1
+      responses:
+        "200":
+          description: Cart updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cart"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/CartNotFound"
+
+  /carts/{id}/cancel:
+    post:
+      tags: [Carts]
+      summary: Cancel a cart
+      operationId: cancelCart
+      description: |
+        Cancels a cart. The seller MUST return the cart state before deletion.
+        Subsequent operations on this cart ID SHOULD return 404 Not Found.
+      parameters:
+        - $ref: "#/components/parameters/CartId"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/IdempotencyKey"
+        - $ref: "#/components/parameters/RequestId"
+        - $ref: "#/components/parameters/APIVersion"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Cart canceled successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cart"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/CartNotFound"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: API Key
+
+  parameters:
+    CartId:
+      name: id
+      in: path
+      required: true
+      description: Cart identifier
+      schema:
+        type: string
+        example: cart_abc123
+    Authorization:
+      name: Authorization
+      in: header
+      description: Bearer token for API authentication
+      required: true
+      schema:
+        type: string
+        example: Bearer api_key_123
+    ContentType:
+      name: Content-Type
+      in: header
+      required: true
+      schema:
+        type: string
+        example: application/json
+    AcceptLanguage:
+      name: Accept-Language
+      in: header
+      required: false
+      schema:
+        type: string
+        example: en-US
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: true
+      description: Idempotency key. MUST be present on all POST requests. Opaque string, max 255 characters. UUID v4 recommended.
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 255
+        example: 550e8400-e29b-41d4-a716-446655440000
+    RequestId:
+      name: Request-Id
+      in: header
+      required: false
+      schema:
+        type: string
+        example: request_id_123
+    APIVersion:
+      name: API-Version
+      in: header
+      required: true
+      schema:
+        type: string
+        example: "2026-01-30"
+
+  responses:
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          examples:
+            invalid_request:
+              value:
+                type: invalid_request
+                code: missing_line_items
+                message: "line_items is required and must contain at least one item"
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          examples:
+            unauthorized:
+              value:
+                type: invalid_request
+                code: unauthorized
+                message: "Invalid or missing Authorization header"
+    CartNotFound:
+      description: Cart not found, expired, or canceled
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          examples:
+            not_found:
+              value:
+                type: invalid_request
+                code: not_found
+                message: Cart not found or has expired.
+
+  schemas:
+    Cart:
+      $ref: "../../unreleased/json-schema/schema.cart.json#/$defs/Cart"
+    CartCreateRequest:
+      $ref: "../../unreleased/json-schema/schema.cart.json#/$defs/CartCreateRequest"
+    CartUpdateRequest:
+      $ref: "../../unreleased/json-schema/schema.cart.json#/$defs/CartUpdateRequest"
+    Error:
+      $ref: "../../unreleased/json-schema/schema.agentic_checkout.json#/$defs/Error"

--- a/spec/unreleased/openapi/openapi.cart.yaml
+++ b/spec/unreleased/openapi/openapi.cart.yaml
@@ -58,15 +58,6 @@ paths:
                       quantity: 1
                   buyer:
                     email: buyer@example.com
-              with_discounts:
-                summary: With discount code
-                value:
-                  line_items:
-                    - id: item_123
-                      quantity: 1
-                  discounts:
-                    codes:
-                      - SAVE20
       responses:
         "201":
           description: Cart created successfully

--- a/spec/unreleased/openapi/openapi.cart.yaml
+++ b/spec/unreleased/openapi/openapi.cart.yaml
@@ -182,6 +182,18 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/CartNotFound"
+        "422":
+          description: Unprocessable — all items unavailable or currency unresolvable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                out_of_stock:
+                  value:
+                    type: invalid_request
+                    code: out_of_stock
+                    message: All requested items are currently unavailable.
 
   /carts/{id}/cancel:
     post:

--- a/spec/unreleased/openapi/openapi.cart.yaml
+++ b/spec/unreleased/openapi/openapi.cart.yaml
@@ -139,7 +139,7 @@ paths:
         "404":
           $ref: "#/components/responses/CartNotFound"
 
-    post:
+    put:
       tags: [Carts]
       summary: Update a cart
       operationId: updateCart


### PR DESCRIPTION
# SEP: Cart Capability for Pre-Checkout Basket Building

## 📋 SEP Metadata

- **SEP Number**: #187
- **Status**: `proposal`
- **Type**: [x] Major Change [ ] Process Change
- **Related Issues/RFCs**: `rfcs/rfc.cart.md`

---

## 🎯 Abstract

This SEP introduces a **Cart** capability to ACP -- a lightweight CRUD interface for pre-checkout basket building. Agents frequently build baskets incrementally ("add this, remove that, what's the total?") before the buyer expresses purchase intent. Today, ACP requires creating a full checkout session for this, which triggers capability negotiation, payment handler configuration, and status lifecycle management -- all unnecessary overhead for browsing.

The cart provides four endpoints (`POST /carts`, `GET /carts/{id}`, `POST /carts/{id}`, `POST /carts/{id}/cancel`) with estimated pricing and session persistence. No new domain types are introduced; carts reuse existing ACP types (LineItem, Buyer, Total, Message).

---

## 💡 Motivation

ACP's checkout session is designed for purchase finalization, but agents need a pre-purchase exploration phase. Without a cart:

* **Agents must create heavyweight checkout sessions for browsing** -- triggering capability negotiation, payment handler setup, and status lifecycle for what is essentially adding items to a basket.
* **Agents must track items client-side** -- meaning the seller has no visibility into browsing behavior, cannot provide estimated pricing, and cannot validate item availability until checkout.
* **No session persistence** -- there's no way to save a basket across agent sessions or share it via a URL for human-in-the-loop flows.
* **No incremental building** -- the common pattern of "add this... add that... remove that... check out" doesn't map cleanly to checkout session semantics.

Carts solve these by providing a binary-state (exists / not found) resource with estimated totals, no payment configuration, and no status lifecycle. The typical flow becomes: cart (browsing) -> checkout session (purchasing) -> order.

---

## 📐 Specification

This PR includes the following spec changes:

**New files:**

* `rfcs/rfc.cart.md` -- Full RFC with design, operations, schema, and conformance checklist
* `spec/unreleased/json-schema/schema.cart.json` -- Cart, CartCreateRequest, CartUpdateRequest schemas (all referencing existing ACP types via `$ref`)
* `spec/unreleased/openapi/openapi.cart.yaml` -- OpenAPI 3.1 for 4 REST endpoints
* `changelog/unreleased/cart.md` -- Changelog entry

**Modified files:**

* `spec/unreleased/json-schema/schema.agentic_checkout.json` -- Added `"carts"` to discovery services enum
* `rfcs/rfc.discovery.md` -- Added `"carts"` to services enum table and example

**Key design decisions:**

* **4 operations**: Create (`POST /carts`), Get (`GET /carts/{id}`), Update (`POST /carts/{id}`), Cancel (`POST /carts/{id}/cancel`)
* **Full replacement on update** -- matches existing ACP checkout update semantics; documented rationale and future ETag/`If-Match` option for optimistic concurrency
* **Single-seller scoping** -- carts are scoped to one seller; agents maintain separate carts per merchant for cross-merchant shopping
* **External cart origins** -- carts MAY originate outside the ACP API (e.g., merchant storefronts); agents can pick up browser-created carts via `GET /carts/{id}`
* **Manual cart-to-checkout conversion** -- agent reads cart via `GET /carts/{id}` and creates a checkout session with the retrieved items
* **No capabilities, no payment, no status lifecycle** -- these are checkout concerns

**Deferred to follow-up SEPs:**

* Cart-to-checkout conversion via a `cart_id` field on `CheckoutSessionCreateRequest` (conversion rules, idempotency, post-conversion cart lifecycle)
* Extension support (e.g., discount codes during browsing, fulfillment previews)

---

## 🤔 Rationale

**Why a separate resource instead of a "lightweight checkout"?**
Overloading checkout with a "pre-payment" mode would complicate the status lifecycle and capability negotiation contract. A separate cart resource with no status machine is simpler for both implementers and agents.

**Why full replacement instead of partial updates (add/remove item)?**
Consistent with ACP's existing checkout update pattern. Full replacement is simpler to implement and avoids the complexity of item-level CRUD operations (add, remove, change quantity as separate calls). The agent always has the full desired state and sends it. Future protocol versions MAY introduce optimistic concurrency (e.g., `If-Match` / ETag) if race conditions prove problematic in practice.

**Why reuse existing types instead of cart-specific types?**
Carts and checkouts share the same commerce domain (items, buyers, totals). Reusing types via `$ref` ensures consistency and reduces the schema surface area.

**Why is `currency` not required on cart create (unlike checkout)?**
Carts are lightweight. The seller determines currency from context (buyer locale, buyer address, storefront default, or seller default). If the seller cannot determine a currency, it SHOULD return `422 Unprocessable Entity`. Currency is always present on the cart response.

**Why defer cart-to-checkout conversion and extensions?**
Keeping the initial SEP focused on the core CRUD resource reduces scope and implementation complexity. The manual conversion path (read cart, create checkout with items) works today. `cart_id` conversion and extension support can be added additively in follow-up SEPs without breaking changes.

---

## 🔄 Backward Compatibility

This is a purely additive change with no breaking changes:

* New endpoints (`/carts/*`) do not conflict with existing paths.
* `"carts"` in the discovery services enum is a new value; existing values are unaffected.
* Cart is an optional service; sellers that don't implement it simply omit `"carts"` from their discovery document.
* No fields are added to or modified on existing ACP types. The checkout session schema is unchanged.

No deprecation or migration is needed.

---

## 🛠️ Reference Implementation

Not yet available. The RFC and schema definitions in this PR serve as the specification from which implementations can be built.

---

## 🔒 Security Implications

* **Authentication**: Cart endpoints use the same `Authorization: Bearer` mechanism as checkout. No new auth flows are introduced.
* **Data privacy**: Carts carry buyer email and item data, same sensitivity as checkout sessions. No additional PII exposure.
* **Cart enumeration**: Cart IDs are server-generated opaque strings. Sequential or predictable IDs SHOULD be avoided to prevent enumeration.
* **Expiry**: Carts support `expires_at` to prevent indefinite data retention. Sellers SHOULD set reasonable TTLs and SHOULD refresh expiry on successful updates.

---

## ✅ Pre-Submission Checklist

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
- [x] I have linked the SEP issue number above
- [x] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [x] I have signed the Contributor License Agreement (CLA)
- [x] This PR includes updates to OpenAPI/JSON schemas
- [x] This PR includes example requests/responses (in the RFC and OpenAPI)
- [x] This PR includes a changelog entry file in `changelog/unreleased/cart.md`
- [x] I am seeking or have found a sponsor (Founding Maintainer)

---

## 📚 Additional Context

The cart capability was designed based on common agent interaction patterns observed in early ACP implementations, where agents frequently needed to build baskets incrementally before committing to a purchase. The design prioritizes simplicity and reuse of existing ACP types to minimize the implementation surface area for sellers.

The scope was intentionally narrowed to focus on the core cart CRUD resource. Cart-to-checkout conversion (`cart_id` on checkout create) and extension support (e.g., discounts on carts) are deferred to follow-up SEPs that will build on this foundation additively.

---

## 🙋 Questions for Reviewers

1. **Update semantics**: Should cart update be `POST` (matching checkout) or `PUT` (more RESTful for full replacement)? The current proposal uses `POST` for consistency with ACP's existing patterns.
2. **Cart expiry defaults**: Should the spec recommend a default TTL (e.g., 24 hours, 7 days), or leave this entirely to the seller?
3. **Conversion path**: Is the manual cart-to-checkout conversion (read cart, create checkout) sufficient for the initial release, or should `cart_id` conversion be included in this SEP?
