### PR TITLE
SEP: Add Product Feeds API to Agentic Commerce Protocol

### DIFF
--- a/changelog/unreleased/add-feed-api.md
+++ b/changelog/unreleased/add-feed-api.md
@@ -1,0 +1,21 @@
+# Feed API
+
+**Added** – an unreleased Feed API surface for feed metadata and product catalog management.
+
+## New API Surface
+
+- `POST /feeds` to create feed metadata
+- `GET /feeds/{id}` to retrieve feed metadata
+- `GET /feeds/{id}/products` to retrieve the current product set
+- `PATCH /feeds/{id}/products` to partially upsert products by `Product.id`
+
+## File Ingestion Format
+
+- `metadata.json` uses the `FeedMetadata` shape
+- `products.jsonl` contains one `Product` object per line
+- file ingestion performs full replacement of the feed's product set
+- partial updates are only supported through `PATCH /feeds/{id}/products`
+
+## Deferred
+
+- promotions are intentionally deferred to a stacked follow-up PR

--- a/changelog/unreleased/add-feed-api.md
+++ b/changelog/unreleased/add-feed-api.md
@@ -4,10 +4,14 @@
 
 ## New API Surface
 
-- `POST /feeds` to create feed metadata
-- `GET /feeds/{id}` to retrieve feed metadata
-- `GET /feeds/{id}/products` to retrieve the current product set
-- `PATCH /feeds/{id}/products` to partially upsert products by `Product.id`
+These endpoints are hosted by Agents and called by merchants. The Feed API is a
+push model: merchants push product catalog metadata and product records to
+Agents, rather than Agents pulling catalog data from merchant-hosted endpoints.
+
+- `POST /feeds` for merchants to create feed metadata on an Agent-hosted feed service
+- `GET /feeds/{id}` for merchants to retrieve feed metadata from the Agent
+- `GET /feeds/{id}/products` for merchants to retrieve the current Agent-hosted product set
+- `PATCH /feeds/{id}/products` for merchants to partially upsert products by `Product.id` into the Agent-hosted feed
 
 ## File Ingestion Format
 

