### PR TITLE
SEP: Marketing Consent

### DIFF
--- a/changelog/unreleased/marketing-consent.md
+++ b/changelog/unreleased/marketing-consent.md
@@ -6,9 +6,9 @@ Add marketing consent support to enable sellers to offer opt-in marketing subscr
 
 ## New Schemas
 
-- **MarketingConsentOption**: Seller-declared consent option with `type` (email, sms, whatsapp),
+- **MarketingConsentOption**: Seller-declared consent option with `channel` (open enum, e.g. email, sms, whatsapp),
   `description`, `privacy_policy_url`, and optional `is_subscribed` boolean for returning buyers.
-- **MarketingConsent**: Agent-submitted consent decision with `type` and `opted_in` boolean.
+- **MarketingConsent**: Agent-submitted consent decision with `channel` and `opted_in` boolean.
 
 ## CheckoutSession Changes
 

--- a/changelog/unreleased/marketing-consent.md
+++ b/changelog/unreleased/marketing-consent.md
@@ -1,0 +1,18 @@
+# Unreleased Changes
+
+## Email Marketing Consent on Checkout Complete (SEP #195)
+
+Add marketing consent support to enable sellers to offer opt-in marketing subscriptions at checkout completion.
+
+### Changes
+
+- **MarketingConsentOption**: New schema for seller-declared consent options (type, description, privacy_policy_url)
+- **MarketingConsent**: New schema for agent-submitted consent choices (type, opted_in)
+- **CheckoutSessionBase**: Added optional `marketing_consent_options` array field
+- **CheckoutSessionCompleteRequest**: Added optional `marketing_consents` array field
+
+### Benefits
+
+- **Privacy-compliant**: Consent is explicit opt-in with privacy policy links (GDPR/CAN-SPAM compliant)
+- **Seller-declared**: Sellers define available consent types; agents present them to buyers
+- **Contact-scoped**: Consent applies to fulfillment_details contact info (email, phone)

--- a/changelog/unreleased/marketing-consent.md
+++ b/changelog/unreleased/marketing-consent.md
@@ -1,18 +1,41 @@
 # Unreleased Changes
 
-## Email Marketing Consent on Checkout Complete (SEP #195)
+## Marketing Consent Support
 
-Add marketing consent support to enable sellers to offer opt-in marketing subscriptions at checkout completion.
+Add marketing consent support to enable sellers to offer opt-in marketing subscriptions during checkout.
 
-### Changes
+## New Schemas
 
-- **MarketingConsentOption**: New schema for seller-declared consent options (type, description, privacy_policy_url)
-- **MarketingConsent**: New schema for agent-submitted consent choices (type, opted_in)
-- **CheckoutSessionBase**: Added optional `marketing_consent_options` array field
-- **CheckoutSessionCompleteRequest**: Added optional `marketing_consents` array field
+- **MarketingConsentOption**: Seller-declared consent option with `type` (email, sms, whatsapp),
+  `description`, `privacy_policy_url`, and optional `is_subscribed` boolean for returning buyers.
+- **MarketingConsent**: Agent-submitted consent decision with `type` and `opted_in` boolean.
 
-### Benefits
+## CheckoutSession Changes
 
-- **Privacy-compliant**: Consent is explicit opt-in with privacy policy links (GDPR/CAN-SPAM compliant)
-- **Seller-declared**: Sellers define available consent types; agents present them to buyers
-- **Contact-scoped**: Consent applies to fulfillment_details contact info (email, phone)
+- **`marketing_consent_options`** added as an optional array on `CheckoutSessionBase`. Sellers
+  include this to signal available marketing channels and the buyer's existing subscription status.
+- **`marketing_consents`** added as an optional array on `CheckoutSessionCompleteRequest`. Agents
+  include the buyer's consent decisions for each option surfaced.
+
+## Marketing Channel Resolution
+
+- For email consent: seller uses `buyer.email` (primary) or `fulfillment_details.email` (fallback).
+- For SMS/WhatsApp consent: seller uses `buyer.phone_number` (primary) or
+  `fulfillment_details.phone_number` (fallback).
+
+## Design Notes
+
+- Consent is captured at complete checkout time only — not during checkout updates.
+- `is_subscribed` lets sellers communicate existing subscription status so agents render the
+  correct default (pre-checked for returning subscribers, unchecked for new buyers).
+- Agents MAY selectively surface a subset of options; unsurfaced options are omitted from the
+  response, preserving existing subscription state.
+- Omission of `marketing_consents` in the complete request preserves all existing subscriptions.
+- Sellers who do not want to risk accidental revocation should omit the channel from
+  `marketing_consent_options`.
+
+**Files changed:**
+
+- `spec/unreleased/json-schema/schema.agentic_checkout.json` (new schemas and fields)
+- `spec/unreleased/openapi/openapi.agentic_checkout.yaml` (new schemas and fields)
+- `examples/unreleased/examples.agentic_checkout.json` (consent examples)

--- a/changelog/unreleased/marketing-consent.md
+++ b/changelog/unreleased/marketing-consent.md
@@ -7,15 +7,17 @@ Add marketing consent support to enable sellers to offer opt-in marketing subscr
 ## New Schemas
 
 - **MarketingConsentOption**: Seller-declared consent option with `channel` (open enum, e.g. email, sms, whatsapp),
-  `description`, `privacy_policy_url`, and optional `is_subscribed` boolean for returning buyers.
+  `display_text`, `privacy_policy_url`, and optional `is_subscribed` boolean for returning buyers.
 - **MarketingConsent**: Agent-submitted consent decision with `channel` and `opted_in` boolean.
 
 ## CheckoutSession Changes
 
 - **`marketing_consent_options`** added as an optional array on `CheckoutSessionBase`. Sellers
   include this to signal available marketing channels and the buyer's existing subscription status.
+  An empty array is equivalent to absent.
 - **`marketing_consents`** added as an optional array on `CheckoutSessionCompleteRequest`. Agents
-  include the buyer's consent decisions for each option surfaced.
+  include the buyer's consent decisions for each option surfaced. Sellers ignore entries for
+  channels not offered.
 
 ## Marketing Channel Resolution
 
@@ -39,3 +41,4 @@ Add marketing consent support to enable sellers to offer opt-in marketing subscr
 - `spec/unreleased/json-schema/schema.agentic_checkout.json` (new schemas and fields)
 - `spec/unreleased/openapi/openapi.agentic_checkout.yaml` (new schemas and fields)
 - `examples/unreleased/examples.agentic_checkout.json` (consent examples)
+- `rfcs/rfc.marketing_consent.md` (RFC document)

--- a/examples/unreleased/examples.agentic_checkout.json
+++ b/examples/unreleased/examples.agentic_checkout.json
@@ -256,6 +256,13 @@
         ]
       }
     ],
+    "marketing_consent_options": [
+      {
+        "type": "email",
+        "description": "Promotional emails, product launches, and exclusive offers",
+        "privacy_policy_url": "https://www.testshop.com/privacy"
+      }
+    ],
     "messages": [],
     "links": [
       {
@@ -437,7 +444,13 @@
         "postal_code": "94131"
       }
     },
