### PR TITLE
SEP: Suggested Pricing on Checkout Create

### DIFF
--- a/changelog/unreleased/suggested-pricing.md
+++ b/changelog/unreleased/suggested-pricing.md
@@ -1,0 +1,16 @@
+# Unreleased Changes
+
+## Suggested Pricing on Checkout Create (SEP #197)
+
+Add suggested_price to Item on CheckoutSessionCreateRequest, enabling agents to communicate price provenance to sellers for catalog price matching.
+
+### Changes
+
+- **SuggestedPrice**: New schema with amount, source, and observed_at fields
+- **Item**: Added optional `suggested_price` field
+
+### Benefits
+
+- **Price consistency**: Sellers can honor catalog prices displayed to buyers, reducing checkout price discrepancies
+- **Verifiable provenance**: Source and timestamp enable sellers to validate price claims against their own catalog feeds
+- **Seller-controlled policy**: Time window and source verification are seller-defined, not protocol-mandated

--- a/changelog/unreleased/suggested-pricing.md
+++ b/changelog/unreleased/suggested-pricing.md
@@ -6,11 +6,12 @@ Add suggested_price to Item on CheckoutSessionCreateRequest, enabling agents to 
 
 ### Changes
 
-- **SuggestedPrice**: New schema with amount, source, and observed_at fields
+- **PriceSource**: New schema with feed_id (required), channel, feed_update_id, and updated_at fields
+- **SuggestedPrice**: New schema with amount, structured source (PriceSource), and observed_at fields
 - **Item**: Added optional `suggested_price` field
 
 ### Benefits
 
 - **Price consistency**: Sellers can honor catalog prices displayed to buyers, reducing checkout price discrepancies
-- **Verifiable provenance**: Source and timestamp enable sellers to validate price claims against their own catalog feeds
+- **Structured provenance**: Feed ID, channel, update version, and timestamp enable sellers to validate price claims against specific feed updates
 - **Seller-controlled policy**: Time window and source verification are seller-defined, not protocol-mandated

--- a/examples/unreleased/examples.agentic_checkout.json
+++ b/examples/unreleased/examples.agentic_checkout.json
@@ -3,7 +3,12 @@
     "currency": "usd",
     "line_items": [
       {
-        "id": "item_123"
+        "id": "item_123",
+        "suggested_price": {
+          "amount": 7999,
+          "source": "feed_upload_session:7829461035",
+          "observed_at": "2026-03-23T08:30:00Z"
+        }
       }
     ],
     "capabilities": {

--- a/examples/unreleased/examples.agentic_checkout.json
+++ b/examples/unreleased/examples.agentic_checkout.json
@@ -6,8 +6,13 @@
         "id": "item_123",
         "suggested_price": {
           "amount": 7999,
-          "source": "feed_upload_session:7829461035",
-          "observed_at": "2026-03-23T08:30:00Z"
+          "source": {
+            "feed_id": "feed_8f3K2x",
+            "channel": "feed_api",
+            "feed_update_id": "upd_7kQ9mR",
+            "updated_at": "2026-05-20T14:30:01Z"
+          },
+          "observed_at": "2026-05-20T14:35:00Z"
         }
       }
     ],

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -783,6 +783,36 @@
         ]
       }
     },