--- a/examples/unreleased/examples.feed.json
+++ b/examples/unreleased/examples.feed.json
@@ -1,0 +1,107 @@
+{
+  "create_feed_request_minimal": {
+    "target_country": "US"
+  },
+  "create_feed_response": {
+    "id": "feed_8f3K2x",
+    "target_country": "US",
+    "updated_at": "2026-03-01T00:00:00Z"
+  },
+  "get_feed_response": {
+    "id": "feed_8f3K2x",
+    "target_country": "US",
+    "updated_at": "2026-03-01T00:00:00Z"
+  },
+  "get_products_response": {
+    "products": [
+      {
+        "id": "prod_classic_tee",
+        "title": "Classic Tee",
+        "variants": [
+          {
+            "id": "sku123-red-s",
+            "title": "Classic Tee - Red / Small"
+          }
+        ]
+      }
+    ]
+  },
+  "upsert_products_request_single_product": {
+    "products": [
+      {
+        "id": "prod_classic_tee",
+        "title": "Classic Tee",
+        "description": {
+          "plain": "A classic cotton tee with a soft feel and relaxed fit."
+        },
+        "url": "https://merchant.com/products/classic-tee",
+        "media": [
+          {
+            "type": "image",
+            "url": "https://cdn.merchant.com/products/classic-tee/main.jpg",
+            "alt_text": "Classic Tee front view"
+          }
+        ],
+        "variants": [
+          {
+            "id": "sku124-red-m",
+            "title": "Classic Tee - Red / Medium",
+            "description": {
+              "plain": "Classic cotton tee in red, size medium."
+            },
+            "url": "https://merchant.com/products/classic-tee?variant=sku124-red-m",
+            "barcodes": [
+              {
+                "type": "GTIN",
+                "value": "00012345600029"
+              }
+            ],
+            "price": {
+              "amount": 1999,
+              "currency": "USD"
+            },
+            "availability": {
+              "available": false,
+              "status": "out_of_stock"
+            },
+            "variant_options": [
+              {
+                "name": "Color",
+                "value": "Red"
+              },
+              {
+                "name": "Size",
+                "value": "Medium"
+              }
+            ],
+            "media": [
+              {
+                "type": "image",
+                "url": "https://cdn.merchant.com/products/classic-tee/red-medium-1.jpg",
+                "alt_text": "Classic Tee in red, size medium"
+              }
+            ],
+            "seller": {
+              "name": "Example Merchant"
+            },
+            "marketplace": {
+              "name": "Example Marketplace"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "feed_error_not_found": {
+    "type": "invalid_request",
+    "code": "feed_not_found",
+    "message": "Feed not found",
+    "param": "id"
+  },
+  "feed_error_invalid_request": {
+    "type": "invalid_request",
+    "code": "invalid_product_payload",
+    "message": "products must contain at least one valid Product",
+    "param": "products"
+  }
+}

--- a/rfcs/rfc.product_feeds.md
+++ b/rfcs/rfc.product_feeds.md
@@ -1,0 +1,715 @@
+# RFC: Agentic Commerce - Product Feeds
+
+**Status:** Proposal
+**Version:** unreleased
+**Scope:** Product catalog publication, discovery, and consumption for agent-driven commerce flows
+
+This RFC introduces **Product Feeds** for the Agentic Commerce Protocol (ACP).
+Product feeds give merchants and seller platforms a standard way to publish
+product catalog data that agents can consume before checkout. Feeds provide the
+product, variant, price, availability, media, category, and seller information
+an agent needs to discover relevant products, explain choices to buyers, and
+create checkout sessions using merchant-recognized item identifiers.
+
+Product feeds are a discovery and merchandising surface. Checkout remains the
+authoritative surface for pricing, taxes, fulfillment, payment, policy checks,
+and order creation.
+
+---
+
+## 1. Motivation
+
+ACP currently standardizes checkout and related post-purchase surfaces, but
+agents still need a reliable way to answer a prior question: **"What can this
+merchant sell, and which exact item should be passed into checkout?"**
+
+Without a standard feed:
+
+- **Agents rely on scraping or proprietary catalog APIs**: Product discovery is
+  brittle, incomplete, and inconsistent across merchants.
+- **Checkout item identifiers are hard to obtain**: An agent may find a product
+  page but not know the variant ID, SKU, or item identifier accepted by
+  `POST /checkout_sessions`.
+- **Availability and pricing context is stale or missing**: Agents cannot
+  confidently recommend items, filter out unavailable variants, or explain
+  price differences before checkout.
+- **Merchants lose control over product representation**: Agents may infer
+  names, images, variants, seller details, or policy links from unstructured
+  pages rather than using merchant-provided data.
+- **Cross-merchant journeys are hard to normalize**: Comparing products across
+  merchants requires a common product and variant shape.
+
+Product feeds address these gaps by giving merchants a structured, ACP-native
+catalog surface that agents can ingest, index, and use to prepare checkout
+requests.
+
+### 1.1 What Agents Do With a Feed
+
+An agent consumes a product feed to:
+
+1. Build or refresh a searchable index of the merchant's products and variants.
+2. Match buyer intent to concrete purchasable variants, using attributes such as
+   title, description, category, condition, option values, price, availability,
+   seller, marketplace, media, and canonical product URLs.
+3. Present product choices to the buyer with enough context for review, such as
+   images, price, stock status, seller identity, and policy links.
+4. Select the merchant-recognized item identifier to pass into checkout.
+5. Re-check product context shortly before checkout so the buyer is not acting
+   on obviously stale price or availability information.
+
+Feeds do not authorize a purchase. They provide the input an agent needs to
+decide which checkout request to create.
+
+### 1.2 User Journeys
+
+#### Discovery to Checkout
+
+1. A buyer asks: "Find me a red cotton t-shirt under $25 that can arrive next
+   week."
+2. The agent uses the merchant's product feed to find matching `Product` and
+   `Variant` records.
+3. The agent filters variants by price, availability, condition, category, and
+   option values such as color and size.
+4. The agent presents the buyer with a small set of options, including product
+   images and current feed prices.
+5. After the buyer chooses a variant, the agent creates a checkout session using
+   the feed's checkout-compatible item identifier.
+6. The merchant returns authoritative checkout state, including final line item
+   details, tax, fulfillment options, messages, and totals.
+
+#### Comparison Across Merchants
+
+1. A buyer asks: "Compare noise-canceling headphones from Merchant A and
+   Merchant B."
+2. The agent consumes feeds from both merchants and normalizes product and
+   variant fields into an internal comparison model.
+3. The agent compares product attributes, media, price, availability, seller
+   identity, condition, and canonical URLs.
+4. The buyer selects an option.
+5. The agent proceeds with the chosen merchant's ACP checkout flow.
+
+#### Availability Change Before Checkout
+
+1. A buyer saves a recommendation and returns later.
+2. The merchant has since applied an incremental feed update marking the
+   selected variant as `out_of_stock`.
+3. Before checkout, the agent refreshes the feed metadata or product set.
+4. The agent sees the updated availability and asks the buyer to choose a
+   substitute rather than starting a checkout that is likely to fail.
+
+#### Merchant-Curated Agent Merchandising
+
+1. A merchant publishes product titles, descriptions, category assignments,
+   media, barcodes, seller information, and policy links in a feed.
+2. Agents use the merchant-provided content instead of scraping storefront HTML.
+3. The merchant controls which variants are purchasable by agents and how those
+   products are represented before checkout.
+
+---
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+1. **Structured product discovery**: Define a product and variant model agents
+   can ingest without scraping storefront pages.
+2. **Checkout compatibility**: Ensure feed identifiers can be used to construct
+   checkout requests or mapped deterministically to checkout item identifiers.
+3. **Merchant-controlled content**: Allow merchants to provide canonical names,
+   descriptions, URLs, images, prices, categories, seller details, and
+   availability signals.
+4. **Publication flexibility**: Support both offline full-snapshot ingestion and
+   API-based incremental upserts.
+5. **Fresh-enough agent indexes**: Provide metadata and update semantics that
+   let agents detect when cached catalog data should be refreshed.
+6. **Additive protocol surface**: Introduce feeds as an optional ACP service that
+   existing checkout integrations can adopt incrementally.
+
+### 2.2 Non-Goals
+
+- **Authoritative checkout pricing**: Feed prices are discovery-time signals.
+  Checkout session responses remain authoritative for pricing, tax,
+  fulfillment, discounts, fees, and totals.
+- **Search or ranking algorithms**: This RFC defines the data surface, not how
+  agents rank products or personalize recommendations.
+- **Promotion and coupon modeling**: Promotions are intentionally deferred to a
+  follow-up proposal.
+- **A complete product information management system**: The schema is optimized
+  for agent commerce, not full merchant PIM replacement.
+- **Real-time inventory reservations**: Availability in a feed does not reserve
+  inventory. Reservation semantics, if any, occur during checkout.
+- **Order, payment, or fulfillment lifecycle changes**: These remain covered by
+  existing ACP checkout and order specifications.
+- **Delta cursors for consumers**: This proposal supports publisher-side
+  incremental upserts. Consumer-facing change streams or cursor-based deltas are
+  deferred.
+
+---
+
+## 3. Design
+
+### 3.1 Feed Resource
+
+A feed is a merchant- or seller-platform-managed product catalog resource. A
+feed has server-managed metadata and a current product set.
+
+Feed metadata contains:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Stable server-generated feed identifier. |
+| `target_country` | string | No | ISO 3166-1 alpha-2 target market for the feed. |
+| `updated_at` | string | No | RFC 3339 timestamp for the most recent update applied to the feed. |
+
+Merchants MAY create multiple feeds for different markets, storefronts,
+languages, sellers, or marketplace partitions. When multiple feeds are
+available, agents SHOULD select the feed that best matches the buyer's market,
+locale, and merchant context.
+
+### 3.2 Product and Variant Model
+
+The feed schema separates products from variants:
+
+- `Product` groups one or more purchasable `Variant` records.
+- `Variant` represents the purchasable unit an agent usually passes to checkout.
+- Product-level fields describe the shared product concept.
+- Variant-level fields describe the specific offer, option selection, price,
+  availability, seller, and media.
+
+Important fields include:
+
+| Object | Field | Purpose |
+|---|---|---|
+| `Product` | `id` | Stable product grouping identifier. |
+| `Product` | `title`, `description`, `url`, `media` | Merchant-provided display and navigation context. |
+| `Product` | `variants` | Purchasable variants grouped under the product. |
+| `Variant` | `id` | Stable variant identifier, preferred for checkout item selection when variants exist. |
+| `Variant` | `title`, `description`, `url`, `media` | Variant-specific display context. |
+| `Variant` | `price`, `list_price`, `unit_price` | Discovery-time price information. |
+| `Variant` | `availability` | Purchasability and fulfillment state. |
+| `Variant` | `categories`, `condition`, `variant_options` | Filtering and comparison signals. |
+| `Variant` | `seller`, `marketplace` | Merchant-of-record and marketplace context. |
+
+Variant IDs SHOULD be stable across feed updates. If a merchant uses different
+identifiers for catalog variants and checkout items, the merchant MUST provide a
+deterministic mapping outside this RFC or ensure the feed `Variant.id` is
+accepted as an ACP checkout item ID.
+
+### 3.3 Feed vs Checkout
+
+| Aspect | Product Feed | Checkout Session |
+|---|---|---|
+| Purpose | Discovery and product selection | Purchase finalization |
+| Timing | Before buyer commits to purchase | After buyer chooses items |
+| Pricing | Informational, may be stale | Authoritative |
+| Tax and fulfillment totals | Not authoritative | Authoritative |
+| Inventory | Availability signal only | Validated by merchant |
+| Payment | None | Required to complete purchase |
+| Identifier use | Supplies product/variant IDs | Consumes item IDs |
+| Failure handling | Agent refreshes or substitutes | Merchant returns checkout messages/errors |
+
+Agents MUST treat checkout responses as authoritative even when they differ from
+feed data. Merchants SHOULD include checkout messages when price, availability,
+or policy constraints differ materially from the feed state the agent may have
+seen.
+
+### 3.4 Publication Models
+
+This RFC supports two publication models.
+
+#### Offline Full Replacement
+
+The merchant publishes a complete feed snapshot:
+
+- `metadata.json` contains the `FeedMetadata` shape.
+- `products.jsonl` contains one `Product` object per line.
+
+File ingestion replaces the full product set for the feed. Products omitted from
+the next full snapshot are removed from the current feed. This model is suitable
+for large catalogs and batch-oriented merchant systems.
+
+#### API-Based Incremental Upserts
+
+The merchant uses the Feed API to create metadata and partially upsert products:
+
+| Operation | Method | Endpoint | Description |
+|---|---|---|---|
+| Create Feed | `POST` | `/feeds` | Create feed metadata. |
+| Get Feed | `GET` | `/feeds/{id}` | Retrieve feed metadata. |
+| Get Feed Products | `GET` | `/feeds/{id}/products` | Retrieve the current product set. |
+| Upsert Feed Products | `PATCH` | `/feeds/{id}/products` | Create or update products by `Product.id`. |
+
+`PATCH /feeds/{id}/products` is an upsert operation. Products omitted from the
+request remain unchanged. For interoperability, merchants SHOULD send the
+complete current `Product` object for each `Product.id` being upserted unless a
+seller platform explicitly documents finer-grained merge semantics. Deleting
+products through partial updates is deferred; merchants SHOULD either publish a
+full replacement or mark variants as unavailable or discontinued when they
+should no longer be purchased.
+
+### 3.5 Discovery Integration
+
+Sellers advertise product feed support through ACP discovery. A seller that
+supports feeds SHOULD include `"feeds"` in `capabilities.services`:
+
+```json
+{
+  "protocol": {
+    "name": "acp",
+    "version": "2026-01-30",
+    "supported_versions": ["2026-01-30"]
+  },
+  "api_base_url": "https://merchant.example.com/api",
+  "transports": ["rest"],
+  "capabilities": {
+    "services": ["checkout", "feeds"]
+  }
+}
+```
+
+The initial Feed API assumes an agent has a feed identifier from discovery,
+merchant onboarding, a seller platform registry, or another trusted channel.
+A follow-up discovery update SHOULD define a standard way to advertise available
+feed descriptors, including feed ID, target country, locale, and product
+endpoint. Until that descriptor exists, sellers and platforms SHOULD document
+which feed IDs agents are expected to consume.
+
+### 3.6 Caching and Freshness
+
+Feed responses SHOULD be cacheable. Servers SHOULD include validators such as
+`ETag` or `Last-Modified` where possible, and agents SHOULD use conditional
+requests when refreshing large feeds.
+
+Agents SHOULD use `updated_at` on `FeedMetadata` as a coarse freshness signal:
+
+1. Cache the last observed `updated_at`.
+2. Poll `GET /feeds/{id}` or use platform-provided notifications.
+3. If `updated_at` changes, refresh `GET /feeds/{id}/products`.
+4. Re-index changed product data.
+
+Because this RFC does not define consumer-facing deltas, agents SHOULD assume
+`GET /feeds/{id}/products` returns the full current product set.
+
+---
+
+## 4. End-to-End Flow
+
+### 4.1 Merchant Publishes a Feed
+
+1. Merchant chooses feed scope, such as US catalog, UK catalog, or marketplace
+   seller subset.
+2. Merchant creates a feed:
+
+```http
+POST /feeds HTTP/1.1
+API-Version: 2026-01-30
+Idempotency-Key: idk_feed_create_123
+Content-Type: application/json
+
+{
+  "target_country": "US"
+}
+```
+
+3. Seller platform returns feed metadata:
+
+```http
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+  "id": "feed_8f3K2x",
+  "target_country": "US",
+  "updated_at": "2026-03-01T00:00:00Z"
+}
+```
+
+4. Merchant publishes an initial product set by either:
+   - uploading `metadata.json` and `products.jsonl` as a full replacement, or
+   - calling `PATCH /feeds/{id}/products` with product records.
+
+Example partial upsert:
+
+```http
+PATCH /feeds/feed_8f3K2x/products HTTP/1.1
+API-Version: 2026-01-30
+Content-Type: application/json
+
+{
+  "products": [
+    {
+      "id": "prod_classic_tee",
+      "title": "Classic Tee",
+      "description": {
+        "plain": "A classic cotton tee with a soft feel and relaxed fit."
+      },
+      "url": "https://merchant.example/products/classic-tee",
+      "media": [
+        {
+          "type": "image",
+          "url": "https://cdn.merchant.example/products/classic-tee/main.jpg",
+          "alt_text": "Classic Tee front view"
+        }
+      ],
+      "variants": [
+        {
+          "id": "sku124-red-m",
+          "title": "Classic Tee - Red / Medium",
+          "price": {
+            "amount": 1999,
+            "currency": "USD"
+          },
+          "availability": {
+            "available": true,
+            "status": "in_stock"
+          },
+          "variant_options": [
+            { "name": "Color", "value": "Red" },
+            { "name": "Size", "value": "Medium" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+5. Feed service updates the current product set and advances `updated_at`.
+6. Seller advertises feed support in discovery and makes the feed ID available
+   to authorized consuming agents or indexes.
+
+### 4.2 Agent Discovers and Consumes the Feed
+
+1. Agent starts with a seller domain, such as `merchant.example`.
+2. Agent fetches `https://merchant.example/.well-known/acp.json`.
+3. Agent verifies:
+   - ACP is supported.
+   - The agent's preferred API version is supported.
+   - `capabilities.services` contains `"feeds"` and `"checkout"`.
+4. Agent obtains the relevant feed ID from discovery, seller platform
+   onboarding, registry metadata, or another trusted channel.
+5. Agent retrieves feed metadata:
+
+```http
+GET /feeds/feed_8f3K2x HTTP/1.1
+API-Version: 2026-01-30
+```
+
+6. Agent retrieves the current product set:
+
+```http
+GET /feeds/feed_8f3K2x/products HTTP/1.1
+API-Version: 2026-01-30
+```
+
+7. Agent indexes the returned `Product[]` and stores freshness metadata such as
+   `updated_at`, `ETag`, or `Last-Modified`.
+8. When the buyer asks a product question, the agent searches the index and
+   grounds recommendations in feed-provided product and variant data.
+
+### 4.3 Agent Creates Checkout From Feed Data
+
+1. Buyer chooses the red medium Classic Tee.
+2. Agent refreshes or validates the selected variant if the cached feed state is
+   stale.
+3. Agent creates a checkout session using the checkout-compatible item ID:
+
+```http
+POST /checkout_sessions HTTP/1.1
+API-Version: 2026-01-30
+Idempotency-Key: idk_checkout_456
+Content-Type: application/json
+
+{
+  "items": [
+    {
+      "id": "sku124-red-m",
+      "quantity": 1
+    }
+  ]
+}
+```
+
+4. Merchant returns authoritative checkout state.
+5. If checkout returns a different price, unavailable item message, required
+   buyer input, or fulfillment constraint, the agent presents that state to the
+   buyer and follows the normal ACP checkout lifecycle.
+
+### 4.4 Incremental Updates Propagate
+
+1. Merchant inventory system marks `sku124-red-m` out of stock.
+2. Merchant calls `PATCH /feeds/feed_8f3K2x/products` with the affected product
+   and updated variant availability. For widest interoperability, the payload
+   includes the complete current `Product` representation for
+   `prod_classic_tee`:
+
+```json
+{
+  "products": [
+    {
+      "id": "prod_classic_tee",
+      "title": "Classic Tee",
+      "description": {
+        "plain": "A classic cotton tee with a soft feel and relaxed fit."
+      },
+      "url": "https://merchant.example/products/classic-tee",
+      "media": [
+        {
+          "type": "image",
+          "url": "https://cdn.merchant.example/products/classic-tee/main.jpg",
+          "alt_text": "Classic Tee front view"
+        }
+      ],
+      "variants": [
+        {
+          "id": "sku124-red-m",
+          "title": "Classic Tee - Red / Medium",
+          "price": {
+            "amount": 1999,
+            "currency": "USD"
+          },
+          "availability": {
+            "available": false,
+            "status": "out_of_stock"
+          },
+          "variant_options": [
+            { "name": "Color", "value": "Red" },
+            { "name": "Size", "value": "Medium" }
+          ],
+          "media": [
+            {
+              "type": "image",
+              "url": "https://cdn.merchant.example/products/classic-tee/red-medium-1.jpg",
+              "alt_text": "Classic Tee in red, size medium"
+            }
+          ],
+          "seller": {
+            "name": "Example Merchant"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+3. Feed service upserts the product by `Product.id` and advances `updated_at`.
+4. Agent detects the changed `updated_at` or cache validator.
+5. Agent refreshes `GET /feeds/{id}/products` and updates its index.
+6. Future recommendations avoid the unavailable variant or explain that it is
+   out of stock.
+7. If the buyer had already selected the variant, the agent asks for a substitute
+   before checkout or lets checkout return the authoritative failure message.
+
+---
+
+## 5. HTTP Interface
+
+All endpoints follow ACP REST conventions:
+
+- HTTPS required.
+- JSON request and response bodies.
+- Bearer authorization in the `Authorization` header required unless a seller
+  explicitly publishes a public read-only feed.
+- `API-Version` required.
+- Mutating requests SHOULD use idempotency where supported.
+- Errors use ACP's flat error shape:
+
+```json
+{
+  "type": "invalid_request",
+  "code": "feed_not_found",
+  "message": "Feed not found",
+  "param": "id"
+}
+```
+
+### 5.1 Create Feed
+
+`POST /feeds` creates feed metadata and returns `201 Created` with a
+`FeedMetadata` object.
+
+Request:
+
+```json
+{
+  "target_country": "US"
+}
+```
+
+Response:
+
+```json
+{
+  "id": "feed_8f3K2x",
+  "target_country": "US",
+  "updated_at": "2026-03-01T00:00:00Z"
+}
+```
+
+### 5.2 Get Feed
+
+`GET /feeds/{id}` returns the feed metadata.
+
+### 5.3 Get Feed Products
+
+`GET /feeds/{id}/products` returns the full current product set:
+
+```json
+{
+  "products": [
+    {
+      "id": "prod_classic_tee",
+      "title": "Classic Tee",
+      "variants": [
+        {
+          "id": "sku123-red-s",
+          "title": "Classic Tee - Red / Small"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 5.4 Upsert Feed Products
+
+`PATCH /feeds/{id}/products` upserts products by `Product.id`. Products omitted
+from the request remain unchanged. Merchants SHOULD submit complete current
+product objects for each upserted product unless the seller platform documents
+field-level merge behavior.
+
+Response:
+
+```json
+{
+  "id": "feed_8f3K2x",
+  "accepted": true
+}
+```
+
+---
+
+## 6. Rationale
+
+### 6.1 Why a Feed Instead of Search?
+
+Search APIs embed ranking, personalization, query syntax, and business rules
+that vary widely by merchant. Feeds are simpler and more interoperable: they let
+agents build their own retrieval layer while merchants keep control over source
+catalog data.
+
+### 6.2 Why Product and Variant Separation?
+
+Many commerce catalogs group several purchasable offers under one product page:
+size, color, condition, seller, or bundle variants. Agents need product-level
+context for explanation and variant-level context for checkout. Separating the
+two avoids ambiguous item selection.
+
+### 6.3 Why Full Snapshot Reads?
+
+Full snapshot reads are easy for consumers to reason about and match existing
+feed ingestion systems. Publisher-side incremental upserts reduce merchant
+write cost without requiring a more complex consumer cursor protocol in the
+first version.
+
+### 6.4 Why Checkout Remains Authoritative?
+
+Feed data can be cached, delayed, or scoped for discovery. Checkout has the
+current buyer, address, selected fulfillment option, payment context, merchant
+policy checks, and inventory validation. Keeping checkout authoritative avoids
+making feeds responsible for transactional guarantees they cannot provide.
+
+---
+
+## 7. Security, Privacy, and Trust
+
+- **No buyer data in feeds**: Product feeds MUST NOT contain buyer PII or
+  session-specific data.
+- **Management authorization**: Feed creation and product upserts MUST require
+  merchant or seller-platform authorization.
+- **Read authorization**: Sellers MAY publish public read-only feeds, but private
+  or restricted feeds MUST require authorization.
+- **Discovery enumeration**: Public discovery documents SHOULD avoid exposing
+  private feed IDs or merchant-specific data that would create enumeration risk.
+- **HTML and markdown safety**: Agents that render `description.html` or
+  `description.markdown` MUST sanitize content before display.
+- **Media safety**: Agents SHOULD proxy, cache, or otherwise handle media URLs in
+  a way that avoids leaking unnecessary buyer context to third-party hosts.
+- **Staleness handling**: Agents MUST NOT represent feed price or availability as
+  guaranteed. Buyer-facing UI SHOULD make clear that checkout confirms final
+  availability and totals.
+- **Abuse controls**: Feed endpoints SHOULD support rate limiting, cache
+  validators, and pagination or file-based transfer for large catalogs.
+
+---
+
+## 8. Backward Compatibility
+
+Product feeds are additive:
+
+- New endpoints under `/feeds` do not conflict with existing ACP endpoints.
+- The `"feeds"` discovery service value can be introduced in an unreleased or
+  future API version without changing existing service semantics.
+- Existing checkout sessions, order APIs, delegate payment, and delegate
+  authentication flows continue to work unchanged.
+- Agents that do not consume feeds can continue to create checkout sessions
+  using item identifiers obtained out-of-band.
+
+---
+
+## 9. Required Spec Updates
+
+- [ ] `spec/unreleased/json-schema/schema.feed.json` - Define `FeedMetadata`,
+  `CreateFeedRequest`, `Product`, `Variant`, product response, upsert request,
+  and upsert response schemas.
+- [ ] `spec/unreleased/openapi/openapi.feed.yaml` - Define `/feeds`,
+  `/feeds/{id}`, and `/feeds/{id}/products` REST endpoints.
+- [ ] `examples/unreleased/examples.feed.json` - Add feed creation, product
+  retrieval, product upsert, and error examples.
+- [ ] `changelog/unreleased/add-feed-api.md` - Document the new feed API
+  surface.
+- [ ] `spec/unreleased/json-schema/schema.agentic_checkout.json` - Add `"feeds"`
+  to discovery `capabilities.services`.
+- [ ] `rfcs/rfc.discovery.md` - Document the `"feeds"` service value and any
+  future feed descriptor fields.
+
+---
+
+## 10. Conformance Checklist
+
+**MUST requirements:**
+
+- [ ] Feed management implementations MUST create feed metadata with stable feed
+  IDs.
+- [ ] `GET /feeds/{id}` MUST return the current `FeedMetadata` or `404` if the
+  feed does not exist.
+- [ ] `GET /feeds/{id}/products` MUST return the full current product set.
+- [ ] `PATCH /feeds/{id}/products` MUST upsert products by `Product.id`.
+- [ ] Product records MUST include stable `Product.id` values.
+- [ ] Product records MUST include `variants`.
+- [ ] Variant records MUST include stable `Variant.id` and `title` values.
+- [ ] Agents MUST treat checkout responses as authoritative over feed data.
+
+**SHOULD requirements:**
+
+- [ ] Sellers SHOULD advertise feed support with `"feeds"` in discovery
+  `capabilities.services`.
+- [ ] Sellers SHOULD make feed IDs discoverable through a trusted channel.
+- [ ] Sellers SHOULD update `updated_at` after successful full replacements or
+  product upserts.
+- [ ] Sellers SHOULD include `ETag` or `Last-Modified` validators for large feed
+  responses.
+- [ ] Sellers SHOULD keep variant IDs stable across updates.
+- [ ] Agents SHOULD refresh stale feed data before creating checkout sessions.
+- [ ] Agents SHOULD sanitize rich descriptions before rendering.
+
+**MAY requirements:**
+
+- [ ] Sellers MAY publish multiple feeds for different target countries,
+  storefronts, sellers, or locales.
+- [ ] Sellers MAY publish public read-only feeds.
+- [ ] Sellers MAY require authorization for feed reads.
+- [ ] Sellers MAY use full replacement file ingestion for large catalogs.
+- [ ] Sellers MAY use `PATCH /feeds/{id}/products` for small incremental
+  updates.

--- a/rfcs/rfc.product_feeds.md
+++ b/rfcs/rfc.product_feeds.md
@@ -386,8 +386,8 @@ GET /feeds/feed_8f3K2x/products HTTP/1.1
 API-Version: 2026-01-30
 ```
 
-7. Agent indexes the returned `Product[]` and stores freshness metadata such as
-   `updated_at`, `ETag`, or `Last-Modified`.
+7. Agent indexes the returned `Product[]` and stores the last observed
+   `updated_at` value.
 8. When the buyer asks a product question, the agent searches the index and
    grounds recommendations in feed-provided product and variant data.
 
@@ -478,7 +478,7 @@ Content-Type: application/json
 ```
 
 3. Feed service upserts the product by `Product.id` and advances `updated_at`.
-4. Agent detects the changed `updated_at` or cache validator.
+4. Agent detects the changed `updated_at`.
 5. Agent refreshes `GET /feeds/{id}/products` and updates its index.
 6. Future recommendations avoid the unavailable variant or explain that it is
    out of stock.
@@ -623,8 +623,8 @@ making feeds responsible for transactional guarantees they cannot provide.
 - **Staleness handling**: Agents MUST NOT represent feed price or availability as
   guaranteed. Buyer-facing UI SHOULD make clear that checkout confirms final
   availability and totals.
-- **Abuse controls**: Feed endpoints SHOULD support rate limiting, cache
-  validators, and pagination or file-based transfer for large catalogs.
+- **Abuse controls**: Feed endpoints SHOULD support rate limiting and pagination
+  or file-based transfer for large catalogs.
 
 ---
 
@@ -682,8 +682,6 @@ Product feeds are additive:
 - [ ] Sellers SHOULD make feed IDs discoverable through a trusted channel.
 - [ ] Sellers SHOULD update `updated_at` after successful full replacements or
   product upserts.
-- [ ] Sellers SHOULD include `ETag` or `Last-Modified` validators for large feed
-  responses.
 - [ ] Sellers SHOULD keep variant IDs stable across updates.
 - [ ] Agents SHOULD refresh stale feed data before creating checkout sessions.
 - [ ] Agents SHOULD sanitize rich descriptions before rendering.

--- a/rfcs/rfc.product_feeds.md
+++ b/rfcs/rfc.product_feeds.md
@@ -93,7 +93,8 @@ decide which checkout request to create.
 1. A buyer saves a recommendation and returns later.
 2. The merchant has since applied an incremental feed update marking the
    selected variant as `out_of_stock`.
-3. Before checkout, the agent refreshes the feed metadata or product set.
+3. Before checkout, the agent refreshes its local index from its current
+   agent-hosted feed state.
 4. The agent sees the updated availability and asks the buyer to choose a
    substitute rather than starting a checkout that is likely to fail.
 
@@ -121,7 +122,8 @@ decide which checkout request to create.
 4. **Publication flexibility**: Support both offline full-snapshot ingestion and
    API-based incremental upserts.
 5. **Fresh-enough agent indexes**: Provide metadata and update semantics that
-   let agents detect when cached catalog data should be refreshed.
+   let merchants and agents coordinate the latest catalog state known to the
+   agent.
 6. **Additive protocol surface**: Introduce feeds as an optional ACP service that
    existing checkout integrations can adopt incrementally.
 
@@ -140,9 +142,9 @@ decide which checkout request to create.
   inventory. Reservation semantics, if any, occur during checkout.
 - **Order, payment, or fulfillment lifecycle changes**: These remain covered by
   existing ACP checkout and order specifications.
-- **Delta cursors for consumers**: This proposal supports publisher-side
-  incremental upserts. Consumer-facing change streams or cursor-based deltas are
-  deferred.
+- **Delta cursors for feed reads**: This proposal supports publisher-side
+  incremental upserts and merchant readback of current state. Cursor-based
+  deltas are deferred.
 
 ---
 
@@ -150,8 +152,12 @@ decide which checkout request to create.
 
 ### 3.1 Feed Resource
 
-A feed is a merchant- or seller-platform-managed product catalog resource. A
-feed has server-managed metadata and a current product set.
+A feed is an agent-managed product catalog resource populated by a merchant or
+seller platform. A feed has server-managed metadata and a current product set.
+The Product Feed API is hosted by the agent. Merchants and seller platforms call
+these endpoints to create feeds, upsert product data, and inspect the latest
+feed state known to the agent. Agents MUST NOT call Product Feed API endpoints
+on merchants.
 
 Feed metadata contains:
 
@@ -163,7 +169,7 @@ Feed metadata contains:
 
 Merchants MAY create multiple feeds for different markets, storefronts,
 languages, sellers, or marketplace partitions. When multiple feeds are
-available, agents SHOULD select the feed that best matches the buyer's market,
+available, agents SHOULD use the feed that best matches the buyer's market,
 locale, and merchant context.
 
 ### 3.2 Product and Variant Model
@@ -230,7 +236,8 @@ for large catalogs and batch-oriented merchant systems.
 
 #### API-Based Incremental Upserts
 
-The merchant uses the Feed API to create metadata and partially upsert products:
+The merchant uses the agent-hosted Feed API to create metadata, inspect the
+latest feed state known to the agent, and partially upsert products:
 
 | Operation | Method | Endpoint | Description |
 |---|---|---|---|
@@ -267,12 +274,14 @@ supports feeds SHOULD include `"feeds"` in `capabilities.services`:
 }
 ```
 
-The initial Feed API assumes an agent has a feed identifier from discovery,
-merchant onboarding, a seller platform registry, or another trusted channel.
-A follow-up discovery update SHOULD define a standard way to advertise available
-feed descriptors, including feed ID, target country, locale, and product
-endpoint. Until that descriptor exists, sellers and platforms SHOULD document
-which feed IDs agents are expected to consume.
+The initial Feed API assumes the merchant has an agent-hosted Feed API base URL
+and feed identifier from agent onboarding, a seller platform registry, or another
+trusted channel. Discovery advertises that the seller supports feeds, but it does
+not make the merchant's ACP API a Product Feed API host. A follow-up discovery
+update SHOULD define a standard way to advertise available feed descriptors,
+including feed ID, target country, locale, and agent-hosted product endpoint.
+Until that descriptor exists, sellers and platforms SHOULD document which feed
+IDs merchants are expected to populate and inspect on the agent.
 
 ---
 
@@ -282,7 +291,7 @@ which feed IDs agents are expected to consume.
 
 1. Merchant chooses feed scope, such as US catalog, UK catalog, or marketplace
    seller subset.
-2. Merchant creates a feed:
+2. Merchant creates a feed on the agent-hosted Feed API:
 
 ```http
 POST /feeds HTTP/1.1
@@ -295,7 +304,7 @@ Content-Type: application/json
 }
 ```
 
-3. Seller platform returns feed metadata:
+3. Agent-hosted feed service returns feed metadata:
 
 ```http
 HTTP/1.1 201 Created
@@ -308,7 +317,7 @@ Content-Type: application/json
 }
 ```
 
-4. Merchant publishes an initial product set by either:
+4. Merchant publishes an initial product set to the agent by either:
    - uploading `metadata.json` and `products.jsonl` as a full replacement, or
    - calling `PATCH /feeds/{id}/products` with product records.
 
@@ -358,44 +367,51 @@ Content-Type: application/json
 }
 ```
 
-5. Feed service updates the current product set and advances `updated_at`.
+5. Agent-hosted feed service updates the current product set and advances
+   `updated_at`.
 6. Seller advertises feed support in discovery and makes the feed ID available
-   to authorized consuming agents or indexes.
+   to authorized merchant systems or seller platforms that will populate and
+   inspect the agent-hosted feed.
 
-### 4.2 Agent Discovers and Consumes the Feed
+### 4.2 Merchant Inspects Agent-Known Feed State
 
-1. Agent starts with a seller domain, such as `merchant.example`.
-2. Agent fetches `https://merchant.example/.well-known/acp.json`.
-3. Agent verifies:
-   - ACP is supported.
-   - The agent's preferred API version is supported.
-   - `capabilities.services` contains `"feeds"` and `"checkout"`.
-4. Agent obtains the relevant feed ID from discovery, seller platform
-   onboarding, registry metadata, or another trusted channel.
-5. Agent retrieves feed metadata:
+The Product Feed API call direction is merchant-to-agent. The agent never calls
+`GET /feeds/{id}`, `GET /feeds/{id}/products`, or any other Product Feed API
+endpoint on the merchant.
+
+1. Merchant starts with an agent-hosted Feed API base URL and feed ID from agent
+   onboarding, seller platform registry metadata, or another trusted channel.
+2. Merchant may verify its own ACP discovery document advertises feed support so
+   agents know feed-backed checkout can be used for this seller.
+3. Merchant retrieves the current feed metadata known to the agent:
 
 ```http
 GET /feeds/feed_8f3K2x HTTP/1.1
 API-Version: 2026-01-30
 ```
 
-6. Agent retrieves the current product set:
+4. Merchant retrieves the current product set known to the agent:
 
 ```http
 GET /feeds/feed_8f3K2x/products HTTP/1.1
 API-Version: 2026-01-30
 ```
 
-7. Agent indexes the returned `Product[]` and stores the last observed
-   `updated_at` value.
-8. When the buyer asks a product question, the agent searches the index and
-   grounds recommendations in feed-provided product and variant data.
+5. Merchant compares the returned `FeedMetadata.updated_at` and `Product[]`
+   state with its source catalog.
+6. Merchant calls `PATCH /feeds/{id}/products` or publishes a full replacement
+   when the agent-known state is stale or incomplete.
+7. The agent indexes its own current product set and stores the last observed
+   `updated_at` value internally.
+8. When the buyer asks a product question, the agent searches its local index and
+   grounds recommendations in the feed-provided product and variant data it has
+   received.
 
 ### 4.3 Agent Creates Checkout From Feed Data
 
 1. Buyer chooses the red medium Classic Tee.
-2. Agent refreshes or validates the selected variant if the cached feed state is
-   stale.
+2. Agent refreshes or validates the selected variant from its current
+   agent-hosted feed state if the cached index is stale.
 3. Agent creates a checkout session using the checkout-compatible item ID:
 
 ```http
@@ -477,9 +493,10 @@ Content-Type: application/json
 }
 ```
 
-3. Feed service upserts the product by `Product.id` and advances `updated_at`.
-4. Agent detects the changed `updated_at`.
-5. Agent refreshes `GET /feeds/{id}/products` and updates its index.
+3. Agent-hosted feed service upserts the product by `Product.id` and advances
+   `updated_at`.
+4. Agent detects that its agent-hosted feed state has a changed `updated_at`.
+5. Agent refreshes its local index from the current feed state it already hosts.
 6. Future recommendations avoid the unavailable variant or explain that it is
    out of stock.
 7. If the buyer had already selected the variant, the agent asks for a substitute
@@ -489,12 +506,17 @@ Content-Type: application/json
 
 ## 5. HTTP Interface
 
+The endpoints in this section are implemented by the agent-hosted Feed API.
+Merchants and seller platforms call them on the agent to publish product data
+and read back the latest state known to the agent. Agents MUST NOT call these
+endpoints on merchants.
+
 All endpoints follow ACP REST conventions:
 
 - HTTPS required.
 - JSON request and response bodies.
-- Bearer authorization in the `Authorization` header required unless a seller
-  explicitly publishes a public read-only feed.
+- Bearer authorization in the `Authorization` header required unless the seller
+  explicitly authorizes public read-only access to the agent-hosted feed.
 - `API-Version` required.
 - Mutating requests SHOULD use idempotency where supported.
 - Errors use ACP's flat error shape:
@@ -533,11 +555,14 @@ Response:
 
 ### 5.2 Get Feed
 
-`GET /feeds/{id}` returns the feed metadata.
+`GET /feeds/{id}` returns the feed metadata known to the agent. This endpoint is
+for merchant or seller-platform readback against the agent-hosted Feed API.
 
 ### 5.3 Get Feed Products
 
-`GET /feeds/{id}/products` returns the full current product set:
+`GET /feeds/{id}/products` returns the full current product set known to the
+agent. This endpoint is for merchant or seller-platform readback against the
+agent-hosted Feed API:
 
 ```json
 {
@@ -592,10 +617,10 @@ two avoids ambiguous item selection.
 
 ### 6.3 Why Full Snapshot Reads?
 
-Full snapshot reads are easy for consumers to reason about and match existing
-feed ingestion systems. Publisher-side incremental upserts reduce merchant
-write cost without requiring a more complex consumer cursor protocol in the
-first version.
+Full snapshot reads are easy for merchants and seller platforms to reason about
+when checking the latest feed state known to the agent. Publisher-side
+incremental upserts reduce merchant write cost without requiring a more complex
+cursor protocol in the first version.
 
 ### 6.4 Why Checkout Remains Authoritative?
 
@@ -612,8 +637,9 @@ making feeds responsible for transactional guarantees they cannot provide.
   session-specific data.
 - **Management authorization**: Feed creation and product upserts MUST require
   merchant or seller-platform authorization.
-- **Read authorization**: Sellers MAY publish public read-only feeds, but private
-  or restricted feeds MUST require authorization.
+- **Read authorization**: Sellers MAY authorize public read-only access to
+  agent-hosted feeds, but private or restricted feed reads MUST require
+  authorization.
 - **Discovery enumeration**: Public discovery documents SHOULD avoid exposing
   private feed IDs or merchant-specific data that would create enumeration risk.
 - **HTML and markdown safety**: Agents that render `description.html` or
@@ -623,8 +649,8 @@ making feeds responsible for transactional guarantees they cannot provide.
 - **Staleness handling**: Agents MUST NOT represent feed price or availability as
   guaranteed. Buyer-facing UI SHOULD make clear that checkout confirms final
   availability and totals.
-- **Abuse controls**: Feed endpoints SHOULD support rate limiting and pagination
-  or file-based transfer for large catalogs.
+- **Abuse controls**: Agent-hosted feed endpoints SHOULD support rate limiting
+  and pagination or file-based transfer for large catalogs.
 
 ---
 
@@ -632,7 +658,8 @@ making feeds responsible for transactional guarantees they cannot provide.
 
 Product feeds are additive:
 
-- New endpoints under `/feeds` do not conflict with existing ACP endpoints.
+- New agent-hosted endpoints under `/feeds` do not conflict with existing ACP
+  endpoints.
 - The `"feeds"` discovery service value can be introduced in an unreleased or
   future API version without changing existing service semantics.
 - Existing checkout sessions, order APIs, delegate payment, and delegate
@@ -647,8 +674,8 @@ Product feeds are additive:
 - [ ] `spec/unreleased/json-schema/schema.feed.json` - Define `FeedMetadata`,
   `CreateFeedRequest`, `Product`, `Variant`, product response, upsert request,
   and upsert response schemas.
-- [ ] `spec/unreleased/openapi/openapi.feed.yaml` - Define `/feeds`,
-  `/feeds/{id}`, and `/feeds/{id}/products` REST endpoints.
+- [ ] `spec/unreleased/openapi/openapi.feed.yaml` - Define the agent-hosted
+  `/feeds`, `/feeds/{id}`, and `/feeds/{id}/products` REST endpoints.
 - [ ] `examples/unreleased/examples.feed.json` - Add feed creation, product
   retrieval, product upsert, and error examples.
 - [ ] `changelog/unreleased/add-feed-api.md` - Document the new feed API
@@ -664,10 +691,11 @@ Product feeds are additive:
 
 **MUST requirements:**
 
-- [ ] Feed management implementations MUST create feed metadata with stable feed
-  IDs.
+- [ ] Agent-hosted feed management implementations MUST create feed metadata
+  with stable feed IDs.
+- [ ] Agents MUST NOT call Product Feed API endpoints on merchants.
 - [ ] `GET /feeds/{id}` MUST return the current `FeedMetadata` or `404` if the
-  feed does not exist.
+  feed does not exist when called on the agent-hosted Feed API.
 - [ ] `GET /feeds/{id}/products` MUST return the full current product set.
 - [ ] `PATCH /feeds/{id}/products` MUST upsert products by `Product.id`.
 - [ ] Product records MUST include stable `Product.id` values.
@@ -679,19 +707,22 @@ Product feeds are additive:
 
 - [ ] Sellers SHOULD advertise feed support with `"feeds"` in discovery
   `capabilities.services`.
-- [ ] Sellers SHOULD make feed IDs discoverable through a trusted channel.
+- [ ] Sellers SHOULD make feed IDs discoverable to authorized merchant systems
+  or seller platforms through a trusted channel.
 - [ ] Sellers SHOULD update `updated_at` after successful full replacements or
   product upserts.
 - [ ] Sellers SHOULD keep variant IDs stable across updates.
-- [ ] Agents SHOULD refresh stale feed data before creating checkout sessions.
+- [ ] Agents SHOULD refresh stale local indexes from their agent-hosted feed
+  state before creating checkout sessions.
 - [ ] Agents SHOULD sanitize rich descriptions before rendering.
 
 **MAY requirements:**
 
 - [ ] Sellers MAY publish multiple feeds for different target countries,
   storefronts, sellers, or locales.
-- [ ] Sellers MAY publish public read-only feeds.
-- [ ] Sellers MAY require authorization for feed reads.
+- [ ] Sellers MAY authorize public read-only access to agent-hosted feeds.
+- [ ] Agent-hosted Feed API implementations MAY require authorization for feed
+  reads.
 - [ ] Sellers MAY use full replacement file ingestion for large catalogs.
 - [ ] Sellers MAY use `PATCH /feeds/{id}/products` for small incremental
   updates.

--- a/rfcs/rfc.product_feeds.md
+++ b/rfcs/rfc.product_feeds.md
@@ -274,22 +274,6 @@ feed descriptors, including feed ID, target country, locale, and product
 endpoint. Until that descriptor exists, sellers and platforms SHOULD document
 which feed IDs agents are expected to consume.
 
-### 3.6 Caching and Freshness
-
-Feed responses SHOULD be cacheable. Servers SHOULD include validators such as
-`ETag` or `Last-Modified` where possible, and agents SHOULD use conditional
-requests when refreshing large feeds.
-
-Agents SHOULD use `updated_at` on `FeedMetadata` as a coarse freshness signal:
-
-1. Cache the last observed `updated_at`.
-2. Poll `GET /feeds/{id}` or use platform-provided notifications.
-3. If `updated_at` changes, refresh `GET /feeds/{id}/products`.
-4. Re-index changed product data.
-
-Because this RFC does not define consumer-facing deltas, agents SHOULD assume
-`GET /feeds/{id}/products` returns the full current product set.
-
 ---
 
 ## 4. End-to-End Flow

--- a/spec/unreleased/json-schema/schema.feed.json
+++ b/spec/unreleased/json-schema/schema.feed.json
@@ -1,0 +1,626 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/feed/bundle.schema.json",
+  "title": "Feed - Schema Bundle",
+  "$defs": {
+    "Description": {
+      "description": "Structured long-form or rich-text description content for a product or variant.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "plain": {
+          "type": "string",
+          "description": "Plain-text description intended for clients that do not render rich formatting."
+        },
+        "html": {
+          "type": "string",
+          "description": "HTML-formatted description content."
+        },
+        "markdown": {
+          "type": "string",
+          "description": "Markdown-formatted description content."
+        }
+      },
+      "minProperties": 1,
+      "example": {
+        "plain": "Classic cotton tee in red, size small."
+      }
+    },
+    "Price": {
+      "description": "Monetary amount expressed in minor units with an associated ISO 4217 currency code.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["amount", "currency"],
+      "properties": {
+        "amount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Monetary amount expressed in ISO 4217 minor units."
+        },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$",
+          "description": "Three-letter ISO 4217 currency identifier."
+        }
+      },
+      "example": {
+        "amount": 1999,
+        "currency": "USD"
+      }
+    },
+    "Availability": {
+      "description": "Purchasability and fulfillment state for a variant.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available": {
+          "type": "boolean",
+          "description": "Indicates whether the variant is currently purchasable. Use status for fulfillment context."
+        },
+        "status": {
+          "type": "string",
+          "description": "Extensible fulfillment state for the variant. Known values include in_stock, limited_stock, backorder, preorder, out_of_stock, and discontinued."
+        }
+      },
+      "example": {
+        "available": true,
+        "status": "in_stock"
+      }
+    },
+    "Barcode": {
+      "description": "Machine-readable identifier attached to a variant, such as a GTIN or UPC.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "value"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Barcode scheme or identifier type, such as GTIN, UPC, or EAN."
+        },
+        "value": {
+          "type": "string",
+          "description": "Raw barcode value as provided by the merchant."
+        }
+      },
+      "example": {
+        "type": "GTIN",
+        "value": "00012345600012"
+      }
+    },
+    "Media": {
+      "description": "Media asset associated with a product or variant.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "url"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Media kind, such as image, video, or model."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical URL where the media asset can be retrieved."
+        },
+        "alt_text": {
+          "type": "string",
+          "description": "Human-readable alternate text describing the asset."
+        },
+        "width": {
+          "type": "integer",
+          "description": "Rendered width of the asset in pixels, when known."
+        },
+        "height": {
+          "type": "integer",
+          "description": "Rendered height of the asset in pixels, when known."
+        }
+      },
+      "example": {
+        "type": "image",
+        "url": "https://cdn.merchant.com/products/classic-tee/main.jpg",
+        "alt_text": "Classic Tee front view"
+      }
+    },
+    "VariantOption": {
+      "description": "One selected characteristic of a variant, such as size or color.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "value"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Display name of the option dimension, such as Color or Size."
+        },
+        "value": {
+          "type": "string",
+          "description": "Selected option value for this variant."
+        }
+      },
+      "example": {
+        "name": "Color",
+        "value": "Red"
+      }
+    },
+    "Category": {
+      "description": "Category assignment for a product or variant within a specific taxonomy.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value"],
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "Category label or hierarchical path, for example Mens > Sweaters > Crewnecks."
+        },
+        "taxonomy": {
+          "type": "string",
+          "description": "Names the taxonomy system used for the category value, such as google_product_category, shopify, or merchant."
+        }
+      },
+      "example": {
+        "value": "Apparel > Shirts",
+        "taxonomy": "merchant"
+      }
+    },
+    "Link": {
+      "description": "Merchant-provided informational or policy link associated with a seller.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "url"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Extensible link type, such as privacy_policy, terms_of_service, refund_policy, shipping_policy, or faq."
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable label for the linked resource."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical URL for the linked resource."
+        }
+      },
+      "example": {
+        "type": "shipping_policy",
+        "title": "Shipping Policy",
+        "url": "https://merchant.com/policies/shipping"
+      }
+    },
+    "Seller": {
+      "description": "Merchant or seller identity associated with a variant offer.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Display name of the seller or merchant of record."
+        },
+        "links": {
+          "type": "array",
+          "description": "Informational or policy links associated with this seller.",
+          "items": {
+            "$ref": "#/$defs/Link"
+          }
+        }
+      },
+      "example": {
+        "name": "Example Merchant",
+        "links": [
+          {
+            "type": "refund_policy",
+            "title": "Refund Policy",
+            "url": "https://merchant.com/policies/refunds"
+          }
+        ]
+      }
+    },
+    "Condition": {
+      "description": "Extensible list of applicable item conditions, such as new or secondhand.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Condition label supplied by the merchant."
+      },
+      "example": ["new"]
+    },
+    "Measure": {
+      "description": "Measured quantity paired with a unit for unit-price calculations.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "unit"],
+      "properties": {
+        "value": {
+          "type": "number",
+          "description": "Measured quantity for the package or item."
+        },
+        "unit": {
+          "type": "string",
+          "description": "Unit label for the measured quantity, such as oz, ml, or kg."
+        }
+      },
+      "example": {
+        "value": 12,
+        "unit": "oz"
+      }
+    },
+    "ReferenceMeasure": {
+      "description": "Reference unit used when normalizing a unit price for display.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "unit"],
+      "properties": {
+        "value": {
+          "type": "integer",
+          "description": "Reference quantity used to normalize the unit price."
+        },
+        "unit": {
+          "type": "string",
+          "description": "Reference unit label, such as ml, g, or oz."
+        }
+      },
+      "example": {
+        "value": 100,
+        "unit": "ml"
+      }
+    },
+    "UnitPrice": {
+      "description": "Normalized unit price for products sold by weight, volume, or measure.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["amount", "currency", "measure", "reference"],
+      "properties": {
+        "amount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Normalized price amount expressed in ISO 4217 minor units."
+        },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$",
+          "description": "Three-letter ISO 4217 currency identifier."
+        },
+        "measure": {
+          "$ref": "#/$defs/Measure",
+          "description": "Actual packaged measure associated with the sale item."
+        },
+        "reference": {
+          "$ref": "#/$defs/ReferenceMeasure",
+          "description": "Reference measure used to display the normalized unit price."
+        }
+      },
+      "example": {
+        "amount": 499,
+        "currency": "USD",
+        "measure": {
+          "value": 12,
+          "unit": "oz"
+        },
+        "reference": {
+          "value": 1,
+          "unit": "oz"
+        }
+      }
+    },
+    "Variant": {
+      "description": "Purchasable variant of a product within a feed.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable global identifier for this variant."
+        },
+        "title": {
+          "type": "string",
+          "description": "Display title for the variant."
+        },
+        "description": {
+          "$ref": "#/$defs/Description",
+          "description": "Structured description content for the variant."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical URL for the variant detail page."
+        },
+        "barcodes": {
+          "type": "array",
+          "description": "Machine-readable identifiers associated with this variant.",
+          "items": {
+            "$ref": "#/$defs/Barcode"
+          }
+        },
+        "price": {
+          "$ref": "#/$defs/Price",
+          "description": "Active selling price for the variant."
+        },
+        "list_price": {
+          "$ref": "#/$defs/Price",
+          "description": "Reference or pre-discount price for the variant."
+        },
+        "unit_price": {
+          "$ref": "#/$defs/UnitPrice",
+          "description": "Normalized unit price, when applicable."
+        },
+        "availability": {
+          "$ref": "#/$defs/Availability",
+          "description": "Purchasability and fulfillment state for the variant."
+        },
+        "categories": {
+          "type": "array",
+          "description": "Category assignments associated with this variant.",
+          "items": {
+            "$ref": "#/$defs/Category"
+          }
+        },
+        "condition": {
+          "$ref": "#/$defs/Condition",
+          "description": "Extensible list of conditions applicable to this variant."
+        },
+        "variant_options": {
+          "type": "array",
+          "description": "Option selections that distinguish this variant, such as Color: Red or Size: Small.",
+          "items": {
+            "$ref": "#/$defs/VariantOption"
+          }
+        },
+        "media": {
+          "type": "array",
+          "description": "Media assets specific to this variant. The first item is the primary listing asset.",
+          "items": {
+            "$ref": "#/$defs/Media"
+          }
+        },
+        "seller": {
+          "$ref": "#/$defs/Seller",
+          "description": "Seller or merchant of record for this variant."
+        },
+        "marketplace": {
+          "$ref": "#/$defs/Seller",
+          "description": "Marketplace or intermediary platform through which this variant is offered, if applicable."
+        }
+      },
+      "example": {
+        "id": "sku123-red-s",
+        "title": "Classic Tee - Red / Small",
+        "description": {
+          "plain": "Classic cotton tee in red, size small."
+        },
+        "url": "https://merchant.com/products/classic-tee?variant=sku123-red-s",
+        "barcodes": [
+          {
+            "type": "GTIN",
+            "value": "00012345600012"
+          }
+        ],
+        "price": {
+          "amount": 1999,
+          "currency": "USD"
+        },
+        "list_price": {
+          "amount": 2499,
+          "currency": "USD"
+        },
+        "availability": {
+          "available": true,
+          "status": "in_stock"
+        },
+        "variant_options": [
+          {
+            "name": "Color",
+            "value": "Red"
+          },
+          {
+            "name": "Size",
+            "value": "Small"
+          }
+        ],
+        "media": [
+          {
+            "type": "image",
+            "url": "https://cdn.merchant.com/products/classic-tee/red-small-1.jpg",
+            "alt_text": "Classic Tee in red, size small"
+          }
+        ],
+        "seller": {
+          "name": "Example Merchant"
+        },
+        "marketplace": {
+          "name": "Example Marketplace"
+        }
+      }
+    },
+    "Product": {
+      "description": "Catalog product grouping one or more purchasable variants within a feed.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "variants"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable global identifier for this product."
+        },
+        "title": {
+          "type": "string",
+          "description": "Display title for the product."
+        },
+        "description": {
+          "$ref": "#/$defs/Description",
+          "description": "Structured description content for the product."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical URL for the product detail page."
+        },
+        "media": {
+          "type": "array",
+          "description": "Media assets associated with the product.",
+          "items": {
+            "$ref": "#/$defs/Media"
+          }
+        },
+        "variants": {
+          "type": "array",
+          "description": "Purchasable variants grouped under this product.",
+          "items": {
+            "$ref": "#/$defs/Variant"
+          }
+        }
+      },
+      "example": {
+        "id": "prod_classic_tee",
+        "title": "Classic Tee",
+        "media": [
+          {
+            "type": "image",
+            "url": "https://cdn.merchant.com/products/classic-tee/main.jpg",
+            "alt_text": "Classic Tee front view"
+          }
+        ],
+        "variants": [
+          {
+            "id": "sku123-red-s",
+            "title": "Classic Tee - Red / Small"
+          }
+        ]
+      }
+    },
+    "FeedMetadata": {
+      "description": "Server-managed metadata describing a feed resource.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable identifier for the feed resource."
+        },
+        "target_country": {
+          "type": "string",
+          "pattern": "^[A-Z]{2}$",
+          "description": "Optional ISO 3166-1 alpha-2 country code describing the feed's target market."
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the most recent update applied to this feed."
+        }
+      },
+      "example": {
+        "id": "feed_8f3K2x",
+        "target_country": "US",
+        "updated_at": "2026-03-01T00:00:00Z"
+      }
+    },
+    "CreateFeedRequest": {
+      "description": "Request payload used to create a feed.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "target_country": {
+          "type": "string",
+          "pattern": "^[A-Z]{2}$",
+          "description": "Optional ISO 3166-1 alpha-2 country code describing the feed's target market."
+        }
+      },
+      "example": {
+        "target_country": "US"
+      }
+    },
+    "ProductsResponse": {
+      "description": "Response envelope containing the current product set for a feed.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["products"],
+      "properties": {
+        "products": {
+          "type": "array",
+          "description": "Full list of products currently associated with the feed.",
+          "items": {
+            "$ref": "#/$defs/Product"
+          }
+        }
+      },
+      "example": {
+        "products": [
+          {
+            "id": "prod_classic_tee",
+            "title": "Classic Tee",
+            "variants": [
+              {
+                "id": "sku123-red-s",
+                "title": "Classic Tee - Red / Small"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "UpsertProductsRequest": {
+      "description": "Request payload that partially upserts products into a feed. Products omitted from the request remain unchanged.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["products"],
+      "properties": {
+        "products": {
+          "type": "array",
+          "description": "Subset of products to create or update within the feed, matched by Product.id.",
+          "items": {
+            "$ref": "#/$defs/Product"
+          }
+        }
+      },
+      "example": {
+        "products": [
+          {
+            "id": "prod_classic_tee",
+            "title": "Classic Tee",
+            "variants": [
+              {
+                "id": "sku124-red-m",
+                "title": "Classic Tee - Red / Medium",
+                "availability": {
+                  "available": false,
+                  "status": "out_of_stock"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "Error": {
+      "description": "Structured error returned when a feed request cannot be fulfilled.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "code", "message"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "High-level error category."
+        },
+        "code": {
+          "type": "string",
+          "description": "Machine-readable error code for programmatic handling."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable explanation of the error."
+        },
+        "param": {
+          "type": "string",
+          "description": "Optional request parameter or field associated with the error."
+        }
+      },
+      "example": {
+        "type": "invalid_request",
+        "code": "feed_not_found",
+        "message": "Feed not found",
+        "param": "id"
+      }
+    }
+  }
+}

--- a/spec/unreleased/openapi/openapi.feed.yaml
+++ b/spec/unreleased/openapi/openapi.feed.yaml
@@ -1,0 +1,715 @@
+openapi: 3.1.0
+info:
+  title: Agentic Commerce — Feed API
+  version: unreleased
+  description: |
+    Create and manage ACP feed resources and their product catalogs.
+
+    This API supports feed metadata creation and retrieval and partial product upserts by `Product.id`.
+
+    For offline full replacement ingestion, `metadata.json` uses the `FeedMetadata` shape and
+    `products.jsonl` contains one `Product` object per line. File ingestion replaces the full product
+    set. Partial updates are only supported through `PATCH /feeds/{id}/products`.
+servers:
+  - url: https://merchant.example.com
+tags:
+  - name: Feeds
+    description: Create and manage feed resources and product catalogs
+paths:
+  /feeds:
+    post:
+      tags:
+        - Feeds
+      summary: Create a feed
+      operationId: createFeed
+      description: Creates a feed resource and returns server-managed metadata for the new feed.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateFeedRequest"
+            examples:
+              minimal:
+                summary: Create a feed for the United States market
+                value:
+                  target_country: US
+      responses:
+        "201":
+          description: Feed created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeedMetadata"
+              examples:
+                created:
+                  value:
+                    id: feed_8f3K2x
+                    target_country: US
+                    updated_at: "2026-03-01T00:00:00Z"
+        "400":
+          description: Invalid feed payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                invalid_request:
+                  value:
+                    type: invalid_request
+                    code: invalid_target_country
+                    message: target_country must be an ISO 3166-1 alpha-2 code
+                    param: target_country
+  /feeds/{id}:
+    parameters:
+      - $ref: "#/components/parameters/FeedId"
+    get:
+      tags:
+        - Feeds
+      summary: Retrieve feed metadata
+      operationId: getFeed
+      description: Returns server-managed metadata for the specified feed.
+      responses:
+        "200":
+          description: Feed metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FeedMetadata"
+              examples:
+                found:
+                  value:
+                    id: feed_8f3K2x
+                    target_country: US
+                    updated_at: "2026-03-01T00:00:00Z"
+        "404":
+          description: Feed not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                not_found:
+                  value:
+                    type: invalid_request
+                    code: feed_not_found
+                    message: Feed not found
+                    param: id
+  /feeds/{id}/products:
+    parameters:
+      - $ref: "#/components/parameters/FeedId"
+    get:
+      tags:
+        - Feeds
+      summary: Retrieve products for a feed
+      operationId: getFeedProducts
+      description: Returns the full current product set for the specified feed.
+      responses:
+        "200":
+          description: Feed products
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProductsResponse"
+              examples:
+                products:
+                  value:
+                    products:
+                      - id: prod_classic_tee
+                        title: Classic Tee
+                        variants:
+                          - id: sku123-red-s
+                            title: Classic Tee - Red / Small
+        "404":
+          description: Feed not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                not_found:
+                  value:
+                    type: invalid_request
+                    code: feed_not_found
+                    message: Feed not found
+                    param: id
+    patch:
+      tags:
+        - Feeds
+      summary: Upsert products for a feed
+      operationId: upsertFeedProducts
+      description: Upserts products into the specified feed by `Product.id`. Products omitted from the request remain unchanged.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpsertProductsRequest"
+            examples:
+              upsert_single_product:
+                summary: Upsert a single product
+                value:
+                  products:
+                    - id: prod_classic_tee
+                      title: Classic Tee
+                      variants:
+                        - id: sku124-red-m
+                          title: Classic Tee - Red / Medium
+                          availability:
+                            available: false
+                            status: out_of_stock
+      responses:
+        "200":
+          description: Product upsert accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpsertProductsResponse"
+              examples:
+                accepted:
+                  value:
+                    id: feed_8f3K2x
+                    accepted: true
+        "400":
+          description: Invalid product payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                invalid_request:
+                  value:
+                    type: invalid_request
+                    code: invalid_product_payload
+                    message: products must contain at least one valid Product
+                    param: products
+        "404":
+          description: Feed not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                not_found:
+                  value:
+                    type: invalid_request
+                    code: feed_not_found
+                    message: Feed not found
+                    param: id
+components:
+  parameters:
+    FeedId:
+      name: id
+      in: path
+      required: true
+      description: Identifier of the feed resource.
+      schema:
+        type: string
+        example: feed_8f3K2x
+  schemas:
+    Description:
+      description: Structured long-form or rich-text description content for a product or variant.
+      type: object
+      additionalProperties: false
+      properties:
+        plain:
+          type: string
+          description: Plain-text description intended for clients that do not render rich formatting.
+        html:
+          type: string
+          description: HTML-formatted description content.
+        markdown:
+          type: string
+          description: Markdown-formatted description content.
+      minProperties: 1
+      example:
+        plain: Classic cotton tee in red, size small.
+    Price:
+      description: Monetary amount expressed in minor units with an associated ISO 4217 currency code.
+      type: object
+      additionalProperties: false
+      required:
+        - amount
+        - currency
+      properties:
+        amount:
+          type: integer
+          minimum: 0
+          description: Monetary amount expressed in ISO 4217 minor units.
+        currency:
+          type: string
+          pattern: ^[A-Z]{3}$
+          description: Three-letter ISO 4217 currency identifier.
+      example:
+        amount: 1999
+        currency: USD
+    Availability:
+      description: Purchasability and fulfillment state for a variant.
+      type: object
+      additionalProperties: false
+      properties:
+        available:
+          type: boolean
+          description: Indicates whether the variant is currently purchasable. Use status for fulfillment context.
+        status:
+          type: string
+          description: Extensible fulfillment state for the variant. Known values include in_stock, limited_stock, backorder, preorder, out_of_stock, and discontinued.
+      example:
+        available: true
+        status: in_stock
+    Barcode:
+      description: Machine-readable identifier attached to a variant, such as a GTIN or UPC.
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - value
+      properties:
+        type:
+          type: string
+          description: Barcode scheme or identifier type, such as GTIN, UPC, or EAN.
+        value:
+          type: string
+          description: Raw barcode value as provided by the merchant.
+      example:
+        type: GTIN
+        value: "00012345600012"
+    Media:
+      description: Media asset associated with a product or variant.
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - url
+      properties:
+        type:
+          type: string
+          description: Media kind, such as image, video, or model.
+        url:
+          type: string
+          format: uri
+          description: Canonical URL where the media asset can be retrieved.
+        alt_text:
+          type: string
+          description: Human-readable alternate text describing the asset.
+        width:
+          type: integer
+          description: Rendered width of the asset in pixels, when known.
+        height:
+          type: integer
+          description: Rendered height of the asset in pixels, when known.
+      example:
+        type: image
+        url: https://cdn.merchant.com/products/classic-tee/main.jpg
+        alt_text: Classic Tee front view
+    VariantOption:
+      description: One selected characteristic of a variant, such as size or color.
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - value
+      properties:
+        name:
+          type: string
+          description: Display name of the option dimension, such as Color or Size.
+        value:
+          type: string
+          description: Selected option value for this variant.
+      example:
+        name: Color
+        value: Red
+    Category:
+      description: Category assignment for a product or variant within a specific taxonomy.
+      type: object
+      additionalProperties: false
+      required:
+        - value
+      properties:
+        value:
+          type: string
+          description: Category label or hierarchical path, for example Mens > Sweaters > Crewnecks.
+        taxonomy:
+          type: string
+          description: Names the taxonomy system used for the category value, such as google_product_category, shopify, or merchant.
+      example:
+        value: Apparel > Shirts
+        taxonomy: merchant
+    Link:
+      description: Merchant-provided informational or policy link associated with a seller.
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - url
+      properties:
+        type:
+          type: string
+          description: Extensible link type, such as privacy_policy, terms_of_service, refund_policy, shipping_policy, or faq.
+        title:
+          type: string
+          description: Human-readable label for the linked resource.
+        url:
+          type: string
+          format: uri
+          description: Canonical URL for the linked resource.
+      example:
+        type: shipping_policy
+        title: Shipping Policy
+        url: https://merchant.com/policies/shipping
+    Seller:
+      description: Merchant or seller identity associated with a variant offer.
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: Display name of the seller or merchant of record.
+        links:
+          type: array
+          description: Informational or policy links associated with this seller.
+          items:
+            $ref: "#/components/schemas/Link"
+      example:
+        name: Example Merchant
+        links:
+          - type: refund_policy
+            title: Refund Policy
+            url: https://merchant.com/policies/refunds
+    Condition:
+      description: Extensible list of applicable item conditions, such as new or secondhand.
+      type: array
+      items:
+        type: string
+        description: Condition label supplied by the merchant.
+      example:
+        - new
+    Measure:
+      description: Measured quantity paired with a unit for unit-price calculations.
+      type: object
+      additionalProperties: false
+      required:
+        - value
+        - unit
+      properties:
+        value:
+          type: number
+          description: Measured quantity for the package or item.
+        unit:
+          type: string
+          description: Unit label for the measured quantity, such as oz, ml, or kg.
+      example:
+        value: 12
+        unit: oz
+    ReferenceMeasure:
+      description: Reference unit used when normalizing a unit price for display.
+      type: object
+      additionalProperties: false
+      required:
+        - value
+        - unit
+      properties:
+        value:
+          type: integer
+          description: Reference quantity used to normalize the unit price.
+        unit:
+          type: string
+          description: Reference unit label, such as ml, g, or oz.
+      example:
+        value: 1
+        unit: oz
+    UnitPrice:
+      description: Normalized unit price for products sold by weight, volume, or measure.
+      type: object
+      additionalProperties: false
+      required:
+        - amount
+        - currency
+        - measure
+        - reference
+      properties:
+        amount:
+          type: integer
+          minimum: 0
+          description: Normalized price amount expressed in ISO 4217 minor units.
+        currency:
+          type: string
+          pattern: ^[A-Z]{3}$
+          description: Three-letter ISO 4217 currency identifier.
+        measure:
+          allOf:
+            - $ref: "#/components/schemas/Measure"
+          description: Actual packaged measure associated with the sale item.
+        reference:
+          allOf:
+            - $ref: "#/components/schemas/ReferenceMeasure"
+          description: Reference measure used to display the normalized unit price.
+      example:
+        amount: 499
+        currency: USD
+        measure:
+          value: 12
+          unit: oz
+        reference:
+          value: 1
+          unit: oz
+    Variant:
+      description: Purchasable variant of a product within a feed.
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - title
+      properties:
+        id:
+          type: string
+          description: Stable global identifier for this variant.
+        title:
+          type: string
+          description: Display title for the variant.
+        description:
+          allOf:
+            - $ref: "#/components/schemas/Description"
+          description: Structured description content for the variant.
+        url:
+          type: string
+          format: uri
+          description: Canonical URL for the variant detail page.
+        barcodes:
+          type: array
+          description: Machine-readable identifiers associated with this variant.
+          items:
+            $ref: "#/components/schemas/Barcode"
+        price:
+          allOf:
+            - $ref: "#/components/schemas/Price"
+          description: Active selling price for the variant.
+        list_price:
+          allOf:
+            - $ref: "#/components/schemas/Price"
+          description: Reference or pre-discount price for the variant.
+        unit_price:
+          allOf:
+            - $ref: "#/components/schemas/UnitPrice"
+          description: Normalized unit price, when applicable.
+        availability:
+          allOf:
+            - $ref: "#/components/schemas/Availability"
+          description: Purchasability and fulfillment state for the variant.
+        categories:
+          type: array
+          description: Category assignments associated with this variant.
+          items:
+            $ref: "#/components/schemas/Category"
+        condition:
+          allOf:
+            - $ref: "#/components/schemas/Condition"
+          description: Extensible list of conditions applicable to this variant.
+        variant_options:
+          type: array
+          description: "Option selections that distinguish this variant, such as Color: Red or Size: Small."
+          items:
+            $ref: "#/components/schemas/VariantOption"
+        media:
+          type: array
+          description: Media assets specific to this variant. The first item is the primary listing asset.
+          items:
+            $ref: "#/components/schemas/Media"
+        seller:
+          allOf:
+            - $ref: "#/components/schemas/Seller"
+          description: Seller or merchant of record for this variant.
+        marketplace:
+          allOf:
+            - $ref: "#/components/schemas/Seller"
+          description: Marketplace or intermediary platform through which this variant is offered, if applicable.
+      example:
+        id: sku123-red-s
+        title: Classic Tee - Red / Small
+        description:
+          plain: Classic cotton tee in red, size small.
+        url: https://merchant.com/products/classic-tee?variant=sku123-red-s
+        barcodes:
+          - type: GTIN
+            value: "00012345600012"
+        price:
+          amount: 1999
+          currency: USD
+        list_price:
+          amount: 2499
+          currency: USD
+        availability:
+          available: true
+          status: in_stock
+        variant_options:
+          - name: Color
+            value: Red
+          - name: Size
+            value: Small
+        media:
+          - type: image
+            url: https://cdn.merchant.com/products/classic-tee/red-small-1.jpg
+            alt_text: Classic Tee in red, size small
+        seller:
+          name: Example Merchant
+        marketplace:
+          name: Example Marketplace
+    Product:
+      description: Catalog product grouping one or more purchasable variants within a feed.
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - variants
+      properties:
+        id:
+          type: string
+          description: Stable global identifier for this product.
+        title:
+          type: string
+          description: Display title for the product.
+        description:
+          allOf:
+            - $ref: "#/components/schemas/Description"
+          description: Structured description content for the product.
+        url:
+          type: string
+          format: uri
+          description: Canonical URL for the product detail page.
+        media:
+          type: array
+          description: Media assets associated with the product.
+          items:
+            $ref: "#/components/schemas/Media"
+        variants:
+          type: array
+          description: Purchasable variants grouped under this product.
+          items:
+            $ref: "#/components/schemas/Variant"
+      example:
+        id: prod_classic_tee
+        title: Classic Tee
+        media:
+          - type: image
+            url: https://cdn.merchant.com/products/classic-tee/main.jpg
+            alt_text: Classic Tee front view
+        variants:
+          - id: sku123-red-s
+            title: Classic Tee - Red / Small
+    FeedMetadata:
+      description: Server-managed metadata describing a feed resource.
+      type: object
+      additionalProperties: false
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: Stable identifier for the feed resource.
+        target_country:
+          type: string
+          pattern: ^[A-Z]{2}$
+          description: Optional ISO 3166-1 alpha-2 country code describing the feed's target market.
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp of the most recent update applied to this feed.
+      example:
+        id: feed_8f3K2x
+        target_country: US
+        updated_at: "2026-03-01T00:00:00Z"
+    CreateFeedRequest:
+      description: Request payload used to create a feed.
+      type: object
+      additionalProperties: false
+      properties:
+        target_country:
+          type: string
+          pattern: ^[A-Z]{2}$
+          description: Optional ISO 3166-1 alpha-2 country code describing the feed's target market.
+      example:
+        target_country: US
+    ProductsResponse:
+      description: Response envelope containing the current product set for a feed.
+      type: object
+      additionalProperties: false
+      required:
+        - products
+      properties:
+        products:
+          type: array
+          description: Full list of products currently associated with the feed.
+          items:
+            $ref: "#/components/schemas/Product"
+      example:
+        products:
+          - id: prod_classic_tee
+            title: Classic Tee
+            variants:
+              - id: sku123-red-s
+                title: Classic Tee - Red / Small
+    UpsertProductsResponse:
+      description: Acknowledgement returned after accepting an upsert payload for a feed.
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - accepted
+      properties:
+        id:
+          type: string
+          description: Identifier for the feed whose product upsert was processed.
+        accepted:
+          type: boolean
+          description: Whether the submitted product upsert payload was accepted for processing.
+      example:
+        id: feed_8f3K2x
+        accepted: true
+    UpsertProductsRequest:
+      description: Request payload that partially upserts products into a feed. Products omitted from the request remain unchanged.
+      type: object
+      additionalProperties: false
+      required:
+        - products
+      properties:
+        products:
+          type: array
+          description: Subset of products to create or update within the feed, matched by Product.id.
+          items:
+            $ref: "#/components/schemas/Product"
+      example:
+        products:
+          - id: prod_classic_tee
+            title: Classic Tee
+            variants:
+              - id: sku124-red-m
+                title: Classic Tee - Red / Medium
+                availability:
+                  available: false
+                  status: out_of_stock
+    Error:
+      description: Structured error returned when a feed request cannot be fulfilled.
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - code
+        - message
+      properties:
+        type:
+          type: string
+          description: High-level error category.
+        code:
+          type: string
+          description: Machine-readable error code for programmatic handling.
+        message:
+          type: string
+          description: Human-readable explanation of the error.
+        param:
+          type: string
+          description: Optional request parameter or field associated with the error.
+      example:
+        type: invalid_request
+        code: feed_not_found
+        message: Feed not found
+        param: id


### PR DESCRIPTION
# SEP: Product Feeds

## 📋 SEP Metadata
- **SEP Number**: [SEP: Product Feeds #189](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/issues/189)
- **Author(s)**: Aravind Rao, Rahul Bansal
- **Status**: `proposal`
- **Type**: [X] Major Change [ ] Process Change

---

## 🎯 Abstract

This PR proposes an unreleased Feed API surface for publishing feed metadata and managing product catalogs in ACP.

The new API surface includes:

- `POST /feeds` to create feed metadata
- `GET /feeds/{id}` to retrieve feed metadata
- `GET /feeds/{id}/products` to retrieve the current product set
- `PATCH /feeds/{id}/products` to partially upsert products by `Product.id`

This PR also adds the supporting schema bundle and example payloads needed to define a reusable catalog representation for ACP outside the checkout session lifecycle.

---

## 💡 Motivation

ACP currently supports transactional flows well, but it does not yet provide a standard way to exchange structured product catalog data before checkout begins.

This PR addresses that gap by introducing a feed-oriented model for catalog distribution and synchronization. In particular, it supports:

- feed metadata retrieval
- full product-set reads
- incremental product updates by stable `Product.id`
- a reusable product model with variants, pricing, availability, media, seller, marketplace, and category metadata

This change is intentionally scoped to the base feed API only. Promotions are deferred to the stacked follow-up PR so the core catalog surface can land independently.

---

## 📐 Specification

This proposal makes the following normative additions in unreleased ACP:

1. Add a new `FeedMetadata` model for server-managed feed metadata
2. Add a canonical `Product` / `Variant` catalog schema bundle in `schema.feed.json`
3. Add `POST /feeds` for feed creation
4. Add `GET /feeds/{id}` for feed metadata retrieval
5. Add `GET /feeds/{id}/products` for reading the full current product set
6. Add `PATCH /feeds/{id}/products` for partial upsert semantics keyed by `Product.id`

The schema bundle includes reusable definitions for:

- `Description`
- `Price`
- `Availability`
- `Barcode`
- `Media`
- `VariantOption`
- `Category`
- `Link`
- `Seller`
- `Condition`
- `Measure`
- `ReferenceMeasure`
- `UnitPrice`
- `Variant`
- `Product`
- `FeedMetadata`
- request/response envelopes for create, list, and upsert operations

This PR also documents the offline ingestion format:

- `metadata.json` uses the `FeedMetadata` shape
- `products.jsonl` contains one `Product` object per line
- file ingestion performs full replacement of the feed's product set
- partial updates are only supported through `PATCH /feeds/{id}/products`

---

## 🤔 Rationale

A feed resource is a better fit than overloading checkout or discovery for catalog exchange.

This structure gives ACP:

- a dedicated resource for catalog synchronization
- support for both full retrieval and incremental updates
- a stable product and variant representation that can be reused across implementations
- room to layer promotions and other catalog-adjacent features in follow-up changes

Separating the base feed model from promotions also keeps this PR reviewable and makes the stack easier to reason about.

---

## 🔄 Backward Compatibility

This is a backward-compatible, additive change in unreleased ACP.

Migration impact:

- no existing ACP endpoints are removed
- no existing ACP schemas are redefined in this PR
- clients that do not use feeds are unaffected

Implementations that adopt this API can begin using the new `/feeds` endpoints and schema bundle without changing existing checkout flows.

---

## 🛠️ Reference Implementation

This PR adds the unreleased specification and related examples/docs in:

- `spec/unreleased/openapi/openapi.feed.yaml`
- `spec/unreleased/json-schema/schema.feed.json`
- `examples/unreleased/examples.feed.json`
- `changelog/unreleased/add-feed-api.md`

---

## 🔒 Security Implications

This PR introduces a new catalog-bearing API surface, so implementers should treat feed contents as potentially sensitive merchant data.

Key considerations:

- feed metadata and product catalogs may include pricing, assortment, and availability data
- product payloads may contain external URLs and rich content that consumers should treat as untrusted input
- incremental upsert behavior should validate payloads strictly before accepting product updates

This PR defines the surface and schemas; implementation-specific authentication, authorization, and abuse controls should be enforced by ACP servers.

---

## 📚 Additional Context

This PR is the base layer for the Product Feeds SEP and intentionally excludes promotions.

Promotions are deferred to the stacked follow-up branch/PR so the foundational feed resource and product model can be reviewed independently first.

---

## 🙋 Questions for Reviewers

- Are `/feeds` the right endpoint names for this first pass, or should this land as `/product_feeds` to match the SEP wording more closely?
- Is the scope split between base feeds and promotions the right review boundary?
- Is whole-product upsert by `Product.id` sufficiently clear for implementers?

---

## ✅ Pre-Submission Checklist

Before submitting this SEP PR, ensure:

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
- [x] I have linked the SEP issue number above
- [x] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [x] I have signed the Contributor License Agreement (CLA)