-    "order_notes": "Please ring doorbell twice. Leave with neighbor at #12 if no answer."
+    "order_notes": "Please ring doorbell twice. Leave with neighbor at #12 if no answer.",
+    "marketing_consents": [
+      {
+        "type": "email",
+        "opted_in": true
+      }
+    ]
   },
   "complete_checkout_session_request_seller_backed": {
     "buyer": {

--- a/examples/unreleased/examples.agentic_checkout.json
+++ b/examples/unreleased/examples.agentic_checkout.json
@@ -258,7 +258,7 @@
     ],
     "marketing_consent_options": [
       {
-        "type": "email",
+        "channel": "email",
         "description": "Promotional emails, product launches, and exclusive offers",
         "privacy_policy_url": "https://www.testshop.com/privacy",
         "is_subscribed": false
@@ -448,7 +448,7 @@
     "order_notes": "Please ring doorbell twice. Leave with neighbor at #12 if no answer.",
     "marketing_consents": [
       {
-        "type": "email",
+        "channel": "email",
         "opted_in": true
       }
     ]

--- a/examples/unreleased/examples.agentic_checkout.json
+++ b/examples/unreleased/examples.agentic_checkout.json
@@ -260,7 +260,8 @@
       {
         "type": "email",
         "description": "Promotional emails, product launches, and exclusive offers",
-        "privacy_policy_url": "https://www.testshop.com/privacy"
+        "privacy_policy_url": "https://www.testshop.com/privacy",
+        "is_subscribed": false
       }
     ],
     "messages": [],

--- a/examples/unreleased/examples.agentic_checkout.json
+++ b/examples/unreleased/examples.agentic_checkout.json
@@ -259,7 +259,13 @@
     "marketing_consent_options": [
       {
         "channel": "email",
-        "description": "Promotional emails, product launches, and exclusive offers",
+        "display_text": "Promotional emails, product launches, and exclusive offers",
+        "privacy_policy_url": "https://www.testshop.com/privacy",
+        "is_subscribed": false
+      },
+      {
+        "channel": "sms",
+        "display_text": "Order updates and exclusive deals via text message",
         "privacy_policy_url": "https://www.testshop.com/privacy",
         "is_subscribed": false
       }
@@ -450,6 +456,10 @@
       {
         "channel": "email",
         "opted_in": true
+      },
+      {
+        "channel": "sms",
+        "opted_in": false
       }
     ]
   },

--- a/rfcs/rfc.marketing_consent.md
+++ b/rfcs/rfc.marketing_consent.md
@@ -1,0 +1,299 @@
+# RFC: Marketing Consent
+
+**Status:** Proposal
+**Version:** unreleased
+**Scope:** Marketing opt-in consent capture during checkout
+
+This RFC defines a marketing consent mechanism for the Agentic Commerce Protocol (ACP). Sellers declare available marketing opt-in channels on the checkout session response; agents render the consent UI and submit the buyer's decisions on the checkout complete request.
+
+---
+
+## 1. Motivation
+
+Marketing opt-in is a standard feature on virtually every e-commerce checkout page. When buyers purchase through ACP-integrated agents instead of merchant storefronts, this opt-in opportunity is lost because the protocol has no mechanism to:
+
+1. **Signal opt-in availability**: Sellers cannot tell agents they want to offer marketing consent.
+2. **Communicate existing subscription status**: Sellers cannot tell agents that a returning buyer is already subscribed, so agents cannot pre-check the consent box or intelligently skip the prompt.
+3. **Capture consent**: Agents cannot pass the buyer's opt-in decision to the seller.
+4. **Display the prompt**: Agents have no display text or context to render a consent checkbox.
+
+### Why the community should care
+
+- **Merchants lose a key acquisition channel**: Marketing drives repeat purchases — without opt-in support, agentic checkout is less valuable than web checkout.
+- **Buyers lose choice**: Buyers who want merchant updates have no way to opt in during agentic checkout.
+- **Regulatory compliance**: GDPR, CAN-SPAM, and CCPA require explicit consent before marketing communications — the protocol should support capturing this at the right moment.
+- **Merchant adoption**: If ACP cannot capture marketing consent, merchants have less incentive to support the protocol — it is a competitive disadvantage vs. their own checkout.
+
+### Precedent
+
+- **Shopify Checkout API**: Includes `buyer_accepts_marketing` boolean on checkout.
+- **Stripe Checkout**: Supports `consent_collection.promotions` for marketing consent.
+- **BigCommerce**: Offers newsletter subscription opt-in at checkout.
+- **WooCommerce**: Plugins for marketing consent checkbox at checkout.
+
+All major e-commerce platforms treat marketing consent as a core checkout feature, not an afterthought.
+
+---
+
+## 2. Goals and Non-Goals
+
+### 2.1 Goals
+
+1. **Seller-declared consent**: Sellers decide whether to offer marketing opt-in and which channels to include.
+2. **Agent-rendered UI**: Agents control the consent UX — composing display text, choosing layout, and linking to privacy policies.
+3. **Existing subscription awareness**: Sellers communicate whether the buyer is already subscribed, so agents render the correct default state.
+4. **Consent at confirm time**: Consent is captured at checkout completion, not during address or shipping selection.
+5. **Selective surfacing**: Agents MAY surface a subset of offered channels based on platform capabilities.
+
+### 2.2 Non-Goals
+
+- **Subscription management**: This RFC does not cover unsubscribe flows, preference centers, or subscription status queries outside checkout.
+- **Consent storage**: The protocol captures consent at the transaction boundary. How sellers store and enforce consent is out of scope.
+- **Content preview**: The protocol does not define what marketing content will be sent — only that the buyer consents to receive it.
+- **Double opt-in flows**: Some jurisdictions require confirmation emails after initial opt-in. This is a seller-side concern, not a protocol concern.
+
+---
+
+## 3. Design
+
+### 3.1 Three-Phase Architecture
+
+Marketing consent flows through three phases:
+
+| Phase | Actor | Action |
+|-------|-------|--------|
+| **Declare** | Seller | Includes `marketing_consent_options` on the `CheckoutSession` response with channel, display text, privacy policy URL, and existing subscription status. |
+| **Render** | Agent | Displays consent UI based on the options. Sets checkbox default from `is_subscribed`. Links to privacy policy. |
+| **Capture** | Agent → Seller | Includes `marketing_consents` on the `CheckoutSessionCompleteRequest` with the buyer's decision for each surfaced channel. |
+
+### 3.2 Schemas
+
+#### MarketingConsentOption (seller → agent)
+
+Included in the `CheckoutSession` response to declare available marketing channels.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `channel` | string | Yes | Marketing channel (open enum, e.g. `email`, `sms`, `whatsapp`). |
+| `display_text` | string | Yes | What the buyer is consenting to receive. Agents MAY use this to compose their own consent prompt. |
+| `privacy_policy_url` | string (URI) | Yes | URL to the seller's privacy policy. |
+| `is_subscribed` | boolean | No | Whether the buyer is currently subscribed. Defaults to `false`. When `true`, agents SHOULD render the checkbox pre-checked. |
+
+#### MarketingConsent (agent → seller)
+
+Included in the `CheckoutSessionCompleteRequest` to submit the buyer's decisions.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `channel` | string | Yes | Channel matching the consent option. |
+| `opted_in` | boolean | Yes | Whether the buyer consented to marketing on this channel. |
+
+### 3.3 Field Placement
+
+- **`marketing_consent_options`**: Optional array on `CheckoutSessionBase`. Present when the seller offers marketing opt-in.
+- **`marketing_consents`**: Optional array on `CheckoutSessionCompleteRequest`. Present when the agent surfaced consent options to the buyer.
+
+### 3.4 Channel as Open Enum
+
+The `channel` field uses an open enum pattern: `email` and `sms` are well-known values, but sellers MAY use any string (e.g., `whatsapp`, `push`, `messenger`). Agents SHOULD surface channels they recognize and omit unrecognized channels from the response. This avoids a breaking schema change when new channels are added.
+
+### 3.5 Contact Resolution
+
+Marketing consent applies to the buyer's contact information, resolved with the following precedence:
+
+**For `email` consent:**
+1. `buyer.email` (primary — required when `buyer` is present)
+2. `fulfillment_details.email` (fallback)
+
+**For `sms` or `whatsapp` consent:**
+1. `buyer.phone_number` (primary — optional on `Buyer`)
+2. `fulfillment_details.phone_number` (fallback)
+
+If no contact can be resolved for a channel (e.g., email consent without either `buyer.email` or `fulfillment_details.email`), the seller MUST ignore the consent for that channel.
+
+**Rationale**: The buyer is the person opting in to marketing, so their contact info is the natural target. The `fulfillment_details` fallback ensures coverage when the `buyer` object is not provided. This keeps marketing on the same channels the seller already uses for transactional communications.
+
+### 3.6 Edge Cases
+
+**Unsolicited consent entries:**
+- If the agent sends a `marketing_consents` entry for a channel the seller did not offer in `marketing_consent_options`, the seller SHOULD ignore that entry.
+
+**Non-interaction:**
+- If the buyer does not interact with the consent UI, the agent SHOULD send `opted_in` matching the `is_subscribed` value, preserving the current state.
+
+---
+
+## 4. End-to-End Flow
+
+```mermaid
+sequenceDiagram
+    participant B as Buyer
+    participant A as Agent
+    participant S as Seller
+
+    rect rgb(240, 248, 255)
+    Note over B,S: Phase 0: Initiate
+    B->>A: Add items to cart, proceed to checkout
+    A->>S: POST /checkout_sessions
+    end
+
+    rect rgb(240, 255, 240)
+    Note over B,S: Phase 1: Declare
+    S-->>A: 201 CheckoutSession<br/>marketing_consent_options[]<br/>(with is_subscribed status)
+    end
+
+    rect rgb(255, 248, 240)
+    Note over B,S: Phase 2: Render
+    A->>B: Display consent UI<br/>(checkbox state from is_subscribed)
+    B->>A: Buyer interacts<br/>(check/uncheck)
+    end
+
+    rect rgb(248, 240, 255)
+    Note over B,S: Phase 3: Capture
+    A->>S: POST /checkout_sessions/{id}/complete<br/>marketing_consents[]
+    S-->>A: 200 Order confirmed
+    end
+```
+
+### 4.1 Scenario Matrix
+
+| # | Scenario | Seller Behavior | Agent Behavior |
+|---|----------|-----------------|----------------|
+| 1 | **New buyer** (no prior consent) | Sends option with `is_subscribed: false` (or omitted) | Renders unchecked checkbox. Buyer can opt in. |
+| 2 | **Returning buyer** (already subscribed) | Sends option with `is_subscribed: true` | Renders pre-checked checkbox. Buyer can uncheck to revoke. |
+| 3 | **Returning buyer** (seller omits option) | Omits `marketing_consent_options` entirely | Shows nothing. Existing subscription preserved server-side. |
+
+---
+
+## 5. HTTP Interface
+
+Marketing consent uses existing checkout endpoints — no new endpoints are introduced.
+
+### 5.1 CheckoutSession Response (seller → agent)
+
+The `CheckoutSession` response gains an optional `marketing_consent_options` array:
+
+```json
+{
+  "id": "checkout_session_123",
+  "status": "ready_for_payment",
+  "marketing_consent_options": [
+    {
+      "channel": "email",
+      "display_text": "Promotional emails, product launches, and exclusive offers",
+      "privacy_policy_url": "https://www.example.com/privacy",
+      "is_subscribed": false
+    },
+    {
+      "channel": "sms",
+      "display_text": "Order updates and exclusive deals via text message",
+      "privacy_policy_url": "https://www.example.com/privacy",
+      "is_subscribed": false
+    }
+  ]
+}
+```
+
+### 5.2 CheckoutSessionCompleteRequest (agent → seller)
+
+The complete request gains an optional `marketing_consents` array:
+
+```json
+{
+  "payment_data": {
+    "type": "card",
+    "token": "tok_abc123"
+  },
+  "marketing_consents": [
+    { "channel": "email", "opted_in": true },
+    { "channel": "sms", "opted_in": false }
+  ]
+}
+```
+
+---
+
+## 6. Rationale
+
+### Why at confirm time, not during checkout update?
+
+- **Privacy**: The buyer's contact info should not be used for marketing before they commit to a purchase.
+- **Regulatory alignment**: GDPR requires consent to be "freely given, specific, informed and unambiguous" — tying it to checkout completion ensures it accompanies an informed transaction.
+- **UX**: Consent checkboxes naturally belong next to the "Place Order" button, not during address or shipping selection.
+- **Schema separation**: `marketing_consents` is a standalone field on `CheckoutSessionCompleteRequest`, keeping consent separate from both `Buyer` (identity) and `FulfillmentDetails` (delivery logistics).
+
+### Why a three-phase design?
+
+- **Seller control**: Not all merchants want marketing opt-in — the seller decides whether to offer it.
+- **Agent flexibility**: The agent controls the UI, composes its own display text, and presents the consent in the most appropriate way for its platform.
+- **Existing status matters**: `is_subscribed` lets the seller communicate the buyer's current state, so the agent renders the right default.
+
+### Why support multiple channels?
+
+While email is the immediate need, commerce platforms commonly offer SMS and WhatsApp opt-in. Including these as an open enum from the start avoids a future schema change. Agents can ignore channels they do not support.
+
+### Alternatives considered
+
+1. **Pass consent during checkout update**: Premature — buyer has not committed. Creates privacy risk.
+2. **Use `metadata` field**: Unstructured, non-standard, requires per-seller agent logic.
+3. **Post-purchase opt-in**: Loses the high-conversion checkout moment and adds friction.
+4. **Add consent to `Buyer` schema**: Conflates identity with transactional decisions. `Buyer` is sent on update requests, which would allow consent before purchase confirmation.
+5. **Extension mechanism**: Marketing consent is fundamental enough (virtually every checkout has it) that it belongs in the core spec.
+
+---
+
+## 7. Security, Privacy, and Trust
+
+- **Privacy improvement**: This proposal creates a standardized, explicit consent mechanism rather than relying on implicit or non-standard approaches.
+- **Data minimization**: Consent is scoped to specific channels — sellers receive only the consent decisions the buyer explicitly makes.
+- **No new data exposure**: The buyer's email and phone are already included in `buyer` or `fulfillment_details` — this proposal adds only a consent flag, not additional PII.
+- **Regulatory support**: Provides a clear audit trail for GDPR, CAN-SPAM, and CCPA compliance — the `opted_in` boolean is an explicit record of consent.
+- **Revocation path**: Returning buyers with `is_subscribed: true` can revoke consent by unchecking the box. Sellers who do not want to expose this risk should omit the channel.
+
+---
+
+## 8. Backward Compatibility
+
+This is a purely additive change:
+
+- **`marketing_consent_options`** is a new optional field on `CheckoutSessionBase` — existing implementations are unaffected.
+- **`marketing_consents`** is a new optional field on `CheckoutSessionCompleteRequest` — existing complete calls continue to work.
+- **No breaking changes**: Sellers that do not offer marketing consent omit `marketing_consent_options`. Agents that do not support it omit `marketing_consents`.
+- **Graceful degradation**: If the agent does not send `marketing_consents`, the seller treats it as no consent given (current behavior).
+
+---
+
+## 9. Required Spec Updates
+
+- [x] `spec/unreleased/json-schema/schema.agentic_checkout.json` — `MarketingConsentOption`, `MarketingConsent` schemas; `marketing_consent_options` on `CheckoutSessionBase`; `marketing_consents` on `CheckoutSessionCompleteRequest`
+- [x] `spec/unreleased/openapi/openapi.agentic_checkout.yaml` — Matching OpenAPI definitions
+- [x] `examples/unreleased/examples.agentic_checkout.json` — Multi-channel consent examples
+- [x] `changelog/unreleased/marketing-consent.md` — Changelog entry
+- [x] `rfcs/rfc.marketing_consent.md` — This document
+
+---
+
+## 10. Conformance Checklist
+
+### Seller (MUST)
+
+- [ ] MUST NOT treat omission of `marketing_consents` as new consent — preserve existing subscription state.
+- [ ] MUST respect the buyer's `opted_in` value — MUST NOT send marketing to buyers who did not opt in.
+- [ ] MUST ignore consent entries for channels not offered in `marketing_consent_options`.
+- [ ] MUST ignore consent entries where no contact can be resolved for the channel.
+
+### Seller (SHOULD)
+
+- [ ] SHOULD omit `marketing_consent_options` for channels where the seller does not want to risk accidental revocation.
+
+### Agent (MUST)
+
+- [ ] MUST NOT surface marketing consent UI when `marketing_consent_options` is absent or empty.
+- [ ] MUST NOT send `opted_in` values for consent options that were not displayed to the buyer — omit unsurfaced channels from `marketing_consents`.
+
+### Agent (SHOULD)
+
+- [ ] SHOULD render consent checkbox with default state based on `is_subscribed` (`true` = pre-checked, `false`/omitted = unchecked).
+- [ ] SHOULD display the seller's `display_text` and link to `privacy_policy_url`.
+- [ ] SHOULD include the buyer's decision in `marketing_consents` for each option surfaced.
+- [ ] SHOULD send `opted_in` matching `is_subscribed` if the buyer does not interact with the consent UI (preserving current state).

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -3134,14 +3134,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "type": {
+        "channel": {
           "type": "string",
-          "enum": [
-            "email",
-            "sms",
-            "whatsapp"
-          ],
-          "description": "Channel for marketing consent."
+          "description": "Channel for marketing consent.",
+          "examples": ["email", "sms", "whatsapp"]
         },
         "description": {
           "type": "string",
@@ -3158,7 +3154,7 @@
         }
       },
       "required": [
-        "type",
+        "channel",
         "description",
         "privacy_policy_url"
       ]
@@ -3167,14 +3163,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "type": {
+        "channel": {
           "type": "string",
-          "enum": [
-            "email",
-            "sms",
-            "whatsapp"
-          ],
-          "description": "Channel matching the consent option type."
+          "description": "Channel matching the consent option channel.",
+          "examples": ["email", "sms", "whatsapp"]
         },
         "opted_in": {
           "type": "boolean",
@@ -3182,7 +3174,7 @@
         }
       },
       "required": [
-        "type",
+        "channel",
         "opted_in"
       ]
     },

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -3131,6 +3131,7 @@
       }
     },
     "MarketingConsentOption": {
+      "description": "Seller-declared marketing consent option that specifies an available channel for which the seller must obtain the buyer's consent before sending marketing content",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -3157,9 +3158,16 @@
         "channel",
         "description",
         "privacy_policy_url"
-      ]
+      ],
+      "example": {
+        "channel": "email",
+        "description": "Promotional emails, product launches, and exclusive offers",
+        "privacy_policy_url": "https://www.example.com/privacy",
+        "is_subscribed": false
+      }
     },
     "MarketingConsent": {
+      "description": "Buyer's marketing consent decision for a specific channel submitted at checkout completion",
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -3176,7 +3184,11 @@
       "required": [
         "channel",
         "opted_in"
-      ]
+      ],
+      "example": {
+        "channel": "email",
+        "opted_in": true
+      }
     },
     "CheckoutSessionBase": {
       "description": "Base checkout session model containing common fields for all checkout session states",

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -3130,6 +3130,58 @@
         "eci": "05"
       }
     },
