### PR TITLE
SEP: Add promotions API to ACP Product Feeds

### DIFF
--- a/changelog/unreleased/add-feed-promotions.md
+++ b/changelog/unreleased/add-feed-promotions.md
@@ -1,0 +1,22 @@
+# Feed Promotions
+
+**Added** – unreleased promotion support for the Feed API surface.
+
+## New API Surface
+
+- `GET /feeds/{id}/promotions` to retrieve the current promotion set
+- `PATCH /feeds/{id}/promotions` to partially upsert promotions by `Promotion.id`
+
+## New Schemas
+
+- `DateTimeRange`
+- `PromotionStatus`
+- `AmountOffBenefit`
+- `PercentOffBenefit`
+- `FreeShippingBenefit`
+- `PromotionBenefit`
+- `ProductTarget`
+- `Promotion`
+- `PromotionsResponse`
+- `UpsertPromotionsRequest`
+- `UpsertPromotionsResponse`

--- a/examples/unreleased/examples.feed.json
+++ b/examples/unreleased/examples.feed.json
@@ -92,6 +92,107 @@
       }
     ]
   },
+  "get_promotions_response": {
+    "promotions": [
+      {
+        "id": "promo_spring_sale",
+        "title": "Spring Sale",
+        "status": "active",
+        "effective_period": {
+          "start_time": "2026-03-01T00:00:00Z",
+          "end_time": "2026-03-31T23:59:59Z"
+        },
+        "benefits": [
+          {
+            "type": "percent_off",
+            "percent_off": 20
+          }
+        ],
+        "applies_to": [
+          {
+            "product_id": "prod_classic_tee"
+          }
+        ]
+      }
+    ]
+  },
+  "upsert_promotions_request_amount_off": {
+    "promotions": [
+      {
+        "id": "promo_save10",
+        "title": "Save 10",
+        "status": "active",
+        "effective_period": {
+          "start_time": "2026-03-01T00:00:00Z",
+          "end_time": "2026-03-31T23:59:59Z"
+        },
+        "benefits": [
+          {
+            "type": "amount_off",
+            "amount_off": {
+              "amount": 1000,
+              "currency": "USD"
+            }
+          }
+        ],
+        "applies_to": [
+          {
+            "product_id": "prod_classic_tee",
+            "variant_ids": [
+              "sku123-red-s"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "upsert_promotions_request_percent_off": {
+    "promotions": [
+      {
+        "id": "promo_spring_sale",
+        "title": "Spring Sale",
+        "status": "active",
+        "effective_period": {
+          "start_time": "2026-03-01T00:00:00Z",
+          "end_time": "2026-03-31T23:59:59Z"
+        },
+        "benefits": [
+          {
+            "type": "percent_off",
+            "percent_off": 20
+          }
+        ],
+        "applies_to": [
+          {
+            "product_id": "prod_classic_tee"
+          }
+        ]
+      }
+    ]
+  },
+  "upsert_promotions_request_free_shipping": {
+    "promotions": [
+      {
+        "id": "promo_free_ship",
+        "title": "Free Shipping",
+        "status": "scheduled",
+        "effective_period": {
+          "start_time": "2026-03-15T00:00:00Z",
+          "end_time": "2026-03-31T23:59:59Z"
+        },
+        "benefits": [
+          {
+            "type": "free_shipping"
+          }
+        ],
+        "applies_to": [
+          {
+            "product_id": "prod_classic_tee"
+          }
+        ]
+      }
+    ]
+  },
   "feed_error_not_found": {
     "type": "invalid_request",
     "code": "feed_not_found",
@@ -103,5 +204,11 @@
     "code": "invalid_product_payload",
     "message": "products must contain at least one valid Product",
     "param": "products"
+  },
+  "feed_error_invalid_promotion_request": {
+    "type": "invalid_request",
+    "code": "invalid_promotion_payload",
+    "message": "promotions must contain at least one valid Promotion",
+    "param": "promotions"
   }
 }

--- a/rfcs/rfc.feed_promotions.md
+++ b/rfcs/rfc.feed_promotions.md
@@ -1,0 +1,441 @@
+# RFC: Agentic Commerce - Feed Promotions
+
+**Status:** Draft
+**Version:** unreleased
+**Scope:** Merchant-managed promotions for products published through the Feed API
+
+This RFC defines feed-level promotions for the Agentic Commerce Protocol (ACP).
+Promotions let merchants publish structured promotional metadata for products and
+variants that they have already published in a product feed. The Feed Promotions
+API is a merchant-to-agent API: merchants call the agent or platform feed
+ingestion service to create, update, and inspect promotions. Agents do not call
+these promotion endpoints on merchants.
+
+---
+
+## 1. Motivation
+
+Product feeds give agents structured product and variant data for discovery,
+recommendation, and shopping flows. Merchants also need a way to tell agents
+which of those feed items are currently promoted, scheduled for promotion, or no
+longer eligible for a promotion.
+
+Without feed-level promotions, merchants have poor choices:
+
+- **Encode promotions in product text**: Agents must infer promotion semantics
+  from titles, descriptions, or landing pages, which is brittle and hard to keep
+  current.
+- **Wait until checkout**: The buyer may not learn about a promotion until after
+  product discovery and cart building, missing opportunities to rank, compare,
+  and explain relevant offers earlier.
+- **Rely on out-of-band sync**: Merchant and agent systems can disagree about
+  whether a promotion exists, what it applies to, or when it is active.
+
+Feed Promotions gives merchants a direct, structured way to publish promotions
+against the same product and variant identifiers already used in the feed. It
+also gives merchants a read path to retrieve the latest promotion state as the
+agent understands it after ingestion and validation.
+
+### What Feed Promotions provides
+
+- **Merchant-managed promotion publishing**: Merchants can create or update
+  promotions by stable `Promotion.id`.
+- **Product and variant targeting**: Promotions can target products or specific
+  variants already present in the feed.
+- **Structured benefits**: Promotions can describe amount-off, percent-off, and
+  free-shipping benefits without requiring agents to scrape merchant pages.
+- **Lifecycle visibility**: Promotions can include a status and effective time
+  range so agents can reason about draft, scheduled, active, expired, and
+  disabled offers.
+- **Agent-state reconciliation**: Merchants can retrieve the full promotion set
+  the agent currently has for a feed.
+
+---
+
+## 2. Direction of Calls
+
+The Feed Promotions API is hosted by the agent or platform feed ingestion
+service. The merchant is the client.
+
+```text
+Merchant promotion system --PATCH /feeds/{id}/promotions--> Agent feed API
+Merchant promotion system <--200 accepted------------------- Agent feed API
+
+Merchant promotion system --GET /feeds/{id}/promotions----> Agent feed API
+Merchant promotion system <--current promotions------------- Agent feed API
+```
+
+This direction is part of the design. The agent does not call
+`GET /feeds/{id}/promotions` or `PATCH /feeds/{id}/promotions` on the merchant.
+Agents use the promotion state they have ingested for product discovery,
+ranking, explanation, and downstream shopping experiences.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+1. **Structured promotion sync**: Define a standard way for merchants to publish
+   promotions for feed products.
+2. **Partial upsert semantics**: Let merchants create or update a subset of
+   promotions without resending the full promotion set.
+3. **Read-back state**: Let merchants retrieve the current promotion set as
+   understood by the agent.
+4. **Feed alignment**: Tie promotions to product and variant identifiers already
+   published under the same feed.
+5. **Benefit extensibility**: Support common promotion benefits now while
+   allowing future benefit shapes to be added.
+
+### 3.2 Non-Goals
+
+- **Agent-to-merchant promotion retrieval**: Agents do not call these endpoints
+  on merchant systems.
+- **Checkout discount code submission**: Buyer-entered discount codes and
+  applied checkout discounts are handled by checkout and discount extension
+  flows, not this API.
+- **Promotion redemption accounting**: This RFC does not define redemption
+  limits, usage counters, budget tracking, or fraud controls.
+- **Full promotion replacement or deletion**: The API defines partial upserts.
+  Promotions omitted from an upsert remain unchanged. Merchants can disable or
+  expire promotions by updating `status` or `effective_period`.
+- **Authoritative checkout pricing**: Promotions in the feed help agents
+  discover and explain offers. Final pricing remains a checkout concern.
+
+---
+
+## 4. Design
+
+### 4.1 Scope
+
+Promotions are scoped to a single feed. A promotion submitted to
+`/feeds/{id}/promotions` applies only to the feed identified by `{id}`.
+
+Promotion targets refer to product and variant identifiers in that same feed:
+
+- `ProductTarget.product_id` identifies a published product.
+- `ProductTarget.variant_ids` optionally narrows the promotion to specific
+  variants. When omitted, the promotion applies to all variants of the product.
+
+Merchants SHOULD only target products and variants that have been published to
+the same feed. Agents SHOULD reject invalid promotion payloads when targets
+cannot be interpreted.
+
+### 4.2 Lifecycle
+
+```text
+Merchant publishes products
+        |
+        v
+Merchant upserts promotions for those products
+        |
+        v
+Agent validates and stores the promotion set
+        |
+        v
+Merchant reads current promotion state when reconciliation is needed
+        |
+        v
+Agent uses ingested promotion state in discovery and shopping flows
+```
+
+`PATCH /feeds/{id}/promotions` returns an acknowledgement that the submitted
+payload was accepted for processing. Merchants that need the latest effective
+state SHOULD call `GET /feeds/{id}/promotions` after upsert processing.
+
+### 4.3 Promotion vs Checkout Discount
+
+| Aspect | Feed Promotion | Checkout Discount |
+|---|---|---|
+| Purpose | Communicate offers during product discovery | Apply pricing during checkout |
+| Call direction | Merchant to agent | Agent to merchant checkout API |
+| Scope | Feed products and variants | Checkout session line items and totals |
+| Timing | Before shopping or checkout | During checkout session creation/update |
+| Pricing authority | Informational for discovery | Authoritative in checkout response |
+
+Feed Promotions can describe offers that later affect checkout, but this RFC
+does not require a one-to-one mapping between a feed promotion and an applied
+checkout discount.
+
+---
+
+## 5. Schema
+
+### 5.1 Promotion
+
+A `Promotion` describes one merchant-defined offer associated with a feed.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | string | Yes | Stable global identifier for this promotion. |
+| `title` | string | Yes | Display title for the promotion. |
+| `description` | `Description` | No | Structured description content for the promotion. |
+| `status` | `PromotionStatus` | No | Extensible lifecycle state. Known values include `draft`, `scheduled`, `active`, `expired`, and `disabled`. |
+| `effective_period` | `DateTimeRange` | Yes | Time range during which the promotion should apply. |
+| `benefits` | `PromotionBenefit[]` | Yes | One or more benefits granted by the promotion. |
+| `applies_to` | `ProductTarget[]` | No | Product or variant targets to which the promotion applies. |
+| `url` | string (URI) | No | Canonical URL for the promotion detail or landing page. |
+
+### 5.2 DateTimeRange
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `start_time` | string (date-time) | Yes | RFC 3339 timestamp when the promotion becomes active. |
+| `end_time` | string (date-time) | Yes | RFC 3339 timestamp when the promotion stops being active. |
+
+### 5.3 PromotionBenefit
+
+`PromotionBenefit` is a union of supported benefit shapes.
+
+| Benefit | Type discriminator | Required fields | Description |
+|---|---|---|---|
+| Amount off | `amount_off` | `amount_off` | Fixed monetary amount discounted from the applicable item or order. |
+| Percent off | `percent_off` | `percent_off` | Percentage discount applied by the promotion. |
+| Free shipping | `free_shipping` | None beyond `type` | Shipping cost waived for eligible purchases. |
+
+Example amount-off benefit:
+
+```json
+{
+  "type": "amount_off",
+  "amount_off": {
+    "amount": 1000,
+    "currency": "USD"
+  }
+}
+```
+
+Example percent-off benefit:
+
+```json
+{
+  "type": "percent_off",
+  "percent_off": 20
+}
+```
+
+Example free-shipping benefit:
+
+```json
+{
+  "type": "free_shipping"
+}
+```
+
+### 5.4 ProductTarget
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `product_id` | string | Yes | Identifier of the product targeted by the promotion. |
+| `variant_ids` | string[] | No | Optional subset of variant identifiers targeted by the promotion. When omitted, the promotion applies to all variants of the product. |
+
+Example:
+
+```json
+{
+  "product_id": "prod_classic_tee",
+  "variant_ids": ["sku123-red-s"]
+}
+```
+
+---
+
+## 6. HTTP Interface
+
+### 6.1 Operations
+
+| Operation | Method | Endpoint | Description |
+|---|---|---|---|
+| Get Feed Promotions | `GET` | `/feeds/{id}/promotions` | Retrieve the full current promotion set for a feed as understood by the agent. |
+| Upsert Feed Promotions | `PATCH` | `/feeds/{id}/promotions` | Create or update promotions by `Promotion.id`; omitted promotions remain unchanged. |
+
+All endpoints follow ACP's existing HTTP conventions:
+
+- HTTPS required, JSON request and response bodies.
+- `Authorization: Bearer <token>` required.
+- `API-Version` header required.
+
+### 6.2 Get Feed Promotions
+
+`GET /feeds/{id}/promotions`
+
+Returns the full current promotion set for the specified feed as understood by
+the agent.
+
+Response: `200 OK` with `PromotionsResponse`.
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "promotions": [
+    {
+      "id": "promo_spring_sale",
+      "title": "Spring Sale",
+      "status": "active",
+      "effective_period": {
+        "start_time": "2026-03-01T00:00:00Z",
+        "end_time": "2026-03-31T23:59:59Z"
+      },
+      "benefits": [
+        {
+          "type": "percent_off",
+          "percent_off": 20
+        }
+      ],
+      "applies_to": [
+        {
+          "product_id": "prod_classic_tee"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Returns `404 Not Found` if the feed does not exist.
+
+### 6.3 Upsert Feed Promotions
+
+`PATCH /feeds/{id}/promotions`
+
+Partially upserts promotions into the specified feed by `Promotion.id`.
+Promotions omitted from the request remain unchanged.
+
+Request:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `promotions` | `Promotion[]` | Yes | Subset of promotions to create or update within the feed. |
+
+Response: `200 OK` with `UpsertPromotionsResponse`.
+
+Example request:
+
+```json
+PATCH /feeds/feed_8f3K2x/promotions HTTP/1.1
+Authorization: Bearer <token>
+API-Version: 2026-01-30
+Content-Type: application/json
+
+{
+  "promotions": [
+    {
+      "id": "promo_spring_sale",
+      "title": "Spring Sale",
+      "status": "active",
+      "effective_period": {
+        "start_time": "2026-03-01T00:00:00Z",
+        "end_time": "2026-03-31T23:59:59Z"
+      },
+      "benefits": [
+        {
+          "type": "percent_off",
+          "percent_off": 20
+        }
+      ],
+      "applies_to": [
+        {
+          "product_id": "prod_classic_tee"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Example response:
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "feed_8f3K2x",
+  "accepted": true
+}
+```
+
+Invalid promotion payloads return `400 Bad Request` with
+`code: invalid_promotion_payload`. Requests for unknown feeds return
+`404 Not Found` with `code: feed_not_found`.
+
+### 6.4 Partial Upsert Semantics
+
+The `PATCH` operation matches submitted promotions by `Promotion.id`.
+
+- If the `Promotion.id` is new to the feed, the agent creates that promotion.
+- If the `Promotion.id` already exists, the agent updates that promotion.
+- Promotions omitted from the request remain unchanged.
+- To stop a promotion, the merchant SHOULD update it with `status: disabled` or
+  an `effective_period` whose `end_time` has passed.
+
+This avoids requiring merchants to send the full promotion catalog for small
+changes while preserving a read path for reconciliation through
+`GET /feeds/{id}/promotions`.
+
+---
+
+## 7. Backward Compatibility
+
+This is a purely additive change:
+
+- **New endpoints**: `/feeds/{id}/promotions` is a new Feed API subresource.
+- **New schemas**: Promotion schemas are added to the feed schema surface.
+- **No changes to checkout**: Checkout session creation, update, completion,
+  payment, and order flows are unchanged.
+- **No requirement for agents to call merchant promotion APIs**: The endpoint
+  direction is merchant to agent, so existing merchant ACP checkout endpoints do
+  not need to expose these paths.
+
+Merchants and agents that do not use Feed Promotions continue to interoperate
+through existing feed, checkout, and order flows.
+
+---
+
+## 8. Required Spec Updates
+
+- [ ] `spec/unreleased/openapi/openapi.feed.yaml` - Add
+  `GET /feeds/{id}/promotions` and `PATCH /feeds/{id}/promotions`.
+- [ ] `spec/unreleased/json-schema/schema.feed.json` - Add `DateTimeRange`,
+  `PromotionStatus`, `AmountOffBenefit`, `PercentOffBenefit`,
+  `FreeShippingBenefit`, `PromotionBenefit`, `ProductTarget`, `Promotion`,
+  `PromotionsResponse`, `UpsertPromotionsRequest`, and
+  `UpsertPromotionsResponse`.
+- [ ] `examples/unreleased/examples.feed.json` - Add examples for promotion
+  retrieval, promotion upsert requests, and invalid promotion payload errors.
+- [ ] `changelog/unreleased/add-feed-promotions.md` - Add the changelog entry.
+
+---
+
+## 9. Conformance Checklist
+
+**MUST requirements:**
+
+- [ ] MUST expose `GET /feeds/{id}/promotions` on the agent or platform feed
+  ingestion service, not on the merchant's checkout API.
+- [ ] MUST expose `PATCH /feeds/{id}/promotions` on the agent or platform feed
+  ingestion service, not on the merchant's checkout API.
+- [ ] MUST match upserted promotions by `Promotion.id`.
+- [ ] MUST leave omitted promotions unchanged during partial upsert.
+- [ ] MUST return `promotions` in every successful `PromotionsResponse`.
+- [ ] MUST return `id` and `accepted` in every successful
+  `UpsertPromotionsResponse`.
+
+**SHOULD requirements:**
+
+- [ ] SHOULD validate that `applies_to` targets refer to products or variants in
+  the same feed.
+- [ ] SHOULD support amount-off, percent-off, and free-shipping benefit shapes.
+- [ ] SHOULD support the known status values `draft`, `scheduled`, `active`,
+  `expired`, and `disabled`.
+- [ ] SHOULD use `GET /feeds/{id}/promotions` as the reconciliation mechanism
+  for merchant systems that need the agent's latest promotion state.
+
+**MAY requirements:**
+
+- [ ] MAY accept promotion targets before the corresponding product update has
+  finished processing, if the implementation can reconcile them later.
+- [ ] MAY add future promotion benefit shapes without changing the existing
+  benefit discriminators.

--- a/spec/unreleased/json-schema/schema.feed.json
+++ b/spec/unreleased/json-schema/schema.feed.json
@@ -592,6 +592,290 @@
         ]
       }
     },
+    "DateTimeRange": {
+      "description": "Time range describing when a promotion is effective.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start_time", "end_time"],
+      "properties": {
+        "start_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 timestamp when the promotion becomes active."
+        },
+        "end_time": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 timestamp when the promotion stops being active."
+        }
+      },
+      "example": {
+        "start_time": "2026-03-01T00:00:00Z",
+        "end_time": "2026-03-31T23:59:59Z"
+      }
+    },
+    "PromotionStatus": {
+      "description": "Extensible promotion lifecycle state. Known values include draft, scheduled, active, expired, and disabled.",
+      "type": "string",
+      "example": "active"
+    },
+    "AmountOffBenefit": {
+      "description": "Promotion benefit that reduces the price by a fixed monetary amount.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "amount_off"],
+      "properties": {
+        "type": {
+          "const": "amount_off",
+          "description": "Discriminator identifying a fixed-amount discount benefit."
+        },
+        "amount_off": {
+          "$ref": "#/$defs/Price",
+          "description": "Fixed monetary amount discounted from the applicable item or order."
+        }
+      },
+      "example": {
+        "type": "amount_off",
+        "amount_off": {
+          "amount": 1000,
+          "currency": "USD"
+        }
+      }
+    },
+    "PercentOffBenefit": {
+      "description": "Promotion benefit that reduces the price by a percentage.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "percent_off"],
+      "properties": {
+        "type": {
+          "const": "percent_off",
+          "description": "Discriminator identifying a percentage discount benefit."
+        },
+        "percent_off": {
+          "type": "number",
+          "description": "Percentage discount applied by the promotion."
+        }
+      },
+      "example": {
+        "type": "percent_off",
+        "percent_off": 20
+      }
+    },
+    "FreeShippingBenefit": {
+      "description": "Promotion benefit that waives shipping cost.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": {
+          "const": "free_shipping",
+          "description": "Discriminator identifying a free-shipping promotion benefit."
+        }
+      },
+      "example": {
+        "type": "free_shipping"
+      }
+    },
+    "PromotionBenefit": {
+      "description": "Union of supported promotion benefit shapes.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/AmountOffBenefit"
+        },
+        {
+          "$ref": "#/$defs/PercentOffBenefit"
+        },
+        {
+          "$ref": "#/$defs/FreeShippingBenefit"
+        }
+      ],
+      "example": {
+        "type": "amount_off",
+        "amount_off": {
+          "amount": 1000,
+          "currency": "USD"
+        }
+      }
+    },
+    "ProductTarget": {
+      "description": "Target product and optional subset of variants to which a promotion applies.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["product_id"],
+      "properties": {
+        "product_id": {
+          "type": "string",
+          "description": "Identifier of the product targeted by the promotion."
+        },
+        "variant_ids": {
+          "type": "array",
+          "description": "Optional subset of variant identifiers targeted by the promotion. When omitted, the promotion applies to all variants of the product.",
+          "items": {
+            "type": "string",
+            "description": "Stable global identifier for a targeted variant."
+          }
+        }
+      },
+      "example": {
+        "product_id": "prod_classic_tee",
+        "variant_ids": ["sku123-red-s"]
+      }
+    },
+    "Promotion": {
+      "description": "Promotion associated with a feed.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "effective_period", "benefits"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Stable global identifier for this promotion."
+        },
+        "title": {
+          "type": "string",
+          "description": "Display title for the promotion."
+        },
+        "description": {
+          "$ref": "#/$defs/Description",
+          "description": "Structured description content for the promotion."
+        },
+        "status": {
+          "$ref": "#/$defs/PromotionStatus",
+          "description": "Extensible lifecycle status for the promotion."
+        },
+        "effective_period": {
+          "$ref": "#/$defs/DateTimeRange",
+          "description": "Time range during which the promotion should apply."
+        },
+        "benefits": {
+          "type": "array",
+          "description": "One or more benefits granted by the promotion.",
+          "items": {
+            "$ref": "#/$defs/PromotionBenefit"
+          }
+        },
+        "applies_to": {
+          "type": "array",
+          "description": "Optional list of product or variant targets to which the promotion applies.",
+          "items": {
+            "$ref": "#/$defs/ProductTarget"
+          }
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Canonical URL for the promotion detail or landing page."
+        }
+      },
+      "example": {
+        "id": "promo_spring_sale",
+        "title": "Spring Sale",
+        "status": "active",
+        "effective_period": {
+          "start_time": "2026-03-01T00:00:00Z",
+          "end_time": "2026-03-31T23:59:59Z"
+        },
+        "benefits": [
+          {
+            "type": "percent_off",
+            "percent_off": 20
+          }
+        ],
+        "applies_to": [
+          {
+            "product_id": "prod_classic_tee"
+          }
+        ]
+      }
+    },
+    "PromotionsResponse": {
+      "description": "Response envelope containing the current promotions for a feed.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["promotions"],
+      "properties": {
+        "promotions": {
+          "type": "array",
+          "description": "Full list of promotions currently associated with the feed.",
+          "items": {
+            "$ref": "#/$defs/Promotion"
+          }
+        }
+      },
+      "example": {
+        "promotions": [
+          {
+            "id": "promo_spring_sale",
+            "title": "Spring Sale",
+            "effective_period": {
+              "start_time": "2026-03-01T00:00:00Z",
+              "end_time": "2026-03-31T23:59:59Z"
+            },
+            "benefits": [
+              {
+                "type": "percent_off",
+                "percent_off": 20
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "UpsertPromotionsRequest": {
+      "description": "Request payload that partially upserts promotions into a feed. Promotions omitted from the request remain unchanged.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["promotions"],
+      "properties": {
+        "promotions": {
+          "type": "array",
+          "description": "Subset of promotions to create or update within the feed, matched by Promotion.id.",
+          "items": {
+            "$ref": "#/$defs/Promotion"
+          }
+        }
+      },
+      "example": {
+        "promotions": [
+          {
+            "id": "promo_spring_sale",
+            "title": "Spring Sale",
+            "status": "active",
+            "effective_period": {
+              "start_time": "2026-03-01T00:00:00Z",
+              "end_time": "2026-03-31T23:59:59Z"
+            },
+            "benefits": [
+              {
+                "type": "percent_off",
+                "percent_off": 20
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "UpsertPromotionsResponse": {
+      "description": "Acknowledgement returned after accepting a promotion upsert payload for a feed.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "accepted"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identifier for the feed whose promotion upsert was processed."
+        },
+        "accepted": {
+          "type": "boolean",
+          "description": "Whether the submitted promotion upsert payload was accepted for processing."
+        }
+      },
+      "example": {
+        "id": "feed_8f3K2x",
+        "accepted": true
+      }
+    },
     "Error": {
       "description": "Structured error returned when a feed request cannot be fulfilled.",
       "type": "object",

--- a/spec/unreleased/openapi/openapi.feed.yaml
+++ b/spec/unreleased/openapi/openapi.feed.yaml
@@ -3,9 +3,10 @@ info:
   title: Agentic Commerce — Feed API
   version: unreleased
   description: |
-    Create and manage ACP feed resources and their product catalogs.
+    Create and manage ACP feed resources, product catalogs, and promotions.
 
-    This API supports feed metadata creation and retrieval and partial product upserts by `Product.id`.
+    This API supports feed metadata creation and retrieval, partial product upserts by `Product.id`,
+    retrieval of feed promotions, and partial promotion upserts by `Promotion.id`.
 
     For offline full replacement ingestion, `metadata.json` uses the `FeedMetadata` shape and
     `products.jsonl` contains one `Product` object per line. File ingestion replaces the full product
@@ -82,6 +83,112 @@ paths:
                     id: feed_8f3K2x
                     target_country: US
                     updated_at: "2026-03-01T00:00:00Z"
+        "404":
+          description: Feed not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                not_found:
+                  value:
+                    type: invalid_request
+                    code: feed_not_found
+                    message: Feed not found
+                    param: id
+  /feeds/{id}/promotions:
+    parameters:
+      - $ref: "#/components/parameters/FeedId"
+    get:
+      tags:
+        - Feeds
+      summary: Retrieve promotions for a feed
+      operationId: getFeedPromotions
+      description: Returns the full current promotion set for the specified feed.
+      responses:
+        "200":
+          description: Feed promotions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PromotionsResponse"
+              examples:
+                promotions:
+                  value:
+                    promotions:
+                      - id: promo_spring_sale
+                        title: Spring Sale
+                        status: active
+                        effective_period:
+                          start_time: "2026-03-01T00:00:00Z"
+                          end_time: "2026-03-31T23:59:59Z"
+                        benefits:
+                          - type: percent_off
+                            percent_off: 20
+        "404":
+          description: Feed not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                not_found:
+                  value:
+                    type: invalid_request
+                    code: feed_not_found
+                    message: Feed not found
+                    param: id
+    patch:
+      tags:
+        - Feeds
+      summary: Upsert promotions for a feed
+      operationId: upsertFeedPromotions
+      description: Upserts promotions into the specified feed by `Promotion.id`. Promotions omitted from the request remain unchanged.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpsertPromotionsRequest"
+            examples:
+              upsert_percent_off:
+                summary: Upsert a percentage-off promotion
+                value:
+                  promotions:
+                    - id: promo_spring_sale
+                      title: Spring Sale
+                      status: active
+                      effective_period:
+                        start_time: "2026-03-01T00:00:00Z"
+                        end_time: "2026-03-31T23:59:59Z"
+                      benefits:
+                        - type: percent_off
+                          percent_off: 20
+      responses:
+        "200":
+          description: Promotion upsert accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpsertPromotionsResponse"
+              examples:
+                accepted:
+                  value:
+                    id: feed_8f3K2x
+                    accepted: true
+        "400":
+          description: Invalid promotion payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+              examples:
+                invalid_request:
+                  value:
+                    type: invalid_request
+                    code: invalid_promotion_payload
+                    message: promotions must contain at least one valid Promotion
+                    param: promotions
         "404":
           description: Feed not found
           content:
@@ -687,6 +794,228 @@ components:
                 availability:
                   available: false
                   status: out_of_stock
+    DateTimeRange:
+      description: Time range describing when a promotion is effective.
+      type: object
+      additionalProperties: false
+      required:
+        - start_time
+        - end_time
+      properties:
+        start_time:
+          type: string
+          format: date-time
+          description: RFC 3339 timestamp when the promotion becomes active.
+        end_time:
+          type: string
+          format: date-time
+          description: RFC 3339 timestamp when the promotion stops being active.
+      example:
+        start_time: "2026-03-01T00:00:00Z"
+        end_time: "2026-03-31T23:59:59Z"
+    PromotionStatus:
+      description: Extensible promotion lifecycle state. Known values include draft, scheduled, active, expired, and disabled.
+      type: string
+      example: active
+    AmountOffBenefit:
+      description: Promotion benefit that reduces the price by a fixed monetary amount.
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - amount_off
+      properties:
+        type:
+          type: string
+          const: amount_off
+          description: Discriminator identifying a fixed-amount discount benefit.
+        amount_off:
+          allOf:
+            - $ref: "#/components/schemas/Price"
+          description: Fixed monetary amount discounted from the applicable item or order.
+      example:
+        type: amount_off
+        amount_off:
+          amount: 1000
+          currency: USD
+    PercentOffBenefit:
+      description: Promotion benefit that reduces the price by a percentage.
+      type: object
+      additionalProperties: false
+      required:
+        - type
+        - percent_off
+      properties:
+        type:
+          type: string
+          const: percent_off
+          description: Discriminator identifying a percentage discount benefit.
+        percent_off:
+          type: number
+          description: Percentage discount applied by the promotion.
+      example:
+        type: percent_off
+        percent_off: 20
+    FreeShippingBenefit:
+      description: Promotion benefit that waives shipping cost.
+      type: object
+      additionalProperties: false
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          const: free_shipping
+          description: Discriminator identifying a free-shipping promotion benefit.
+      example:
+        type: free_shipping
+    PromotionBenefit:
+      description: Union of supported promotion benefit shapes.
+      oneOf:
+        - $ref: "#/components/schemas/AmountOffBenefit"
+        - $ref: "#/components/schemas/PercentOffBenefit"
+        - $ref: "#/components/schemas/FreeShippingBenefit"
+      example:
+        type: amount_off
+        amount_off:
+          amount: 1000
+          currency: USD
+    ProductTarget:
+      description: Target product and optional subset of variants to which a promotion applies.
+      type: object
+      additionalProperties: false
+      required:
+        - product_id
+      properties:
+        product_id:
+          type: string
+          description: Identifier of the product targeted by the promotion.
+        variant_ids:
+          type: array
+          description: Optional subset of variant identifiers targeted by the promotion. When omitted, the promotion applies to all variants of the product.
+          items:
+            type: string
+            description: Stable global identifier for a targeted variant.
+      example:
+        product_id: prod_classic_tee
+        variant_ids:
+          - sku123-red-s
+    Promotion:
+      description: Promotion associated with a feed.
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - title
+        - effective_period
+        - benefits
+      properties:
+        id:
+          type: string
+          description: Stable global identifier for this promotion.
+        title:
+          type: string
+          description: Display title for the promotion.
+        description:
+          allOf:
+            - $ref: "#/components/schemas/Description"
+          description: Structured description content for the promotion.
+        status:
+          allOf:
+            - $ref: "#/components/schemas/PromotionStatus"
+          description: Extensible lifecycle status for the promotion.
+        effective_period:
+          allOf:
+            - $ref: "#/components/schemas/DateTimeRange"
+          description: Time range during which the promotion should apply.
+        benefits:
+          type: array
+          description: One or more benefits granted by the promotion.
+          items:
+            $ref: "#/components/schemas/PromotionBenefit"
+        applies_to:
+          type: array
+          description: Optional list of product or variant targets to which the promotion applies.
+          items:
+            $ref: "#/components/schemas/ProductTarget"
+        url:
+          type: string
+          format: uri
+          description: Canonical URL for the promotion detail or landing page.
+      example:
+        id: promo_spring_sale
+        title: Spring Sale
+        status: active
+        effective_period:
+          start_time: "2026-03-01T00:00:00Z"
+          end_time: "2026-03-31T23:59:59Z"
+        benefits:
+          - type: percent_off
+            percent_off: 20
+        applies_to:
+          - product_id: prod_classic_tee
+    PromotionsResponse:
+      description: Response envelope containing the current promotions for a feed.
+      type: object
+      additionalProperties: false
+      required:
+        - promotions
+      properties:
+        promotions:
+          type: array
+          description: Full list of promotions currently associated with the feed.
+          items:
+            $ref: "#/components/schemas/Promotion"
+      example:
+        promotions:
+          - id: promo_spring_sale
+            title: Spring Sale
+            effective_period:
+              start_time: "2026-03-01T00:00:00Z"
+              end_time: "2026-03-31T23:59:59Z"
+            benefits:
+              - type: percent_off
+                percent_off: 20
+    UpsertPromotionsRequest:
+      description: Request payload that partially upserts promotions into a feed. Promotions omitted from the request remain unchanged.
+      type: object
+      additionalProperties: false
+      required:
+        - promotions
+      properties:
+        promotions:
+          type: array
+          description: Subset of promotions to create or update within the feed, matched by Promotion.id.
+          items:
+            $ref: "#/components/schemas/Promotion"
+      example:
+        promotions:
+          - id: promo_spring_sale
+            title: Spring Sale
+            status: active
+            effective_period:
+              start_time: "2026-03-01T00:00:00Z"
+              end_time: "2026-03-31T23:59:59Z"
+            benefits:
+              - type: percent_off
+                percent_off: 20
+    UpsertPromotionsResponse:
+      description: Acknowledgement returned after accepting a promotion upsert payload for a feed.
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - accepted
+      properties:
+        id:
+          type: string
+          description: Identifier for the feed whose promotion upsert was processed.
+        accepted:
+          type: boolean
+          description: Whether the submitted promotion upsert payload was accepted for processing.
+      example:
+        id: feed_8f3K2x
+        accepted: true
     Error:
       description: Structured error returned when a feed request cannot be fulfilled.
       type: object


### PR DESCRIPTION
# SEP: Promotions API for ACP Product Feeds

## 📋 SEP Metadata
- **SEP Number**: [SEP: Promotions API #191](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/issues/191)
- **Author(s)**: Aravind Rao, Rahul Bansal
- **Status**: `proposal`
- **Type**: [X] Major Change [ ] Process Change

---

## 🎯 Abstract

This stacked PR proposes unreleased promotion support on top of the base Feed API introduced in `sep/product_feeds_api`.

The new API surface includes:

- `GET /feeds/{id}/promotions` to retrieve the current promotion set
- `PATCH /feeds/{id}/promotions` to partially upsert promotions by `Promotion.id`

This PR also adds the supporting promotion schema types and example payloads needed to define a reusable ACP representation for merchant-authored offers such as fixed-amount discounts, percentage discounts, and free-shipping promotions attached to a feed.

---

## 💡 Motivation

The base feed API lets ACP participants synchronize product catalogs, but catalog sync without promotion sync is incomplete.

This PR addresses that gap by introducing a feed-scoped promotion model for pre-checkout offer synchronization. In particular, it supports:

- retrieval of the current promotion set for a feed
- incremental promotion updates by stable `Promotion.id`
- structured promotion benefits for `amount_off`, `percent_off`, and `free_shipping`
- promotion targeting by product and optional variant identifiers
- promotion timing through explicit effective periods

This is intentionally a stacked follow-up PR. The base feed resource and product model land in `sep/product_feeds_api`; this PR layers promotion synchronization on top of that existing feed surface.

---

## 📐 Specification

This proposal makes the following normative additions in unreleased ACP, relative to `sep/product_feeds_api`:

1. Add `GET /feeds/{id}/promotions` for reading the full current promotion set
2. Add `PATCH /feeds/{id}/promotions` for partial upsert semantics keyed by `Promotion.id`
3. Extend the feed schema bundle with promotion-specific definitions
4. Add example payloads covering amount-off, percent-off, and free-shipping promotions
5. Add a changelog entry documenting the new promotions surface

The schema additions include:

- `DateTimeRange`
- `PromotionStatus`
- `AmountOffBenefit`
- `PercentOffBenefit`
- `FreeShippingBenefit`
- `PromotionBenefit`
- `ProductTarget`
- `Promotion`
- `PromotionsResponse`
- `UpsertPromotionsRequest`
- `UpsertPromotionsResponse`

The promotion model is feed-scoped and additive. Promotions omitted from a `PATCH /feeds/{id}/promotions` request remain unchanged, and submitted promotions replace existing stored promotions with the same `Promotion.id`.

---

## 🤔 Rationale

Promotions fit naturally as a feed subresource rather than as a standalone ACP service.

This structure gives ACP:

- a promotion synchronization surface aligned with the feed that owns the referenced product IDs
- support for seller-driven promotion creation and subsequent updates without a separate creation workflow
- a reusable normalized promotion model for platforms that need to ingest offers before checkout
- a clean separation between pre-checkout promotion synchronization and transaction-time discount application

Keeping this work in a stacked PR also keeps review scope clear: the first PR establishes the feed foundation, and this one adds promotions on top of it.

---

## 🔄 Backward Compatibility

This is a backward-compatible, additive change on top of the unreleased feed API.

Migration impact:

- no existing feed endpoints are removed
- no existing product feed behavior changes
- implementations that support feeds but not promotions can continue to operate unchanged

Clients that want promotions can begin using the new `/feeds/{id}/promotions` endpoints once both the base feed API and this stacked addition are available.

---

## 🛠️ Reference Implementation

This stacked PR updates the unreleased specification and related examples/docs in:

- `spec/unreleased/openapi/openapi.feed.yaml`
- `spec/unreleased/json-schema/schema.feed.json`
- `examples/unreleased/examples.feed.json`
- `changelog/unreleased/add-feed-promotions.md`

---

## 🔒 Security Implications

This PR introduces a new promotion-bearing API surface, so implementers should treat promotion payloads as potentially sensitive merchant data.

Key considerations:

- promotion data may reveal pricing strategy, offer timing, and merchandising intent
- promotion payloads may contain external URLs and descriptive content that consumers should treat as untrusted input
- sellers should only be allowed to push promotions for feeds they are authorized to manage
- promotion upserts should be validated strictly before acceptance

This PR defines the surface and schemas; implementation-specific authentication, authorization, replay protection, and abuse controls should be enforced by ACP servers.

---

## 📚 Additional Context

This is a stacked PR and should be reviewed relative to `sep/product_feeds_api`, not relative to `main`.

The base feed API PR introduces the feed resource, product model, and `/feeds/{id}/products` operations. This PR only adds promotion retrieval and promotion upsert semantics on top of that existing foundation.

---

## 🙋 Questions for Reviewers

- Is promotions-as-a-feed-subresource the right scoping model for the first ACP promotion sync surface?
- Is whole-promotion upsert by `Promotion.id` the right interoperability tradeoff for v1?
- Should the timing field be named `effective_period` here, or should it align more closely with the SEP wording if that terminology changes?

---

## ✅ Pre-Submission Checklist

Before submitting this SEP PR, ensure:

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
- [x] I have linked the SEP issue number above
- [x] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [x] I have signed the Contributor License Agreement (CLA)