### PR TITLE
SEP: Default Delivery Option Selection on Checkout Create

### DIFF
--- a/changelog/unreleased/default-delivery-option.md
+++ b/changelog/unreleased/default-delivery-option.md
@@ -1,0 +1,16 @@
+# Unreleased Changes
+
+## Default Delivery Option on Checkout Create (SEP #194)
+
+Add `is_default` boolean to fulfillment option types, enabling sellers to indicate a pre-selected delivery option on checkout create.
+
+### Changes
+
+- **FulfillmentOptionShipping**: Added optional `is_default` boolean field
+- **FulfillmentOptionPickup**: Added optional `is_default` boolean field
+- **FulfillmentOptionLocalDelivery**: Added optional `is_default` boolean field
+
+### Benefits
+
+- **Eliminates unnecessary round trip**: Agents no longer need a separate update call to select the default shipping option before displaying checkout
+- **Consistent UX**: Buyers see a pre-selected delivery option immediately on checkout load

--- a/examples/unreleased/examples.agentic_checkout.json
+++ b/examples/unreleased/examples.agentic_checkout.json
@@ -239,6 +239,7 @@
         "carrier": "USPS",
         "earliest_delivery_time": "2025-10-12T07:20:50.52Z",
         "latest_delivery_time": "2025-10-13T07:20:50.52Z",
+        "is_default": true,
         "totals": [
           { "type": "total", "display_text": "Shipping", "amount": 100 }
         ]

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -1315,6 +1315,11 @@
           "format": "date-time",
           "description": "RFC 3339 timestamp by which order must be picked up"
         },
+        "is_default": {
+          "type": "boolean",
+          "description": "Indicates this is the seller's recommended default fulfillment option.",
+
+        },
         "totals": {
           "type": "array",
           "items": {
@@ -1402,6 +1407,11 @@
           },
           "description": "Geographic service area for local delivery"
         },
