### PR TITLE
chore: OpenAPI semantic validation with swagger-parser

### DIFF
--- a/changelog/unreleased/openapi-semantic-validation.md
+++ b/changelog/unreleased/openapi-semantic-validation.md
@@ -1,0 +1,20 @@
+## OpenAPI semantic validation
+
+Adds machine validation of every `openapi.*.yaml` spec using `@apidevtools/swagger-parser`, which resolves `$ref` and applies OpenAPI structural rules beyond YAML parsing and the existing `openapi` / `info` / `paths` checks in `validate-consistency.js`.
+
+### Changes
+
+- New script `scripts/validate-openapi.js` covering the same version directories as the consistency validator.
+- `pnpm run validate:openapi` runs the new script; `pnpm run validate:all` runs consistency validation then OpenAPI semantic validation.
+- Documented behavior in `scripts/README.md`.
+
+### Files Updated
+
+- `package.json`
+- `pnpm-lock.yaml`
+- `scripts/validate-openapi.js`
+- `scripts/README.md`
+
+### Reference
+
+- PR: (add link after opening pull request)

--- a/changelog/unreleased/openapi-semantic-validation.md
+++ b/changelog/unreleased/openapi-semantic-validation.md
@@ -17,4 +17,4 @@ Adds machine validation of every `openapi.*.yaml` spec using `@apidevtools/swagg
 
 ### Reference
 
-- PR: (add link after opening pull request)
+- PR: https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/pull/203

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
   "scripts": {
     "compile:schema": "ajv compile --spec=draft2020 -c ajv-formats -s 'spec/unreleased/json-schema/*.json'",
     "validate:json-schema": "ajv compile --spec=draft2020 -c ajv-formats -s 'spec/**/json-schema/*.json'",
-    "validate:openapi": "echo 'OpenAPI validation requires additional tooling - see scripts/validate-consistency.js'",
+    "validate:openapi": "node scripts/validate-openapi.js",
     "validate:examples": "node scripts/validate-consistency.js",
     "validate:consistency": "node scripts/validate-consistency.js",
     "validate:prohibited-schemas": "node scripts/validate-consistency.js",
     "validate:field-types": "node scripts/validate-consistency.js",
     "report:consistency": "node scripts/validate-consistency.js",
-    "validate:all": "node scripts/validate-consistency.js"
+    "validate:all": "node scripts/validate-consistency.js && node scripts/validate-openapi.js"
   },
   "devDependencies": {
+    "@apidevtools/swagger-parser": "^12.1.0",
     "ajv": "^8.17.1",
     "ajv-cli": "^5.0.0",
     "ajv-formats": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@apidevtools/swagger-parser':
+        specifier: ^12.1.0
+        version: 12.1.0(openapi-types@12.1.3)
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -23,6 +26,25 @@ importers:
 
 packages:
 
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    resolution: {integrity: sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==}
+    engines: {node: '>= 16'}
+
+  '@apidevtools/openapi-schemas@2.1.0':
+    resolution: {integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==}
+    engines: {node: '>=10'}
+
+  '@apidevtools/swagger-methods@3.0.2':
+    resolution: {integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==}
+
+  '@apidevtools/swagger-parser@12.1.0':
+    resolution: {integrity: sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==}
+    peerDependencies:
+      openapi-types: '>=7'
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   ajv-cli@5.0.0:
     resolution: {integrity: sha512-LY4m6dUv44HTyhV+u2z5uX4EhPYTM38Iv1jdgDJJJCyOOuqB8KtZEGjPZ2T+sh5ZIJrXUfgErYx/j3gLd3+PlQ==}
     hasBin: true
@@ -30,6 +52,14 @@ packages:
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       ts-node:
+        optional: true
+
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
         optional: true
 
   ajv-formats@3.0.1:
@@ -54,6 +84,9 @@ packages:
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -118,6 +151,9 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -134,6 +170,27 @@ packages:
 
 snapshots:
 
+  '@apidevtools/json-schema-ref-parser@14.0.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.1
+
+  '@apidevtools/openapi-schemas@2.1.0': {}
+
+  '@apidevtools/swagger-methods@3.0.2': {}
+
+  '@apidevtools/swagger-parser@12.1.0(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.0.1
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
+      ajv: 8.17.1
+      ajv-draft-04: 1.0.0(ajv@8.17.1)
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
+
+  '@types/json-schema@7.0.15': {}
+
   ajv-cli@5.0.0:
     dependencies:
       ajv: 8.17.1
@@ -143,6 +200,10 @@ snapshots:
       json-schema-migrate: 2.0.0
       json5: 2.2.3
       minimist: 1.2.8
+
+  ajv-draft-04@1.0.0(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
@@ -167,6 +228,8 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  call-me-maybe@1.0.2: {}
 
   concat-map@0.0.1: {}
 
@@ -226,6 +289,8 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  openapi-types@12.1.3: {}
 
   path-is-absolute@1.0.1: {}
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,10 @@ This directory contains automated validation scripts that ensure consistency acr
 - Proper OpenAPI 3.x structure
 - Required fields (openapi, info, paths)
 
+### ✅ OpenAPI semantic validation
+- [`validate-openapi.js`](validate-openapi.js) uses [`@apidevtools/swagger-parser`](https://github.com/APIDevTools/swagger-parser) to validate and dereference each `openapi.*.yaml` under every dated `spec/<version>/openapi/` directory
+- Catches invalid references and structural issues beyond the YAML-level checks in `validate-consistency.js`
+
 ### ✅ Prohibited Schemas
 - Enforces architectural rules for schema placement
 - Extensible for custom validation rules
@@ -58,8 +62,8 @@ pnpm install
 pnpm run validate:all
 
 # Run specific validations
-pnpm run validate:json-schema      # JSON Schema syntax only
-pnpm run validate:openapi           # OpenAPI syntax only
+pnpm run validate:json-schema      # JSON Schema syntax (all versions)
+pnpm run validate:openapi           # OpenAPI semantic validation (swagger-parser)
 pnpm run validate:examples          # Examples against schemas
 pnpm run validate:field-types       # Critical field types
 pnpm run validate:consistency       # Full consistency check
@@ -75,6 +79,8 @@ The PR will:
 - ❌ **Fail** if any errors are found
 
 ## Adding New Validations
+
+Edit `scripts/validate-consistency.js` for cross-spec and documentation rules, or `scripts/validate-openapi.js` for OpenAPI-only semantic checks.
 
 Edit `scripts/validate-consistency.js` to add new validation rules:
 
@@ -94,6 +100,7 @@ const CRITICAL_FIELDS = [
 
 ### Errors (Fail CI)
 - Invalid JSON/YAML syntax
+- OpenAPI documents that fail `@apidevtools/swagger-parser` validation (invalid `$ref`, malformed OpenAPI structure)
 - Prohibited schemas in wrong files
 - Critical fields with incorrect types
 - Examples that don't validate against schemas

--- a/scripts/validate-openapi.js
+++ b/scripts/validate-openapi.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+/**
+ * Semantic OpenAPI validation using @apidevtools/swagger-parser.
+ *
+ * Ensures each spec document parses as OpenAPI 2/3, resolves $ref, and
+ * passes the parser's structural validation (beyond YAML load + openapi/info/paths checks).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const SwaggerParser = require('@apidevtools/swagger-parser');
+
+const VERSIONS = ['2025-09-29', '2025-12-12', '2026-01-16', '2026-01-30', 'unreleased'];
+
+function getOpenApiFiles(version) {
+  const openApiDir = path.join(__dirname, '..', 'spec', version, 'openapi');
+  if (!fs.existsSync(openApiDir)) {
+    return [];
+  }
+  return fs
+    .readdirSync(openApiDir)
+    .filter((file) => file.endsWith('.yaml') && file.startsWith('openapi.'))
+    .map((file) => file.replace('openapi.', '').replace('.yaml', ''));
+}
+
+async function main() {
+  const failures = [];
+
+  for (const version of VERSIONS) {
+    const specs = getOpenApiFiles(version);
+    for (const spec of specs) {
+      const openApiPath = path.join(
+        __dirname,
+        '..',
+        'spec',
+        version,
+        'openapi',
+        `openapi.${spec}.yaml`
+      );
+      if (!fs.existsSync(openApiPath)) {
+        continue;
+      }
+      try {
+        await SwaggerParser.validate(openApiPath);
+        console.log(`✅ OpenAPI valid: ${version}/${spec}`);
+      } catch (err) {
+        const rel = path.relative(path.join(__dirname, '..'), openApiPath);
+        console.error(`❌ OpenAPI validation failed: ${version}/${spec}`);
+        console.error(err.message || String(err));
+        failures.push({ file: rel, error: err });
+      }
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(`\n❌ ${failures.length} OpenAPI file(s) failed validation.`);
+    process.exit(1);
+  }
+
+  console.log('\n✅ All OpenAPI documents passed semantic validation.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Type of change

- [x] Tooling improvement

## Description

Replaces the stub `validate:openapi` script with validation using `@apidevtools/swagger-parser` for every `openapi.*.yaml` under each dated `spec/<version>/openapi/` directory (same coverage as `validate-consistency.js`). `pnpm run validate:all` runs consistency checks then OpenAPI semantic validation, so CI (`validate-consistency.yml`) enforces it automatically.

## Motivation

`package.json` previously indicated OpenAPI validation needed additional tooling; `validate-consistency.js` only checks YAML parse and basic `openapi` / `info` / `paths` presence. Swagger Parser adds dereferencing and structural OpenAPI validation.

## Testing

- `pnpm install --frozen-lockfile`
- `pnpm run compile:schema`
- `pnpm run validate:openapi`
- `pnpm run validate:all`

## Checklist

- [x] Individual CLA via CLA Assistant
- [x] `scripts/README.md` updated
- [x] `changelog/unreleased/openapi-semantic-validation.md`
- [x] Tested locally
- [x] No SEP required (tooling only)

## Scope

Minor tooling change only; no protocol semantics.

Made with [Cursor](https://cursor.com)