+    "MarketingConsentOption": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "email",
+            "sms",
+            "whatsapp"
+          ],
+          "description": "Channel for marketing consent."
+        },
+        "description": {
+          "type": "string",
+          "description": "What the buyer is consenting to receive, e.g., 'promotional emails, product launches, and exclusive offers'. Agents MAY use this to compose their own display text."
+        },
+        "privacy_policy_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to the seller's privacy policy governing use of the buyer's contact information for marketing."
+        }
+      },
+      "required": [
+        "type",
+        "description",
+        "privacy_policy_url"
+      ]
+    },
+    "MarketingConsent": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "email",
+            "sms",
+            "whatsapp"
+          ],
+          "description": "Channel matching the consent option type."
+        },
+        "opted_in": {
+          "type": "boolean",
+          "description": "Whether the buyer consented to receive marketing via this channel."
+        }
+      },
+      "required": [
+        "type",
+        "opted_in"
+      ]
+    },
     "CheckoutSessionBase": {
       "description": "Base checkout session model containing common fields for all checkout session states",
       "type": "object",
@@ -3310,6 +3362,13 @@
         "discounts": {
           "$ref": "#/$defs/DiscountsResponse",
           "description": "Discount extension: submitted codes and applied discounts. Present when the 'discount' extension is active."
+        },
+        "marketing_consent_options": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/MarketingConsentOption"
+          },
+          "description": "Marketing consent options the seller offers. When present, the agent SHOULD display these to the buyer before checkout completion."
         },
         "order": {
           "$ref": "#/$defs/Order"
@@ -3583,6 +3642,13 @@
         "risk_signals": {
           "$ref": "#/$defs/RiskSignals",
           "description": "Risk and fraud signals"
+        },
+        "marketing_consents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/MarketingConsent"
+          },
+          "description": "Buyer's marketing consent decisions. Agents SHOULD include this when the session includes marketing_consent_options. Omission is treated as no consent given."
         },
         "order_notes": {
           "type": "string",

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -3151,6 +3151,10 @@
           "type": "string",
           "format": "uri",
           "description": "URL to the seller's privacy policy governing use of the buyer's contact information for marketing."
+        },
+        "is_subscribed": {
+          "type": "boolean",
+          "description": "Whether the buyer is currently subscribed to marketing via this channel. When true, agents SHOULD render the consent checkbox as pre-checked. Defaults to false if omitted."
         }
       },
       "required": [
@@ -3368,7 +3372,7 @@
           "items": {
             "$ref": "#/$defs/MarketingConsentOption"
           },
-          "description": "Marketing consent options the seller offers. When present, the agent SHOULD display these to the buyer before checkout completion."
+          "description": "Marketing consent options the seller offers. When present, the agent SHOULD display these to the buyer before checkout completion. Agents MAY selectively surface a subset of options; options not surfaced MUST be omitted from marketing_consents in the complete request. When absent, the agent MUST NOT surface any marketing consent UI."
         },
         "order": {
           "$ref": "#/$defs/Order"
@@ -3648,7 +3652,7 @@
           "items": {
             "$ref": "#/$defs/MarketingConsent"
           },
-          "description": "Buyer's marketing consent decisions. Agents SHOULD include this when the session includes marketing_consent_options. Omission is treated as no consent given."
+          "description": "Buyer's marketing consent decisions. Agents SHOULD include an entry for each consent option surfaced to the buyer. Options not surfaced MUST be omitted — omission preserves existing subscription state."
         },
         "order_notes": {
           "type": "string",

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -3140,9 +3140,9 @@
           "description": "Channel for marketing consent.",
           "examples": ["email", "sms", "whatsapp"]
         },