+    "SuggestedPrice": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Agent-provided price expectation with provenance. Allows the agent to communicate the price it displayed to the buyer, along with the catalog source and observation timestamp. The seller uses this information to verify the price origin and decide whether to honor it.",
+      "properties": {
+        "amount": {
+          "type": "integer",
+          "description": "Suggested price per unit in minor currency units (e.g. 100 cents for $1.00 or 100 for \u00a5100). This is the price the agent displayed to the buyer."
+        },
+        "source": {
+          "type": "string",
+          "description": "URI or identifier of the catalog source where the agent obtained this price. Examples: a product feed URL, catalog API endpoint, catalog snapshot ID, or seller-provided price list identifier."
+        },
+        "observed_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 timestamp when the agent last observed this price from the source."
+        }
+      },
+      "required": [
+        "amount",
+        "source",
+        "observed_at"
+      ],
+      "example": {
+        "amount": 5999,
+        "source": "feed_upload_session:7829461035",
+        "observed_at": "2026-03-23T08:30:00Z"
+      }
+    },
     "Item": {
       "description": "A purchasable item with variant options (e.g., size, color) and quantity",
       "type": "object",
@@ -799,6 +829,10 @@
         "unit_amount": {
           "type": "integer",
           "description": "Price per unit in minor currency units (e.g. 100 cents for $1.00 or 100 for ¥100)"
+        },
+        "suggested_price": {
+          "$ref": "#/$defs/SuggestedPrice",
+          "description": "Agent-provided price expectation with catalog source provenance. When present, the seller SHOULD verify the source and honor this price if it falls within the seller's acceptable time window."
         }
       },
       "required": [

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -870,7 +870,7 @@
         },
         "suggested_price": {
           "$ref": "#/$defs/SuggestedPrice",
-          "description": "Agent-provided price expectation with catalog source provenance. When present, the seller SHOULD verify the source and honor this price if it falls within the seller's acceptable time window."
+          "description": "Agent-provided price expectation with catalog source provenance. When present, it is RECOMMENDED that the seller verify the source and honor this price if it falls within the seller's acceptable time window."
         }
       },
       "required": [

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -783,6 +783,39 @@
         ]
       }
     },