+        "is_default": {
+          "type": "boolean",
+          "description": "Indicates this is the seller's recommended default fulfillment option.",
+
+        },
         "totals": {
           "type": "array",
           "items": {
@@ -1467,6 +1477,11 @@
           "type": "string",
           "format": "date-time",
           "description": "RFC 3339 timestamp for latest expected delivery"
+        },
+        "is_default": {
+          "type": "boolean",
+          "description": "Indicates this is the seller's recommended default fulfillment option.",
+
         },
         "totals": {
           "type": "array",

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -1497,6 +1497,10 @@ components:
           type: string
           format: date-time
           description: RFC 3339 timestamp by which order must be picked up
+        is_default:
+          type: boolean
+          description: Indicates this is the seller's recommended default fulfillment option.
+
         totals:
           type: array
           items:
@@ -1564,6 +1568,10 @@ components:
               type: string
               description: Center point postal code for delivery radius
           description: Geographic service area for local delivery
+        is_default:
+          type: boolean
+          description: Indicates this is the seller's recommended default fulfillment option.
+
         totals:
           type: array
           items:
@@ -1616,6 +1624,10 @@ components:
           type: string
           format: date-time
           description: RFC 3339 timestamp for latest expected delivery
+        is_default:
+          type: boolean
+          description: Indicates this is the seller's recommended default fulfillment option.
+
         totals:
           type: array
           items:


### PR DESCRIPTION
# SEP: Default Delivery Option Selection on Checkout Create

## SEP Metadata

- **SEP Number**: #194
- **Author(s)**: Lee Hwa / Meta
- **Status**: `proposal` (awaiting sponsor)
- **Type**: [x] Major Change [ ] Process Change
- **Related Issues/RFCs**: rfcs/rfc.agentic_checkout.md, spec/2026-01-30/json-schema/schema.agentic_checkout.json

---

## Abstract

This SEP proposes requiring sellers to pre-select a default fulfillment option when creating a checkout session. Currently, `POST /checkout_sessions` returns available `fulfillment_options[]` but does not select one by default, leaving the session-level `totals[]` without shipping cost. Agents must immediately send a follow-up update call to select a delivery option before displaying pricing — adding an unnecessary API round trip and increasing checkout page load latency.

The proposed changes add an `is_default` boolean to fulfillment option schemas, require sellers to populate `selected_fulfillment_options` with the default on create, and mandate a `fulfillment` total in the response when delivery options are present.

---

## Motivation

### The Problem

Agents building checkout UIs need to display the total price — including shipping — on the first page load. The current protocol does not require sellers to pre-select a delivery option, so:

1. Agent calls `POST /checkout_sessions` with items, buyer info, and shipping address
2. Seller returns delivery options (Standard, Express, etc.) but no selection
3. Session `totals[]` excludes `fulfillment` — the `total` amount has no shipping cost
4. Agent must immediately call `POST /checkout_sessions/{id}` with `selected_fulfillment_options` to get a total that includes shipping
5. Only now can the agent render a complete checkout page

### Why the Community Should Care

- **Agent developers** must all implement the same workaround (pick a default, send an update call) — this is duplicated effort across every ACP agent implementation
- **Sellers** already have default shipping logic in their web storefronts — the protocol should surface it
- **Buyers** experience slower checkout page loads for no functional reason
- **Protocol simplicity**: A checkout create that returns incomplete pricing violates the spec's own principle that create "MUST return 201 with a rich, authoritative cart state"

---

## Specification

### 1. Add `is_default` to Fulfillment Option Schemas

Add an optional `is_default` boolean to `FulfillmentOptionShipping`, `FulfillmentOptionPickup`, and `FulfillmentOptionLocalDelivery`.

### 2. Require Default Selection on Create Response

When the create response includes `fulfillment_options`, the seller MUST:
1. Mark exactly one fulfillment option with `is_default: true`
2. Populate `selected_fulfillment_options` with the default option
3. Include a `fulfillment` entry in session-level `totals[]` reflecting the default option's cost
4. Calculate `tax` and `total` in `totals[]` inclusive of the default fulfillment cost

Sellers SHOULD NOT mark more than one fulfillment option with `is_default: true`. If multiple options have `is_default: true`, the agent MUST use the first one in the `fulfillment_options` array and ignore `is_default` on subsequent options.

### 3. Agent Behavior

Agents SHOULD display the seller's default fulfillment option as pre-selected on the checkout page. Agents MAY override the selection by sending an update with a different `selected_fulfillment_options` value. The buyer's explicit selection always takes precedence over the seller's default.

### 4. Schema Changes

See `spec/unreleased/json-schema/schema.agentic_checkout.json` in this PR — `is_default` added to `FulfillmentOptionShipping`, `FulfillmentOptionPickup`, and `FulfillmentOptionLocalDelivery`.

---

## Rationale

### Why `is_default` instead of just pre-populating `selected_fulfillment_options`?

1. **Signals seller intent**: Distinguishes between "seller recommends this" vs. "buyer explicitly chose this" — important for analytics and fulfillment optimization
2. **Reset capability**: If the buyer clears their selection, the agent knows which option to revert to

### Why MUST instead of SHOULD?

The current gap forces every agent implementation to build the same workaround. A SHOULD would leave the inconsistency in place — some sellers would default, others wouldn't, and agents would still need the fallback code path. MUST ensures consistent behavior.

### Alternatives Considered

1. **Agent picks a default**: Current workaround. Adds latency, duplicates logic across agents, may not match seller preference.
2. **Estimated fulfillment total without selection**: Creates inconsistency — the `total` amount doesn't match any concrete fulfillment option.
3. **New `default_fulfillment_option_id` field on response**: More complex than `is_default` on the option itself.

---

## Backward Compatibility

- **Additive change**: `is_default` is a new optional field on existing schemas — existing implementations that don't set it will default to `false`
- **Behavioral change**: Requiring `selected_fulfillment_options` and `fulfillment` totals on create is a new MUST requirement
- **Severity**: Low. Additive for agents; minor implementation change for sellers (most already have default shipping logic).

---

## Reference Implementation

Not yet available. Will provide before status "Final."

Meta's ACP integration currently implements the agent-side workaround (immediate update call after create) and can validate the proposed behavior.

---

## Security Implications

- No authentication/authorization impact
- No privacy concerns — fulfillment options and pricing are already returned in the create response
- No new attack vectors — `is_default` is informational and read-only from the agent perspective

---

## Pre-Submission Checklist

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
- [x] I have linked the SEP issue number above
- [ ] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] This PR includes updates to OpenAPI/JSON schemas (if applicable)
- [x] This PR includes example requests/responses (if applicable)
- [x] This PR includes a changelog entry file in `changelog/unreleased/default-delivery-option.md`
- [ ] I am seeking or have found a sponsor (Founding Maintainer)

---

## Questions for Reviewers

1. Should `is_default` be required (exactly one must be true) or recommended (SHOULD)?
2. For multi-fulfillment-group scenarios, should each group have its own default?
3. Should the spec define which option sellers should default to (e.g., cheapest, fastest)? Or leave this to seller discretion?

---

**Note**: SEPs require unanimous approval from Founding Maintainers. See [governance.md](../docs/governance.md) and [sep-guidelines.md](../docs/sep-guidelines.md) for the full process.
