### PR TITLE
Allow empty risk_signals in delegate_payment spec

### DIFF
--- a/changelog/unreleased/allow-empty-risk-signals.md
+++ b/changelog/unreleased/allow-empty-risk-signals.md
@@ -1,0 +1,18 @@
+# Unreleased Changes
+
+## Allow empty risk_signals array 
+
+The current implementation of `delegate_payment` does not always provide an array of at least size 1 in the `risk_signals` array. 
+
+### Changes
+
+- **Risk signals:** `minItems` of `1` on the `risk_signals` field is removed. 
+
+### Breaking Changes
+
+None.
+
+### Files Updated
+
+- `spec/unreleased/json-schema/schema.delegate_payment.json`
+- `spec/unreleased/openapi/openapi.delegate_payment.yaml`

--- a/spec/unreleased/json-schema/schema.delegate_payment.json
+++ b/spec/unreleased/json-schema/schema.delegate_payment.json
@@ -277,7 +277,6 @@
         },
         "risk_signals": {
           "type": "array",
-          "minItems": 1,
           "description": "List of risk assessment signals from fraud detection",
           "items": {
             "$ref": "#/$defs/RiskSignal"

--- a/spec/unreleased/openapi/openapi.delegate_payment.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_payment.yaml
@@ -316,7 +316,6 @@ components:
           description: Billing address associated with the payment method
         risk_signals:
           type: array
-          minItems: 1
           description: List of risk assessment signals from fraud detection
           items:
             $ref: "#/components/schemas/RiskSignal"


### PR DESCRIPTION
# Allow empty risk_signals in delegate_payment spec

## 🔧 Type of Change

- [x] Other: Relax field validation to match existing implementations

---

## 📝 Description

This PR introduces a change to the `delegate_payment` endpoint allowing the `risk_signals` to be empty. Before this PR, the `risk_signals` array had a minimum length of `1`. 

---

## 🎯 Motivation and Context

When Braintree was building an `delegate_payment` to be used by OpenAI as a client, we discovered that OpenAI as the caller sometimes sends an empty array for `risk_signals` and we needed to loosen validation on our end. This PR aligns the spec with is happening in the real world. 

---

## 🧪 Testing

* Tested the openapi yaml in https://editor.swagger.io/
* Tested the JSON schema with AJV

---

## 📸 Screenshots / Examples

n/a


---

## ✅ Checklist

Before submitting, ensure:

- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (if applicable)
- [x] I have added/updated examples (if applicable)
- [x] I have added a changelog entry file to `changelog/unreleased/your-change-description.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [x] All CI checks pass

---

## 🔍 Scope Verification

<!-- 
  Please confirm this change is truly minor and doesn't require a SEP.
  If ANY of these are true, you should use the SEP template instead:
-->

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ **This is a minor, straightforward change** (confirm by checking this)

---

## 📚 Additional Notes

<!-- 
  Any other information reviewers should know:
  - Dependencies
  - Follow-up work needed
  - Open questions
-->

n/a


---

**Review Process**: Minor changes require approval from a Steward (may be from the same organization for efficiency). See [governance.md](../docs/governance.md) for details.