+    "PriceSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Structured provenance describing where the agent obtained a price. Connects to the Feed API identifiers for protocol-level verification.",
+      "properties": {
+        "feed_id": {
+          "type": "string",
+          "description": "Identifier of the product feed from which the price was obtained."
+        },
+        "channel": {
+          "type": "string",
+          "description": "Feed update channel through which the data was published. Known values include api, file, and partner_platform."
+        },
+        "feed_update_id": {
+          "type": "string",
+          "description": "Version identifier of the specific feed update that contained this price. Corresponds to the feed_update_id returned by PATCH /feeds/{id}/products."
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "RFC 3339 timestamp of the feed update from which the price was observed."
+        }
+      },
+      "required": [
+        "feed_id"
+      ],
+      "example": {
+        "feed_id": "feed_8f3K2x",
+        "channel": "feed_api",
+        "feed_update_id": "upd_7kQ9mR",
+        "updated_at": "2026-05-20T14:30:01Z"
+      }
+    },
     "SuggestedPrice": {
       "type": "object",
       "additionalProperties": false,
@@ -793,8 +826,8 @@
           "description": "Suggested price per unit in minor currency units (e.g. 100 cents for $1.00 or 100 for \u00a5100). This is the price the agent displayed to the buyer."
         },
         "source": {
-          "type": "string",
-          "description": "URI or identifier of the catalog source where the agent obtained this price. Examples: a product feed URL, catalog API endpoint, catalog snapshot ID, or seller-provided price list identifier."
+          "$ref": "#/$defs/PriceSource",
+          "description": "Structured provenance describing the catalog source where the agent obtained this price."
         },
         "observed_at": {
           "type": "string",
@@ -809,8 +842,13 @@
       ],
       "example": {
         "amount": 5999,
-        "source": "feed_upload_session:7829461035",
-        "observed_at": "2026-03-23T08:30:00Z"
+        "source": {
+          "feed_id": "feed_8f3K2x",
+          "channel": "feed_api",
+          "feed_update_id": "upd_7kQ9mR",
+          "updated_at": "2026-05-20T14:30:01Z"
+        },
+        "observed_at": "2026-05-20T14:35:00Z"
       }
     },
     "Item": {

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -988,6 +988,29 @@ components:
         providers:
           - stripe
           - adyen
+    SuggestedPrice:
+      type: object
+      additionalProperties: false
+      description: Agent-provided price expectation with provenance. Allows the agent to communicate the price it displayed to the buyer, along with the catalog source and observation timestamp. The seller uses this information to verify the price origin and decide whether to honor it.
+      properties:
+        amount:
+          type: integer
+          description: Suggested price per unit in minor currency units (e.g. 100 cents for $1.00 or 100 for yen 100). This is the price the agent displayed to the buyer.
+        source:
+          type: string
+          description: URI or identifier of the catalog source where the agent obtained this price. Examples: a product feed URL, catalog API endpoint, catalog snapshot ID, or seller-provided price list identifier.
+        observed_at:
+          type: string
+          format: date-time
+          description: RFC 3339 timestamp when the agent last observed this price from the source.
+      required:
+        - amount
+        - source
+        - observed_at
+      example:
+        amount: 5999
+        source: "feed_upload_session:7829461035"
+        observed_at: "2026-03-23T08:30:00Z"
     Item:
       type: object
       additionalProperties: false
@@ -1001,6 +1024,9 @@ components:
         unit_amount:
           type: integer
           description: Price per unit in minor currency units (e.g. 100 cents for $1.00 or 100 for ¥100)
+        suggested_price:
+          $ref: "#/components/schemas/SuggestedPrice"
+          description: Agent-provided price expectation with catalog source provenance. When present, the seller SHOULD verify the source and honor this price if it falls within the seller's acceptable time window.
       required:
         - id
       example:

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -988,6 +988,31 @@ components:
         providers:
           - stripe
           - adyen
+    PriceSource:
+      type: object
+      additionalProperties: false
+      description: Structured provenance describing where the agent obtained a price. Connects to the Feed API identifiers for protocol-level verification.
+      properties:
+        feed_id:
+          type: string
+          description: Identifier of the product feed from which the price was obtained.
+        channel:
+          type: string
+          description: Feed update channel through which the data was published. Known values include api, file, and partner_platform.
+        feed_update_id:
+          type: string
+          description: Version identifier of the specific feed update that contained this price. Corresponds to the feed_update_id returned by PATCH /feeds/{id}/products.
+        updated_at:
+          type: string
+          format: date-time
+          description: RFC 3339 timestamp of the feed update from which the price was observed.
+      required:
+        - feed_id
+      example:
+        feed_id: feed_8f3K2x
+        channel: feed_api
+        feed_update_id: upd_7kQ9mR
+        updated_at: "2026-05-20T14:30:01Z"
     SuggestedPrice:
       type: object
       additionalProperties: false
@@ -997,8 +1022,8 @@ components:
           type: integer
           description: Suggested price per unit in minor currency units (e.g. 100 cents for $1.00 or 100 for yen 100). This is the price the agent displayed to the buyer.
         source:
-          type: string
-          description: URI or identifier of the catalog source where the agent obtained this price. Examples: a product feed URL, catalog API endpoint, catalog snapshot ID, or seller-provided price list identifier.
+          $ref: "#/components/schemas/PriceSource"
+          description: Structured provenance describing the catalog source where the agent obtained this price.
         observed_at:
           type: string
           format: date-time
@@ -1009,8 +1034,12 @@ components:
         - observed_at
       example:
         amount: 5999
-        source: "feed_upload_session:7829461035"
-        observed_at: "2026-03-23T08:30:00Z"
+        source:
+          feed_id: feed_8f3K2x
+          channel: feed_api
+          feed_update_id: upd_7kQ9mR
+          updated_at: "2026-05-20T14:30:01Z"
+        observed_at: "2026-05-20T14:35:00Z"
     Item:
       type: object
       additionalProperties: false

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -1055,7 +1055,7 @@ components:
           description: Price per unit in minor currency units (e.g. 100 cents for $1.00 or 100 for ¥100)
         suggested_price:
           $ref: "#/components/schemas/SuggestedPrice"
-          description: Agent-provided price expectation with catalog source provenance. When present, the seller SHOULD verify the source and honor this price if it falls within the seller's acceptable time window.
+          description: Agent-provided price expectation with catalog source provenance. When present, it is RECOMMENDED that the seller verify the source and honor this price if it falls within the seller's acceptable time window.
       required:
         - id
       example:


### PR DESCRIPTION
# SEP: Suggested Pricing on Checkout Create

## 📋 SEP Metadata

- **SEP Number**: [[#197](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/issues/197)](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/issues/197)
- **Author(s)**: Lee Hwa 
- **Status**: `proposal` (awaiting sponsor)
- **Type**: [x] Major Change [ ] Process Change
- **Related Issues/RFCs**: rfcs/rfc.agentic_checkout.md, spec/2026-01-30/json-schema/schema.agentic_checkout.json

---

## 🎯 Abstract

This SEP proposes adding an optional `suggested_price` field to `Item` on `CheckoutSessionCreateRequest`. Agent platforms maintain product catalogs synced from sellers, but pricing data inevitably drifts — a buyer may discover a product at a sale price that has since expired. Currently, the agent has no way to communicate price provenance to the seller. By including `suggested_price` with a structured `PriceSource` (feed identity, update version, timestamp, and channel) and an observation timestamp, the agent provides the seller with the information needed to make an informed decision about whether to honor the price the buyer saw. This is a best-effort mechanism — if the seller does not honor the suggested price, the checkout session proceeds normally with the seller's current pricing breakdown. No error is raised.

---

## 💡 Motivation

### The Problem

Agent platforms display product pricing sourced from seller catalog feeds, product search API, or web crawling. This catalog data is refreshed periodically — every few minutes, hours, or daily depending on the seller and integration. Between refreshes, seller-side pricing can change due to:

- Flash sales ending or starting
- Dynamic pricing adjustments
- Inventory-based price changes
- Promotional period expirations

When a buyer discovers a product at one price on the agent platform and initiates checkout, the seller may return a different price. The buyer experiences an unexpected price change at the most sensitive moment — after they've decided to purchase.

### Why the Community Should Care

- **Buyers** lose trust when prices change between discovery and checkout. Price increases at checkout are a leading cause of cart abandonment.
- **Agent developers** have no protocol-level mechanism to communicate the price they displayed to the buyer. Every agent must implement ad-hoc workarounds (metadata fields, custom headers, out-of-band agreements with sellers).
- **Sellers** want to honor prices from their own catalog feeds — they published those prices intentionally. But without knowing which feed or when the agent observed the price, they can't distinguish a legitimate catalog price from an arbitrary number.
- **The protocol** should enable price consistency across the agent-seller boundary. Catalog-driven commerce is the primary discovery model for agentic checkout — the protocol should support it natively.

---

## 📐 Specification

### 1. Add `PriceSource` Schema

```json
{
  "PriceSource": {
    "type": "object",
    "additionalProperties": false,
    "description": "Structured provenance describing where the agent obtained a price. Connects to the Feed API's identifiers for protocol-level verification.",
    "properties": {
      "feed_id": {
        "type": "string",
        "description": "Identifier of the product feed from which the price was obtained."
      },
      "feed_update_id": {
        "type": "string",
        "description": "Version identifier of the specific feed update that contained this price. Corresponds to the feed_update_id returned by PATCH /feeds/{id}/products."
      },
      "updated_at": {
        "type": "string",
        "format": "date-time",
        "description": "RFC 3339 timestamp of the feed update from which the price was observed."
      },
      "channel": {
        "type": "string",
        "description": "Feed update channel through which the data was published. Known values include api, file, and partner_platform."
      }
    },
    "required": ["feed_id"],
    "example": {
      "feed_id": "feed_8f3K2x",
      "feed_update_id": "upd_7kQ9mR",
      "updated_at": "2026-05-20T14:30:01Z",
      "channel": "api"
    }
  }
}
```

### 2. Add `SuggestedPrice` Schema

```json
{
  "SuggestedPrice": {
    "type": "object",
    "additionalProperties": false,
    "description": "Agent-provided price expectation with provenance. Allows the agent to communicate the price it displayed to the buyer, along with the catalog source and observation timestamp. The seller uses this information to verify the price origin and decide whether to honor it.",
    "properties": {
      "amount": {
        "type": "integer",
        "description": "Suggested price per unit in minor currency units (e.g. 100 cents for $1.00 or 100 for ¥100). This is the price the agent displayed to the buyer."
      },
      "source": {
        "$ref": "#/$defs/PriceSource",
        "description": "Structured provenance describing the catalog source where the agent obtained this price."
      },
      "observed_at": {
        "type": "string",
        "format": "date-time",
        "description": "RFC 3339 timestamp when the agent last observed this price from the source."
      }
    },
    "required": ["amount", "source", "observed_at"],
    "example": {
      "amount": 5999,
      "source": {
        "feed_id": "feed_8f3K2x",
        "feed_update_id": "upd_7kQ9mR",
        "updated_at": "2026-05-20T14:30:01Z",
        "channel": "api"
      },
      "observed_at": "2026-05-20T14:35:00Z"
    }
  }
}
```

### 3. Add `suggested_price` to `Item`

```json
{
  "Item": {
    "type": "object",
    "additionalProperties": false,
    "properties": {
      "id": {
        "type": "string",
        "description": "Unique identifier for the item"
      },
      "name": {
        "type": "string",
        "description": "Display name of the item"
      },
      "unit_amount": {
        "type": "integer",
        "description": "Price per unit in minor currency units (e.g. 100 cents for $1.00 or 100 for ¥100)"
      },
      "suggested_price": {
        "$ref": "#/$defs/SuggestedPrice",
        "description": "Agent-provided price expectation with catalog source provenance. When present, it is RECOMMENDED that the seller verify the source and honor this price if it falls within the seller's acceptable time window."
      }
    },
    "required": ["id"]
  }
}
```

### 4. Best-Effort Price Honoring

> Suggested pricing is a **best-effort** mechanism to honor the price that was visible to the buyer during product discovery. The structured `PriceSource` provides the seller with additional product feed provenance — feed identity, update version, timestamp, and channel — to help the seller make an informed decision about whether to honor the suggested price.
>
> Honoring the suggested price is not required. If the seller chooses not to honor the suggested price — because the source is unrecognized, the price has changed, the time window has expired, or for any other business reason — **this is not an error case**. The seller returns the checkout session response with the current pricing breakdown at the seller's current price. The checkout flow proceeds normally. The agent detects the price difference and informs the buyer.
>
> This design ensures that suggested pricing never blocks or breaks checkout. It provides provenance information that helps sellers honor the buyer's expected price when they can, while preserving normal checkout behavior when they cannot.

### 5. Seller Behavior

> When `suggested_price` is present on an `Item` in the create request:
>
> 1. It is RECOMMENDED that the seller verify the `source` — confirm the `feed_id` is a recognized feed and, if present, the `feed_update_id` corresponds to a known feed update version.
> 2. It is RECOMMENDED that the seller check the `observed_at` timestamp against its own price guarantee policy (e.g., prices observed within the last 24 hours are honored).
> 3. If the source is verified and the timestamp is within the acceptable window, it is RECOMMENDED that the seller honor `suggested_price.amount` as the `unit_amount` for that line item in the checkout session response.
> 4. If the seller does not honor the suggested price, the seller MUST return its current live price in the checkout session response with the full pricing breakdown (line item totals, tax, fulfillment, etc.). The seller MUST NOT return an error — the checkout session proceeds with the current price.
> 5. The time window policy is determined by each seller. The protocol does not prescribe a specific duration.

### 6. Agent Behavior

> It is RECOMMENDED that agents include `suggested_price` on items where the agent displayed a catalog-sourced price to the buyer.
>
> After receiving the checkout session response, the agent MUST compare each line item's returned `unit_amount` against the corresponding `suggested_price.amount` (if one was sent). If the prices differ, the agent MUST inform the buyer of the price change before proceeding with checkout. The checkout session is valid regardless of whether the suggested price was honored.
>
> Agents MUST NOT fabricate `source` values or `observed_at` timestamps. The `source.feed_id` MUST reference an actual product feed. When `source.feed_update_id` is included, it MUST correspond to the version identifier returned by `PATCH /feeds/{id}/products`. The `observed_at` MUST reflect when the agent actually retrieved the price from that source.

### 7. Example Flows

**Price honored (source verified, within time window):**

`POST /checkout_sessions`

```json
{
  "line_items": [
    {
      "id": "item_headphones_123",
      "name": "Wireless Headphones",
      "suggested_price": {
        "amount": 5999,
        "source": {
          "feed_id": "feed_8f3K2x",
          "feed_update_id": "upd_7kQ9mR",
          "updated_at": "2026-03-23T06:00:00Z",
          "channel": "api"
        },
        "observed_at": "2026-03-23T08:30:00Z"
      }
    }
  ],
  "currency": "usd",
  "capabilities": {
    "payment": {
      "handlers": [{ "id": "handler_1", "name": "dev.acp.tokenized.card", "version": "2026-01-30" }]
    }
  }
}
```

Response — seller honors $59.99:

```json
{
  "id": "checkout_session_456",
  "status": "requires_payment",
  "currency": "usd",
  "line_items": [
    {
      "id": "li_1",
      "item": {
        "id": "item_headphones_123",
        "name": "Wireless Headphones",
        "unit_amount": 5999
      },
      "quantity": 1,
      "totals": [
        { "type": "base_amount", "display_text": "Item total", "amount": 5999 },
        { "type": "total", "display_text": "Total", "amount": 5999 }
      ]
    }
  ],
  "totals": [
    { "type": "items_base_amount", "display_text": "Item(s) total", "amount": 5999 },
    { "type": "subtotal", "display_text": "Subtotal", "amount": 5999 },
    { "type": "tax", "display_text": "Tax", "amount": 480 },
    { "type": "total", "display_text": "Total", "amount": 6479 }
  ]
}
```

**Price not honored (outside time window):**

Same request, but seller's policy is a 1-hour window and `observed_at` was 2 hours ago. Seller returns current live price of $79.99:

```json
{
  "id": "checkout_session_456",
  "status": "requires_payment",
  "currency": "usd",
  "line_items": [
    {
      "id": "li_1",
      "item": {
        "id": "item_headphones_123",
        "name": "Wireless Headphones",
        "unit_amount": 7999
      },
      "quantity": 1,
      "totals": [
        { "type": "base_amount", "display_text": "Item total", "amount": 7999 },
        { "type": "total", "display_text": "Total", "amount": 7999 }
      ]
    }
  ],
  "totals": [
    { "type": "items_base_amount", "display_text": "Item(s) total", "amount": 7999 },
    { "type": "subtotal", "display_text": "Subtotal", "amount": 7999 },
    { "type": "tax", "display_text": "Tax", "amount": 640 },
    { "type": "total", "display_text": "Total", "amount": 8639 }
  ],
  "messages": [
    {
      "type": "info",
      "content_type": "plain",
      "content": "The price for Wireless Headphones has changed from $59.99 to $79.99."
    }
  ]
}
```

The agent detects `suggested_price.amount` (5999) differs from the returned `unit_amount` (7999) and informs the buyer of the price change.

---

## 🤔 Rationale

### Why add `suggested_price` to `Item` instead of a request-level field?

Price expectations are per-item — different items in the same checkout may have different catalog sources, observation timestamps, and price freshness. A request-level field cannot express per-item provenance.

### Why structured `source` instead of an opaque string?

An alternative is an opaque `source` string — any identifier recognized between agent and merchant (e.g., `"feed_upload_session:7829461035"`). This is simpler but requires out-of-band agreement on format between every agent-merchant pair and cannot be parsed or validated by the protocol. The structured `PriceSource` object aligns with the Feed API's identifiers (`feed_id`, `feed_update_id`) and enables protocol-level verification. Sellers can validate the `feed_id` is a recognized feed and the `feed_update_id` corresponds to a known update version — without custom parsing logic per agent.

### Why not reuse `unit_amount` on `Item`?

`unit_amount` is a simple integer with no provenance. Sellers cannot verify where the price came from or when it was observed. Adding `source` and `observed_at` transforms a bare number into a verifiable price claim that sellers can evaluate against their own policies.

### Why not use the discount extension?

Price matching is fundamentally different from discounting. A suggested price says "this was your published price at this time from this source." A discount says "apply this promotional reduction." Conflating them creates confusion in seller reporting, tax calculations, and analytics. Price matching should be a first-class concept.

### Why RECOMMENDED instead of MUST for seller honoring?

Sellers have different business rules, catalog architectures, and risk tolerances. Some may honor prices from any recognized feed within 48 hours; others may only honor prices from specific APIs within 1 hour. The protocol provides the mechanism; sellers define the policy. Using MUST would impose a one-size-fits-all obligation that doesn't reflect real-world seller diversity.

### Why leave the time window to seller policy?

Catalog refresh cadences vary widely — some sellers update feeds every 15 minutes, others daily. A protocol-mandated window would either be too short (breaking slow-refresh sellers) or too long (exposing fast-refresh sellers to stale price obligations). Sellers know their own catalog freshness and should define their own windows.

### Why not return a specific error when the price isn't honored?

A price change is not an error — it's a normal commerce event. The checkout session should proceed with the current price. The agent detects the discrepancy by comparing amounts and informs the buyer. Returning an error would force the agent to handle a failure case for what is actually a valid checkout session.

---

## 🔄 Backward Compatibility

- **Additive change**: `suggested_price` is a new optional field on `Item` — existing create requests without it continue to work unchanged
- **No breaking changes**: Sellers that don't support `suggested_price` can ignore the field entirely (existing behavior). The checkout session proceeds with the seller's current live price.
- **Graceful degradation**: If a seller doesn't recognize `suggested_price`, the agent falls back to the current behavior — displaying the seller's returned price without price-match context
- **Severity**: None. Fully additive and backward compatible.

---

## 🛠️ Reference Implementation

Not yet available. Will provide before status "Final."

---

## 🔒 Security Implications

- **Price source verification**: Sellers MUST only honor `suggested_price` from sources they recognize and control. This prevents agents from submitting arbitrary low prices with fabricated sources.
- **Timestamp integrity**: Agents MUST NOT fabricate `observed_at` timestamps. Sellers should apply reasonable time windows to limit exposure to stale prices.
- **No new authentication surface**: `suggested_price` uses the same authentication as the existing create endpoint. No new auth mechanisms required.
- **Abuse mitigation**: Sellers can reject `suggested_price` from unrecognized sources or with timestamps outside their policy window. The protocol gives sellers full control over whether to honor the suggestion.
- **No PII exposure**: `suggested_price` contains pricing data and a catalog source URI — no personally identifiable information.

---

## ✅ Pre-Submission Checklist

Before submitting this SEP PR, ensure:

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
- [x] I have linked the SEP issue number above
- [ ] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [x] I have signed the [[Contributor License Agreement (CLA)](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/legal/cla/INDIVIDUAL.md)](../legal/cla/INDIVIDUAL.md)
- [x] This PR includes updates to OpenAPI/JSON schemas (if applicable)
- [x] This PR includes example requests/responses (if applicable)
- [x] This PR includes a changelog entry file in `changelog/unreleased/suggested-pricing.md`
- [ ] I am seeking or have found a sponsor (Founding Maintainer)

---

## 📚 Additional Context

### Real-World Evidence

In production ACP integrations, agent platforms sync product catalogs from sellers on periodic cadences (minutes to hours). Pricing changes — flash sales ending, dynamic pricing adjustments, promotional expirations — frequently cause the agent's displayed price to diverge from the seller's live price by the time the buyer initiates checkout. This price discrepancy at checkout is a leading driver of buyer confusion and cart abandonment in agentic commerce flows.

---

## 🙋 Questions for Reviewers

1. Should the `source` field be a URI (restricting to URLs) or a free-form string (allowing catalog snapshot IDs, feed names, or other identifiers)?
2. Should the seller include a message or indicator in the response when it honors the suggested price, so the agent knows the price match was applied?
3. Should there be a capability flag for sellers to advertise that they support `suggested_price` matching?