-        "description": {
+        "display_text": {
           "type": "string",
-          "description": "What the buyer is consenting to receive, e.g., 'promotional emails, product launches, and exclusive offers'. Agents MAY use this to compose their own display text."
+          "description": "What the buyer is consenting to receive, e.g., 'promotional emails, product launches, and exclusive offers'. Agents MAY use this to compose their own consent prompt."
         },
         "privacy_policy_url": {
           "type": "string",
@@ -3156,12 +3156,12 @@
       },
       "required": [
         "channel",
-        "description",
+        "display_text",
         "privacy_policy_url"
       ],
       "example": {
         "channel": "email",
-        "description": "Promotional emails, product launches, and exclusive offers",
+        "display_text": "Promotional emails, product launches, and exclusive offers",
         "privacy_policy_url": "https://www.example.com/privacy",
         "is_subscribed": false
       }
@@ -3376,7 +3376,7 @@
           "items": {
             "$ref": "#/$defs/MarketingConsentOption"
           },
-          "description": "Marketing consent options the seller offers. When present, the agent SHOULD display these to the buyer before checkout completion. Agents MAY selectively surface a subset of options; options not surfaced MUST be omitted from marketing_consents in the complete request. When absent, the agent MUST NOT surface any marketing consent UI."
+          "description": "Marketing consent options the seller offers. When present, the agent SHOULD display these to the buyer before checkout completion. Agents MAY selectively surface a subset of options; options not surfaced MUST be omitted from marketing_consents in the complete request. When absent, the agent MUST NOT surface any marketing consent UI. An empty array is equivalent to absent."
         },
         "order": {
           "$ref": "#/$defs/Order"
@@ -3656,7 +3656,7 @@
           "items": {
             "$ref": "#/$defs/MarketingConsent"
           },
-          "description": "Buyer's marketing consent decisions. Agents SHOULD include an entry for each consent option surfaced to the buyer. Options not surfaced MUST be omitted — omission preserves existing subscription state."
+          "description": "Buyer's marketing consent decisions. Agents SHOULD include an entry for each consent option surfaced to the buyer. Options not surfaced MUST be omitted — omission preserves existing subscription state. Sellers SHOULD ignore entries in marketing_consents that do not correspond to a channel in marketing_consent_options."
         },
         "order_notes": {
           "type": "string",

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -2755,13 +2755,13 @@ components:
       type: object
       additionalProperties: false
       properties:
-        type:
+        channel:
           type: string
-          enum:
+          description: Channel for marketing consent.
+          examples:
             - email
             - sms
             - whatsapp
-          description: Channel for marketing consent.
         description:
           type: string
           description: "What the buyer is consenting to receive, e.g., 'promotional emails, product launches, and exclusive offers'. Agents MAY use this to compose their own display text."
@@ -2775,25 +2775,25 @@ components:
             channel. When true, agents SHOULD render the consent checkbox as pre-checked.
             Defaults to false if omitted.
       required:
-        - type
+        - channel
         - description
         - privacy_policy_url
     MarketingConsent:
       type: object
       additionalProperties: false
       properties:
-        type:
+        channel:
           type: string
-          enum:
+          description: Channel matching the consent option channel.
+          examples:
             - email
             - sms
             - whatsapp
-          description: Channel matching the consent option type.
         opted_in:
           type: boolean
           description: Whether the buyer consented to receive marketing via this channel.
       required:
-        - type
+        - channel
         - opted_in
     CheckoutSessionBase:
       type: object

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -2751,6 +2751,45 @@ components:
         instruments: []
         handlers: []
       description: Payment configuration returned by the seller including accepted methods and handlers
+    MarketingConsentOption:
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          enum:
+            - email
+            - sms
+            - whatsapp
+          description: Channel for marketing consent.
+        description:
+          type: string
+          description: "What the buyer is consenting to receive, e.g., 'promotional emails, product launches, and exclusive offers'. Agents MAY use this to compose their own display text."
+        privacy_policy_url:
+          type: string
+          format: uri
+          description: URL to the seller's privacy policy governing use of the buyer's contact information for marketing.
+      required:
+        - type
+        - description
+        - privacy_policy_url
+    MarketingConsent:
+      type: object
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          enum:
+            - email
+            - sms
+            - whatsapp
+          description: Channel matching the consent option type.
+        opted_in:
+          type: boolean
+          description: Whether the buyer consented to receive marketing via this channel.
+      required:
+        - type
+        - opted_in
     CheckoutSessionBase:
       type: object
       additionalProperties: false
@@ -2871,6 +2910,11 @@ components:
           type: string
           format: date-time
           description: RFC 3339 timestamp when the quote expires
+        marketing_consent_options:
+          type: array
+          items:
+            $ref: "#/components/schemas/MarketingConsentOption"
+          description: Marketing consent options the seller offers. When present, the agent SHOULD display these to the buyer before checkout completion.
         discounts:
           $ref: "#/components/schemas/DiscountsResponse"
           description: "Discount extension: submitted codes and applied discounts. Present when the 'discount' extension is active."
@@ -3079,6 +3123,11 @@ components:
           $ref: "#/components/schemas/AffiliateAttribution"
         risk_signals:
           $ref: "#/components/schemas/RiskSignals"
+        marketing_consents:
+          type: array
+          items:
+            $ref: "#/components/schemas/MarketingConsent"
+          description: "Buyer's marketing consent decisions. Agents SHOULD include this when the session includes marketing_consent_options. Omission is treated as no consent given."
       required:
         - payment_data
       example:

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -2752,6 +2752,7 @@ components:
         handlers: []
       description: Payment configuration returned by the seller including accepted methods and handlers
     MarketingConsentOption:
+      description: Seller-declared marketing consent option that specifies an available channel for which the seller must obtain the buyer's consent before sending marketing content
       type: object
       additionalProperties: false
       properties:
@@ -2778,7 +2779,13 @@ components:
         - channel
         - description
         - privacy_policy_url
+      example:
+        channel: email
+        description: "Promotional emails, product launches, and exclusive offers"
+        privacy_policy_url: "https://www.example.com/privacy"
+        is_subscribed: false
     MarketingConsent:
+      description: Buyer's marketing consent decision for a specific channel submitted at checkout completion
       type: object
       additionalProperties: false
       properties:
@@ -2795,6 +2802,9 @@ components:
       required:
         - channel
         - opted_in
+      example:
+        channel: email
+        opted_in: true
     CheckoutSessionBase:
       type: object
       additionalProperties: false

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -2763,9 +2763,9 @@ components:
             - email
             - sms
             - whatsapp
-        description:
+        display_text:
           type: string
-          description: "What the buyer is consenting to receive, e.g., 'promotional emails, product launches, and exclusive offers'. Agents MAY use this to compose their own display text."
+          description: "What the buyer is consenting to receive, e.g., 'promotional emails, product launches, and exclusive offers'. Agents MAY use this to compose their own consent prompt."
         privacy_policy_url:
           type: string
           format: uri
@@ -2777,11 +2777,11 @@ components:
             Defaults to false if omitted.
       required:
         - channel
-        - description
+        - display_text
         - privacy_policy_url
       example:
         channel: email
-        description: "Promotional emails, product launches, and exclusive offers"
+        display_text: "Promotional emails, product launches, and exclusive offers"
         privacy_policy_url: "https://www.example.com/privacy"
         is_subscribed: false
     MarketingConsent:
@@ -2929,7 +2929,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/MarketingConsentOption"
-          description: "Marketing consent options the seller offers. When present, the agent SHOULD display these to the buyer before checkout completion. Agents MAY selectively surface a subset of options; options not surfaced MUST be omitted from marketing_consents. When absent, the agent MUST NOT surface any marketing consent UI."
+          description: "Marketing consent options the seller offers. When present, the agent SHOULD display these to the buyer before checkout completion. Agents MAY selectively surface a subset of options; options not surfaced MUST be omitted from marketing_consents. When absent, the agent MUST NOT surface any marketing consent UI. An empty array is equivalent to absent."
         discounts:
           $ref: "#/components/schemas/DiscountsResponse"
           description: "Discount extension: submitted codes and applied discounts. Present when the 'discount' extension is active."
@@ -3142,7 +3142,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/MarketingConsent"
-          description: "Buyer's marketing consent decisions. Agents SHOULD include an entry for each consent option surfaced to the buyer. Options not surfaced MUST be omitted -- omission preserves existing subscription state."
+          description: "Buyer's marketing consent decisions. Agents SHOULD include an entry for each consent option surfaced to the buyer. Options not surfaced MUST be omitted -- omission preserves existing subscription state. Sellers SHOULD ignore entries in marketing_consents that do not correspond to a channel in marketing_consent_options."
       required:
         - payment_data
       example:

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -2769,6 +2769,11 @@ components:
           type: string
           format: uri
           description: URL to the seller's privacy policy governing use of the buyer's contact information for marketing.
+        is_subscribed:
+          type: boolean
+          description: Whether the buyer is currently subscribed to marketing via this
+            channel. When true, agents SHOULD render the consent checkbox as pre-checked.
+            Defaults to false if omitted.
       required:
         - type
         - description
@@ -2914,7 +2919,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/MarketingConsentOption"
-          description: Marketing consent options the seller offers. When present, the agent SHOULD display these to the buyer before checkout completion.
+          description: "Marketing consent options the seller offers. When present, the agent SHOULD display these to the buyer before checkout completion. Agents MAY selectively surface a subset of options; options not surfaced MUST be omitted from marketing_consents. When absent, the agent MUST NOT surface any marketing consent UI."
         discounts:
           $ref: "#/components/schemas/DiscountsResponse"
           description: "Discount extension: submitted codes and applied discounts. Present when the 'discount' extension is active."
@@ -3127,7 +3132,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/MarketingConsent"
-          description: "Buyer's marketing consent decisions. Agents SHOULD include this when the session includes marketing_consent_options. Omission is treated as no consent given."
+          description: "Buyer's marketing consent decisions. Agents SHOULD include an entry for each consent option surfaced to the buyer. Options not surfaced MUST be omitted -- omission preserves existing subscription state."
       required:
         - payment_data
       example:


### PR DESCRIPTION
# SEP: Support Marketing Consent

## 📋 SEP Metadata

- **SEP Number**: [[#195](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/issues/195)]
- **Author(s)**: Lee Hwa / Meta
- **Status**: `proposal` 
- **Type**: [x] Major Change [ ] Process Change
- **Related Issues/RFCs**: rfcs/rfc.agentic_checkout.md, spec/2026-01-30/json-schema/schema.agentic_checkout.json

---

## 🎯 Abstract

This SEP proposes adding marketing consent to the ACP checkout flow. The design has three parts: (1) sellers declare marketing opt-in availability in the `CheckoutSession` response via a `marketing_consent_options` field, including the buyer's existing subscription status, (2) agents render the consent UI with the appropriate default state (pre-checked for existing subscribers, unchecked for new buyers), and (3) agents pass the buyer's consent decision in `CheckoutSessionCompleteRequest` via a `marketing_consents` field.

Consent is captured at **complete checkout time** — not during checkout updates — because the buyer should not be subscribed to marketing before confirming their purchase. This aligns with GDPR, CAN-SPAM, and CCPA requirements for explicit, informed consent tied to a completed transaction.

---

## 💡 Motivation

### The Problem

Marketing opt-in is a standard feature on virtually every e-commerce checkout page. When buyers purchase through ACP-integrated agents instead of merchant storefronts, this opt-in opportunity is lost because the protocol has no mechanism to:

1. **Signal opt-in availability**: Sellers cannot tell agents they want to offer marketing consent
2. **Communicate existing subscription status**: Sellers cannot tell agents that a returning buyer is already subscribed, so agents cannot pre-check the consent box or intelligently skip the prompt
3. **Capture consent**: Agents cannot pass the buyer's opt-in decision to the seller
4. **Display the prompt**: Agents have no display text or context to render a consent checkbox

### Why the Community Should Care

- **Merchants lose a key acquisition channel**: Marketing drives repeat purchases — without opt-in support, agentic checkout is less valuable than web checkout
- **Buyers lose choice**: Buyers who want merchant updates have no way to opt in during agentic checkout
- **Regulatory compliance**: GDPR, CAN-SPAM, and CCPA require explicit consent before marketing communications — the protocol should support capturing this at the right moment
- **Merchant adoption**: If ACP cannot capture marketing consent, merchants have less incentive to support the protocol — it's a competitive disadvantage vs. their own checkout

### Scenarios

This proposal addresses three scenarios:

| #   | Scenario                                  | Seller Behavior                                                         | Agent Behavior                                                                             |
| --- | ----------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| 1   | **New buyer** (no prior consent)          | Sends `MarketingConsentOption` with `is_subscribed: false` (or omitted) | Renders unchecked checkbox. Buyer can opt in.                                              |
| 2   | **Returning buyer** (already subscribed)  | Sends `MarketingConsentOption` with `is_subscribed: true`               | Renders pre-checked checkbox. Buyer can uncheck to revoke.                                 |
| 3   | **Returning buyer** (seller omits option) | Omits `MarketingConsentOption` entirely                                 | Shows nothing. Existing subscription is preserved server-side — no revocation signal sent. |

---

## 📐 Specification

### Data Flow

Marketing consent flows through three phases of the checkout lifecycle:

```mermaid
sequenceDiagram
    participant B as Buyer
    participant A as Agent
    participant S as Seller

    rect rgb(240, 248, 255)
    Note over B,S: Phase 0: Initiate
    B->>A: Add items to cart, proceed to checkout
    A->>S: POST /checkout_sessions
    end

    rect rgb(240, 255, 240)
    Note over B,S: Phase 1: Declare
    S-->>A: 201 CheckoutSession<br/>marketing_consent_options[]<br/>(with is_subscribed status)
    end

    rect rgb(255, 248, 240)
    Note over B,S: Phase 2: Render
    A->>B: Display consent UI<br/>(checkbox state from is_subscribed)
    B->>A: Buyer interacts<br/>(check/uncheck)
    end

    rect rgb(248, 240, 255)
    Note over B,S: Phase 3: Capture
    A->>S: POST /checkout_sessions/{id}/complete<br/>marketing_consents[]
    S-->>A: 200 Order confirmed
    end
```

### 1. Add `MarketingConsentOption` Schema

```json
{
  "MarketingConsentOption": {
    "type": "object",
    "additionalProperties": false,
    "properties": {
      "channel": {
        "type": "string",
        "description": "Channel for marketing consent.",
        "examples": ["email", "sms", "whatsapp"]
      },
      "display_text": {
        "type": "string",
        "description": "What the buyer is consenting to receive, e.g., 'promotional emails, product launches, and exclusive offers'. Agents MAY use this to compose their own consent prompt."
      },
      "privacy_policy_url": {
        "type": "string",
        "format": "uri",
        "description": "URL to the seller's privacy policy governing use of the buyer's contact information for marketing."
      },
      "is_subscribed": {
        "type": "boolean",
        "description": "Whether the buyer is currently subscribed to marketing via this channel. When true, agents SHOULD render the consent checkbox as pre-checked. Defaults to false if omitted."
      }
    },
    "required": ["channel", "display_text", "privacy_policy_url"]
  }
}
```

### 2. Add `marketing_consent_options` to CheckoutSession Response

```json
{
  "CheckoutSession": {
    "properties": {
      "marketing_consent_options": {
        "type": "array",
        "items": {
          "$ref": "#/$defs/MarketingConsentOption"
        },
        "description": "Marketing consent options the seller offers. When present, the agent SHOULD display these to the buyer before checkout completion. Agents MAY selectively surface a subset of options; options not surfaced MUST be omitted from marketing_consents in the complete request. When absent, the agent MUST NOT surface any marketing consent UI. An empty array is equivalent to absent."
      }
    }
  }
}
```

### 3. Add `MarketingConsent` Schema

```json
{
  "MarketingConsent": {
    "type": "object",
    "additionalProperties": false,
    "properties": {
      "channel": {
        "type": "string",
        "description": "Channel matching the consent option channel.",
        "examples": ["email", "sms", "whatsapp"]
      },
      "opted_in": {
        "type": "boolean",
        "description": "Whether the buyer consented to receive marketing via this channel."
      }
    },
    "required": ["channel", "opted_in"]
  }
}
```

### 4. Add `marketing_consents` to CheckoutSessionCompleteRequest

```json
{
  "CheckoutSessionCompleteRequest": {
    "properties": {
      "marketing_consents": {
        "type": "array",
        "items": {
          "$ref": "#/$defs/MarketingConsent"
        },
        "description": "Buyer's marketing consent decisions. Agents SHOULD include an entry for each consent option surfaced to the buyer. Options not surfaced MUST be omitted — omission preserves existing subscription state. Sellers SHOULD ignore entries in marketing_consents that do not correspond to a channel in marketing_consent_options."
      }
    }
  }
}
```

### 5. Agent Behavior

> When a `CheckoutSession` response includes `marketing_consent_options`, the agent SHOULD:
> 1. Compose display text using the seller name and the option's `display_text` (e.g., "Receive promotional emails, product launches, and exclusive offers from ExampleStore")
> 2. Render as a checkbox with default state based on `is_subscribed`:
>    - `is_subscribed: false` or omitted → checkbox **unchecked** (new buyer)
>    - `is_subscribed: true` → checkbox **pre-checked** (returning buyer already subscribed)
> 3. Link to the seller's `privacy_policy_url` for the buyer to review
> 4. Include the buyer's decision in `marketing_consents` on the complete request
> 5. If the buyer does not interact with the consent UI, the agent SHOULD send `opted_in` matching the `is_subscribed` value (preserving the current state)
>
> **Selective surfacing**: When the seller provides multiple `marketing_consent_options`, the agent MAY choose to surface one or more of them based on its own UX considerations (e.g., platform capabilities, buyer context). Consent options that the agent does not surface MUST be omitted from the `marketing_consents` response — the agent MUST NOT send an `opted_in` value for options it did not display. Omission preserves the buyer's existing subscription state for that channel.
>
> When a `CheckoutSession` response does **not** include `marketing_consent_options` (or includes an empty array), the agent MUST NOT surface any marketing consent UI. The absence of `marketing_consent_options` means the seller either does not offer marketing consent or the buyer is already subscribed and the seller does not wish to surface the option. In either case, existing subscription state is preserved server-side — no consent signal is sent.

### 6. Contact Resolution

> Marketing consent applies to the buyer's contact information (see [`Buyer` schema](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/blob/main/spec/2026-01-30/json-schema/schema.agentic_checkout.json)), resolved with the following precedence:
>
> **For `email` consent:**
> 1. If a `buyer` object is present, the seller uses `buyer.email` (required when `buyer` exists)
> 2. If the `buyer` object is not present, the seller falls back to `fulfillment_details.email`
>
> **For `sms` or `whatsapp` consent:**
> 1. If a `buyer` object is present and `buyer.phone_number` is provided, the seller uses `buyer.phone_number`
> 2. Otherwise, the seller falls back to `fulfillment_details.phone_number`
>
> If `marketing_consents` includes a channel but no corresponding contact can be resolved (e.g., email consent without either `buyer.email` or `fulfillment_details.email`), the seller MUST ignore the consent for that channel.
>
> **Rationale**: The buyer is the person opting in to marketing, so their contact info is the natural target. The `fulfillment_details` fallback ensures coverage when the `buyer` object is not provided or when `buyer.phone_number` is omitted (since it is optional in the [`Buyer` schema](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/blob/main/spec/2026-01-30/json-schema/schema.agentic_checkout.json)). This keeps marketing on the same channels the seller already uses for transactional communications (order confirmations, shipping updates).

### 7. Seller Behavior

> Sellers MUST NOT treat omission of `marketing_consents` as new consent. When `marketing_consents` is absent from the complete request, sellers MUST preserve the buyer's existing subscription state — no change is implied.
>
> Sellers MUST respect the buyer's `opted_in` value and MUST NOT send marketing communications to buyers who did not opt in.
>
> Sellers SHOULD ignore entries in `marketing_consents` that do not correspond to a channel in `marketing_consent_options`.
>
> **Returning buyers**: When the seller knows the buyer is already subscribed to a marketing channel, the seller has two options:
> 1. **Include the option with `is_subscribed: true`**: The agent will render the checkbox as pre-checked, giving the buyer the opportunity to unsubscribe by unchecking it. If the buyer unchecks and the agent sends `opted_in: false`, the seller MUST honor the revocation.
> 2. **Omit the `MarketingConsentOption` for that channel**: The agent will not surface any consent UI for that channel. The existing subscription is preserved. This is the recommended approach when the seller does not want to risk the buyer unintentionally unsubscribing or revoking consent — since agents may selectively surface options, including a channel exposes it to potential revocation.

### 8. Example Flows

#### 8a. New Buyer — multi-channel (not yet subscribed)

**CheckoutSession Response** (seller offers email and SMS marketing opt-in, buyer not yet subscribed):

```json
{
  "id": "checkout_session_123",
  "protocol": {
    "version": "2026-01-30"
  },
  "status": "ready_for_payment",
  "currency": "usd",
  "marketing_consent_options": [
    {
      "channel": "email",
      "display_text": "Promotional emails, product launches, and exclusive offers",
      "privacy_policy_url": "https://www.example.com/privacy",
      "is_subscribed": false
    },
    {
      "channel": "sms",
      "display_text": "Order updates and exclusive deals via text message",
      "privacy_policy_url": "https://www.example.com/privacy",
      "is_subscribed": false
    }
  ],
  "line_items": [
    {
      "id": "line_item_123",
      "item": {
        "id": "item_123"
      },
      "quantity": 1,
      "name": "Vintage Denim Jacket",
      "unit_amount": 300,
      "totals": [
        {
          "type": "items_base_amount",
          "display_text": "Base Amount",
          "amount": 300
        },
        {
          "type": "total",
          "display_text": "Total",
          "amount": 330
        }
      ]
    }
  ],
  "totals": [
    {
      "type": "subtotal",
      "display_text": "Subtotal",
      "amount": 300
    },
    {
      "type": "tax",
      "display_text": "Tax",
      "amount": 30
    },
    {
      "type": "total",
      "display_text": "Total",
      "amount": 330
    }
  ],
  "messages": [],
  "links": {},
  "capabilities": {}
}
```

**Complete Request** (buyer opts in to email, declines SMS):

`POST /checkout_sessions/checkout_session_123/complete`

```json
{
  "payment_data": {
    "type": "card",
    "token": "tok_abc123"
  },
  "marketing_consents": [
    {
      "channel": "email",
      "opted_in": true
    },
    {
      "channel": "sms",
      "opted_in": false
    }
  ]
}
```

**Complete Request** (buyer declines all or does not interact):

```json
{
  "payment_data": {
    "type": "card",
    "token": "tok_abc123"
  },
  "marketing_consents": [
    {
      "channel": "email",
      "opted_in": false
    },
    {
      "channel": "sms",
      "opted_in": false
    }
  ]
}
```

#### 8b. Returning Buyer (already subscribed — seller surfaces option)

**CheckoutSession Response** (seller indicates buyer is already subscribed to email):

```json
{
  "marketing_consent_options": [
    {
      "channel": "email",
      "display_text": "Promotional emails, product launches, and exclusive offers",
      "privacy_policy_url": "https://www.example.com/privacy",
      "is_subscribed": true
    }
  ]
}
```

Agent renders the checkbox **pre-checked**. If the buyer leaves it checked:

```json
{
  "payment_data": { "type": "card", "token": "tok_abc123" },
  "marketing_consents": [{ "channel": "email", "opted_in": true }]
}
```

If the buyer unchecks to revoke consent:

```json
{
  "payment_data": { "type": "card", "token": "tok_abc123" },
  "marketing_consents": [{ "channel": "email", "opted_in": false }]
}
```

#### 8c. Returning Buyer (already subscribed — seller omits option)

**CheckoutSession Response** (seller omits `marketing_consent_options` entirely):

```json
{
  "id": "checkout_session_456",
  "status": "ready_for_payment",
  "currency": "usd",
  "line_items": [...]
}
```

Agent does not surface any marketing consent UI. Existing subscription is preserved server-side. The complete request has no `marketing_consents` field.

#### 8d. Agent selectively surfaces a subset of channels

**CheckoutSession Response** (seller offers email, SMS, and WhatsApp):

```json
{
  "marketing_consent_options": [
    {
      "channel": "email",
      "display_text": "Promotional emails, product launches, and exclusive offers",
      "privacy_policy_url": "https://www.example.com/privacy",
      "is_subscribed": false
    },
    {
      "channel": "sms",
      "display_text": "Order updates and exclusive deals via text message",
      "privacy_policy_url": "https://www.example.com/privacy",
      "is_subscribed": false
    },
    {
      "channel": "whatsapp",
      "display_text": "Order updates and promotions via WhatsApp",
      "privacy_policy_url": "https://www.example.com/privacy",
      "is_subscribed": false
    }
  ]
}
```

Agent only supports email and SMS UI — it surfaces those two and omits WhatsApp:

```json
{
  "payment_data": { "type": "card", "token": "tok_abc123" },
  "marketing_consents": [
    { "channel": "email", "opted_in": true },
    { "channel": "sms", "opted_in": false }
  ]
}
```

WhatsApp is omitted from `marketing_consents` — the seller preserves the buyer's existing subscription state for that channel.

---

## 🤔 Rationale

### Why at confirm time, not during checkout update?

- **Privacy**: The buyer's contact info should not be used for marketing before they commit to a purchase
- **Regulatory alignment**: GDPR requires consent to be "freely given, specific, informed and unambiguous" — tying it to checkout completion ensures it accompanies an informed transaction
- **UX**: Consent checkboxes naturally belong next to the "Place Order" button, not during address or shipping selection
- **Schema separation**: Marketing consent is a transactional decision that only makes sense at confirmation. A standalone `marketing_consents` field on `CheckoutSessionCompleteRequest` keeps consent separate from both `Buyer` (identity) and `FulfillmentDetails` (delivery logistics), which are sent on create/update requests. While `buyer.email` is used as the primary contact for marketing (with `fulfillment_details.email` as fallback), the consent *decision* belongs at confirm time.

### Why a three-phase design (seller declares with status, agent renders, agent passes)?

- **Seller control**: Not all merchants want marketing opt-in — the seller decides whether to offer it
- **Agent flexibility**: The agent controls the UI, composes its own display text, and presents the consent in the most appropriate way for its platform
- **Existing status matters**: The `is_subscribed` field lets the seller communicate the buyer's current state, so the agent can render the right default (pre-checked vs unchecked) and the buyer can make an informed choice
- **Seller provides context**: The `display_text` tells the agent what the buyer is consenting to, and `privacy_policy_url` provides the legal backing — but the agent owns the UX

### Why use `channel` as an open enum?

The `channel` field uses an open enum pattern: `email` and `sms` are well-known values, but sellers MAY use any string (e.g., `whatsapp`, `push`, `messenger`). This avoids a breaking schema change when new channels are added. Agents SHOULD surface channels they recognize and omit unrecognized channels from the response.

### Why support multiple channels?

While email is the immediate need, commerce platforms commonly offer SMS and WhatsApp opt-in as well — particularly in markets where WhatsApp is a primary communication channel for merchant-to-buyer messaging. Including these from the start avoids a future schema change. Agents can ignore channels they don't support.

### Alternatives Considered

1. **Pass consent during checkout update**: Premature — buyer hasn't committed. Creates privacy risk.
2. **Use `metadata` field**: Unstructured, non-standard, requires per-seller agent logic.
3. **Post-purchase opt-in**: Seller sends email after purchase asking to subscribe. Loses the high-conversion checkout moment and adds friction.
4. **Add consent to [`Buyer` schema](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/blob/main/spec/2026-01-30/json-schema/schema.agentic_checkout.json)**: Include `marketing_consents` on the `Buyer` object, which is passed on both update and complete requests. However, `Buyer` describes who is buying, not what they've agreed to. Adding consent to `Buyer` would conflate identity with transactional decisions. Additionally, `Buyer` is sent on update requests, which would allow consent to be communicated before purchase confirmation — premature from both a privacy and regulatory standpoint. Note: while `buyer.email` is used as the primary contact for marketing (with `fulfillment_details.email` as fallback), the consent *decision* itself belongs at confirm time as a standalone field on `CheckoutSessionCompleteRequest`.
5. **Extension mechanism**: Could be modeled as an ACP extension. However, marketing consent is fundamental enough (virtually every e-commerce checkout has it) that it belongs in the core spec.

---

## 🔄 Backward Compatibility

- **Additive change**: `marketing_consent_options` is a new optional field on `CheckoutSession` — existing implementations unaffected
- **Additive change**: `marketing_consents` is a new optional field on `CheckoutSessionCompleteRequest` — existing complete calls continue to work
- **No breaking changes**: Sellers that don't offer marketing consent simply omit `marketing_consent_options`. Agents that don't support it omit `marketing_consents`.
- **Graceful degradation**: If the agent doesn't send `marketing_consents`, the seller treats it as no consent (current behavior)
- **Severity**: None. Fully additive and backward compatible.

---

## 🛠️ Reference Implementation

Not yet available. The RFC (`rfcs/rfc.marketing_consent.md`) and schema definitions in this PR serve as the specification from which implementations can be built.

---

## 🔒 Security Implications

- **Privacy**: This proposal improves privacy by creating a standardized, explicit consent mechanism rather than relying on implicit or non-standard approaches
- **Data minimization**: Consent is scoped to specific channels — sellers receive only the consent decisions the buyer explicitly makes
- **No new data exposure**: The buyer's email and phone are already included in `buyer` or `fulfillment_details` — this proposal adds only a consent flag, not additional PII
- **Regulatory support**: Provides a clear audit trail for GDPR, CAN-SPAM, and CCPA compliance — the `opted_in` boolean is an explicit record of consent
- **Revocation path**: Returning buyers with `is_subscribed: true` can revoke consent by unchecking the box. Sellers who do not want to expose this risk should omit the channel.

---

## ✅ Pre-Submission Checklist

Before submitting this SEP PR, ensure:

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
- [x] I have linked the SEP issue number above
- [x] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [x] I have signed the [[Contributor License Agreement (CLA)](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/blob/main/legal/cla/INDIVIDUAL.md)](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/blob/main/legal/cla/INDIVIDUAL.md)
- [x] This PR includes updates to OpenAPI/JSON schemas (if applicable)
- [x] This PR includes example requests/responses (if applicable)
- [x] This PR includes a changelog entry file in `changelog/unreleased/marketing-consent.md`
- [x] This PR includes an RFC document in `rfcs/rfc.marketing_consent.md`
- [x] I am seeking or have found a sponsor (Founding Maintainer)

---

## 📚 Additional Context

### Real-World Evidence

Merchants commonly display a marketing opt-in checkbox on their web checkout pages. When the same purchase flows through ACP, this opt-in opportunity is lost because the protocol has no field for it. Additionally, returning buyers who are already subscribed have no way to have their existing subscription status reflected in the checkout UI. Some implementations work around this with non-standard fields in `metadata`, but this is fragile and not interoperable.

### Precedent

- **Shopify Checkout API**: Includes `buyer_accepts_marketing` boolean on checkout
- **Stripe Checkout**: Supports `consent_collection.promotions` for marketing consent
- **BigCommerce**: Offers newsletter subscription opt-in at checkout
- **WooCommerce**: Plugins for marketing consent checkbox at checkout

All major e-commerce platforms treat marketing consent as a core checkout feature, not an afterthought.

---

## 🙋 Questions for Reviewers

1. Should `marketing_consent_options` be part of the core spec or modeled as a standard extension? Given its ubiquity in e-commerce, we propose core spec.
2. Should there be a `consent_timestamp` field for audit purposes, or is the complete request timestamp sufficient?