### PR TITLE
SEP: Allow Fulfillment Details on Checkout Complete

### DIFF
--- a/changelog/unreleased/fulfillment-details-on-complete.md
+++ b/changelog/unreleased/fulfillment-details-on-complete.md
@@ -1,0 +1,15 @@
+# Unreleased Changes
+
+## Fulfillment Details on Checkout Complete (SEP #196)
+
+Add fulfillment_details to CheckoutSessionCompleteRequest, enabling agents to batch contact-only changes with payment submission.
+
+### Changes
+
+- **CheckoutSessionCompleteRequest**: Added optional `fulfillment_details` field
+
+### Benefits
+
+- **Eliminates unnecessary round trip**: Contact-only changes (name, email, phone) no longer require a separate update call before complete
+- **Reduced checkout latency**: One API call instead of two at the most critical moment in the checkout flow
+- **Address safeguard**: Address changes trigger 409 Conflict, forcing the agent back to the update-then-complete flow

--- a/examples/unreleased/examples.agentic_checkout.json
+++ b/examples/unreleased/examples.agentic_checkout.json
@@ -418,6 +418,11 @@
       "email": "johnsmith@mail.com",
       "phone_number": "15552003434"
     },
+    "fulfillment_details": {
+      "name": "John Smith",
+      "phone_number": "15559876543",
+      "email": "john.smith.new@mail.com"
+    },
     "payment_data": {
       "handler_id": "card_tokenized",
       "instrument": {

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -3568,6 +3568,10 @@
           "$ref": "#/$defs/Buyer",
           "description": "Final buyer information"
         },
+        "fulfillment_details": {
+          "$ref": "#/$defs/FulfillmentDetails",
+          "description": "Final fulfillment contact and address details. When present, the seller MUST apply these updates before processing payment."
+        },
         "payment_data": {
           "$ref": "#/$defs/PaymentData",
           "description": "Payment method and details"

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -3038,6 +3038,9 @@ components:
       properties:
         buyer:
           $ref: "#/components/schemas/Buyer"
+        fulfillment_details:
+          $ref: "#/components/schemas/FulfillmentDetails"
+          description: "Final fulfillment contact and address details. When present, the seller MUST apply these updates before processing payment."
         payment_data:
           $ref: "#/components/schemas/PaymentData"
         authentication_result:


### PR DESCRIPTION
# SEP: Allow Fulfillment Details on Checkout Complete

## SEP Metadata

- **SEP Number**: [#196](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/issues/196)
- **Author(s)**: Lee Hwa / Meta
- **Status**: `proposal` (awaiting sponsor)
- **Type**: [x] Major Change [ ] Process Change
- **Related Issues/RFCs**: rfcs/rfc.agentic_checkout.md, spec/2026-01-30/json-schema/schema.agentic_checkout.json

---

## Abstract

This SEP proposes adding an optional `fulfillment_details` field to `CheckoutSessionCompleteRequest`. Currently, agents must make a separate update call to sync fulfillment contact changes (name, email, phone) before calling complete — even when these changes don't affect pricing or delivery options. This extra round trip adds latency at the most critical moment in the checkout flow. By allowing `fulfillment_details` on the complete call, agents can batch contact-only changes with payment submission in a single API call.

---

## Motivation

### The Problem

On the checkout page, buyers can modify:
- **Delivery address** → affects shipping options, cost, and tax → requires an update call to get new options/pricing
- **Shipping option** → affects fulfillment cost and total → requires an update call to get new pricing
- **Recipient name, email, phone** → affects nothing in the pricing or options → no update response needed

Agents handle the first two changes with immediate update calls because the response contains meaningful changes. But for name/email/phone, there's nothing useful in the update response — the agent just needs to ensure the seller has the correct contact info before the order is placed.

In practice, agents defer these contact-only changes until the buyer clicks "Place Order." But at that point, the agent must:

1. `POST /checkout_sessions/{id}` — update with changed contact info
2. Wait for the response (no meaningful pricing changes)
3. `POST /checkout_sessions/{id}/complete` — submit payment

This adds **100-500ms of latency** at checkout completion — the moment with the highest buyer intent and the most sensitivity to delays.

### Why the Community Should Care

- **Agent developers** must all implement update-before-complete sequencing for contact-only changes — duplicated logic across every implementation
- **Buyers** experience slower order confirmation for no functional reason
- **Sellers** already handle `fulfillment_details` on update — accepting it on complete is a minor addition
- **Protocol efficiency**: The complete call already accepts optional `buyer` info — `fulfillment_details` follows the same pattern

---

## Specification

### 1. Add `fulfillment_details` to CheckoutSessionCompleteRequest

```json
{
  "CheckoutSessionCompleteRequest": {
    "type": "object",
    "additionalProperties": false,
    "properties": {
      "buyer": {
        "$ref": "#/$defs/Buyer",
        "description": "Final buyer information"
      },
      "payment_data": {
        "$ref": "#/$defs/PaymentData",
        "description": "Payment method and details"
      },
      "authentication_result": {
        "$ref": "#/$defs/AuthenticationResult",
        "description": "Authentication result for 3DS flows"
      },
      "affiliate_attribution": {
        "$ref": "#/$defs/AffiliateAttribution",
        "description": "Affiliate attribution data for last-touch tracking"
      },
      "risk_signals": {
        "$ref": "#/$defs/RiskSignals",
        "description": "Risk and fraud signals"
      },
      "fulfillment_details": {
        "$ref": "#/$defs/FulfillmentDetails",
        "description": "Final fulfillment contact and address details. When present, the seller MUST apply these updates before processing payment."
      }
    },
    "required": ["payment_data"]
  }
}
```

### 2. Seller Behavior

> When `fulfillment_details` is present on the complete request, the seller MUST:
> 1. Apply the fulfillment detail updates to the checkout session as if an update call had been made immediately prior
> 2. If the address has changed, the seller MUST reject the complete request with a `409 Conflict` response — an address change can impact fulfillment cost, tax calculation, and total price. Any merchant-side recalculation requires user confirmation before the change is taken into the transaction. The agent MUST make an update call with the new address first, refresh the delivery option selection and pricing breakdowns, present the updated information to the buyer, and resubmit the complete call only after the buyer confirms the changes.
> 3. Process payment only after fulfillment details are applied and the address is confirmed unchanged

### 3. Agent Behavior

> Agents SHOULD use `fulfillment_details` on the complete request for contact-only changes (name, email, phone) that don't affect pricing. For address changes that affect delivery options or pricing, agents SHOULD continue using the update endpoint to get updated options before completing.

### 4. Error Handling

> If `fulfillment_details` on the complete request includes an address change:
> - Seller MUST return `409 Conflict` — any address change can impact fulfillment cost, tax, and total price. Recalculation requires buyer review and confirmation before the transaction proceeds.
> - If the address is unserviceable: Seller MUST return `422 Unprocessable Entity` with a message indicating the address cannot be fulfilled.
>
> In all error cases, the agent MUST make an update call with the new address first, refresh the delivery option selection and pricing breakdowns, present the updated information to the buyer, and resubmit the complete call only after the buyer confirms the changes.

### 5. Example Flow

**Contact-only change (single call):**

Since all fields in `FulfillmentDetails` are optional (including `address`), agents can send only the changed contact fields.

`POST /checkout_sessions/checkout_session_123/complete`

```json
{
  "payment_data": {
    "type": "card",
    "token": "tok_abc123"
  },
  "fulfillment_details": {
    "name": "Jane Doe",
    "phone_number": "15559876543",
    "email": "jane.doe@example.com"
  }
}
```

**Success response:**

```json
{
  "id": "checkout_session_123",
  "protocol": {
    "version": "2026-01-30"
  },
  "status": "complete",
  "currency": "usd",
  "totals": [
    {
      "type": "items_base_amount",
      "display_text": "Item(s) total",
      "amount": 300
    },
    {
      "type": "subtotal",
      "display_text": "Subtotal",
      "amount": 300
    },
    {
      "type": "tax",
      "display_text": "Tax",
      "amount": 30
    },
    {
      "type": "fulfillment",
      "display_text": "Fulfillment",
      "amount": 100
    },
    {
      "type": "total",
      "display_text": "Total",
      "amount": 430
    }
  ]
}
```

**Price change error (409 Conflict):**

```json
{
  "error": {
    "type": "price_changed",
    "message": "The delivery address change resulted in a different shipping cost. Please review the updated pricing.",
    "code": "fulfillment_price_changed"
  }
}
```

---

## Rationale

### Why add `fulfillment_details` to complete instead of a new endpoint?

The complete endpoint already accepts optional fields beyond `payment_data` — `buyer`, `affiliate_attribution`, `risk_signals`. Adding `fulfillment_details` follows this established pattern of including final-state data on the complete call. A new endpoint would add protocol surface area unnecessarily.

### Why allow the full `FulfillmentDetails` object (including address) instead of just contact fields?

While the primary use case is contact-only changes, restricting to a `FulfillmentContact` subset would:
- Require a new schema type just for this endpoint
- Force agents to decide at call time whether a change is "contact-only" or "address-related"
- Miss edge cases where the agent has already handled the address change via update but needs to include the full details for completeness

The error handling in Section 4 protects against unintended address-related price changes — the seller rejects with `409 Conflict` if pricing would change, forcing the agent back to the update-then-complete flow.

### Why not include `selected_fulfillment_options` on complete too?

Fulfillment option changes always affect pricing (shipping cost, potentially tax). Similarly, address changes can trigger different tax jurisdictions and shipping rates. Both require the buyer to review updated totals before confirming.

The difference is that `fulfillment_details` contains a mix of price-affecting fields (address) and non-price-affecting fields (name, email, phone). The primary use case for including `fulfillment_details` on complete is contact-only changes. When an address change does come through, the `409 Conflict` safeguard ensures the buyer reviews the updated pricing before payment proceeds.

`selected_fulfillment_options`, on the other hand, is always price-affecting — there's no non-price use case. It should always go through the update endpoint where the buyer can review new totals before confirming.

### Why not just always call update before complete?

This is the current workaround. It works but adds unnecessary latency at the highest-intent moment. The buyer has clicked "Place Order" — every millisecond of delay increases abandonment risk. An update call that returns no meaningful pricing changes is wasted time.

---

## Backward Compatibility

- **Additive change**: `fulfillment_details` is a new optional field on `CheckoutSessionCompleteRequest` — existing complete calls without it continue to work unchanged
- **No breaking changes**: Sellers that don't support `fulfillment_details` on complete can ignore the field (existing behavior) or return an error. However, sellers SHOULD support it for protocol compliance.
- **Graceful degradation**: If a seller doesn't handle `fulfillment_details` on complete, agents fall back to the update-then-complete flow
- **Severity**: None. Fully additive and backward compatible.

---

## Reference Implementation

Not yet available. Will provide before status "Final".

Meta's ACP integration currently implements the update-before-complete workaround for contact-only changes and can validate the proposed single-call behavior.

---

## Security Implications

- **No authentication/authorization impact**: Uses the same auth as existing complete and update endpoints
- **No new data exposure**: `fulfillment_details` is already accepted on the update endpoint — this proposal allows the same data on the complete endpoint
- **Price integrity**: The `409 Conflict` mechanism ensures the buyer always sees accurate pricing before payment is processed — no silent price changes
- **No compliance implications**: Fulfillment details handling is unchanged from the update flow

---

## Pre-Submission Checklist

Before submitting this SEP PR, ensure:

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
- [x] I have linked the SEP issue number above
- [ ] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] This PR includes updates to OpenAPI/JSON schemas (if applicable)
- [x] This PR includes example requests/responses (if applicable)
- [x] This PR includes a changelog entry file in `changelog/unreleased/fulfillment-details-on-complete.md`
- [ ] I am seeking or have found a sponsor (Founding Maintainer)

---

## Additional Context

### Real-World Evidence

In production ACP integrations, buyers edit their phone number or email on the checkout page without changing their address or shipping option. Agents normally defer these changes and then make a redundant update call before complete — adding latency to every checkout where the buyer modifies contact info. This is a common flow: buyers correct typos in their email, update their phone number for delivery notifications, or change the recipient name for a gift.

### Precedent

- The `CheckoutSessionCompleteRequest` already accepts optional `buyer` info — `fulfillment_details` follows the exact same pattern
- Stripe's Checkout API allows updating customer details at payment confirmation time
- Shopify's Checkout API accepts shipping address on the complete step

---

## Questions for Reviewers

1. Should the seller be required to support `fulfillment_details` on complete (MUST) or is it optional (SHOULD)? If optional, agents need to detect support and fall back to update-then-complete.
2. Should the `409 Conflict` response include the updated pricing so the agent can display it without making another update call?

---

**Note**: SEPs require unanimous approval from Founding Maintainers. See [governance.md](../docs/governance.md) and [sep-guidelines.md](../docs/sep-guidelines.md) for the full process.
