### PR TITLE
Fix webhook refund example minor units

### DIFF
--- a/changelog/unreleased/fix-webhook-refund-example-minor-units.md
+++ b/changelog/unreleased/fix-webhook-refund-example-minor-units.md
@@ -1,0 +1,11 @@
+## Fix webhook refund example minor units
+
+Fix the `order_updated` example in the `2026-01-30` webhook OpenAPI snapshot so `Refund.amount` matches the schema definition.
+
+### Changes
+- Changed the inline webhook example from `amount: "1.00"` to `amount: 100`
+- Kept the example aligned with the existing `Refund.amount` schema, which uses integer minor units
+
+### Files Updated
+- `spec/2026-01-30/openapi/openapi.agentic_checkout_webhook.yaml`
+

--- a/spec/2026-01-30/openapi/openapi.agentic_checkout_webhook.yaml
+++ b/spec/2026-01-30/openapi/openapi.agentic_checkout_webhook.yaml
@@ -65,7 +65,7 @@ paths:
                     status: shipped
                     refunds:
                       - type: original_payment
-                        amount: "1.00"
+                        amount: 100
       responses:
         "200":
           description: Event accepted


### PR DESCRIPTION
  ## 🔧 Type of Change

  - [x] Bug fix (non-breaking)
 - [x] Example update
  ---

  ## 📝 Description

  This PR fixes an inconsistency in the released `2026-01-30` webhook OpenAPI snapshot.

  The `order_updated` example used:

  ```yaml
  amount: "1.00"
```

  But Refund.amount in the same file is defined as an integer in minor units.

  This PR updates the example to use the integer representation:

  ```yaml
  amount: 100
```

  ———

  ## 🎯 Motivation and Context

  This keeps the example aligned with the schema and removes ambiguity for implementers and tooling.

  ———

  ## 🧪 Testing

  - Verified the changed example now matches the Refund.amount schema in the same file
  - Confirmed the 2026-01-30 JSON examples already use integer minor units
  - Added an unreleased changelog entry as required by the contribution guide

  ———

  ## 📸 Screenshots / Examples

  Before:

  ```yaml
  refunds:
    - type: original_payment
      amount: "1.00"
```

  After:

  ```yaml
  refunds:
    - type: original_payment
      amount: 100
```
  ———

  ## ✅ Checklist

  - [ ] I have signed the ../legal/cla/INDIVIDUAL.md
  - [x] My change follows the project's code style and conventions
  - [ ] I have updated relevant documentation (if applicable)
  - [x] I have added/updated examples (if applicable)
  - [x] I have added a changelog entry file to changelog/unreleased/your-change-description.md
  - [x] I have tested my changes locally
  - [x] This change does NOT require a SEP (it's minor/non-breaking)
  - [ ] All CI checks pass

  ———

  ## 🔍 Scope Verification

  - [ ] ❌ This adds/removes/modifies protocol features
  - [ ] ❌ This introduces breaking changes
  - [ ] ❌ This changes governance or processes
  - [ ] ❌ This is complex or controversial
  - [x] ✅ This is a minor, straightforward change

  ———

  ## 📚 Additional Notes

  This PR only updates the released OpenAPI example in:

  - spec/2026-01-30/openapi/openapi.agentic_checkout_webhook.yaml

  It does not change the schema itself.