### PR TITLE
SEP: Add Feed Extensions Framework

### DIFF
--- a/changelog/unreleased/feed-extensions-framework.md
+++ b/changelog/unreleased/feed-extensions-framework.md
@@ -1,0 +1,21 @@
+# Feed Extensions Framework
+
+**Added** – extends the ACP Extensions Framework to cover product feeds.
+
+## Changes
+
+- **FeedMetadata.extensions**: Added optional `extensions` array to
+  `FeedMetadata` that declares which feed extensions are active, reusing
+  the existing `ExtensionDeclaration` structure from the checkout
+  extension framework.
+
+## Deferred
+
+- Concrete feed extensions (e.g., image attributes) and any necessary
+  `additionalProperties` handling on extensible feed objects are
+  deferred to follow-up PRs.
+
+## Files Modified
+- `spec/unreleased/json-schema/schema.feed.json`
+- `spec/unreleased/openapi/openapi.feed.yaml`
+- `examples/unreleased/examples.feed.json`

--- a/examples/unreleased/examples.feed.json
+++ b/examples/unreleased/examples.feed.json
@@ -96,6 +96,22 @@
     "id": "feed_8f3K2x",
     "accepted": true
   },
+  "get_feed_response_with_extensions": {
+    "id": "feed_8f3K2x",
+    "target_country": "US",
+    "updated_at": "2026-04-07T00:00:00Z",
+    "extensions": [
+      {
+        "name": "image_attributes",
+        "extends": [
+          "$.Media.description",
+          "$.Media.shot_style"
+        ],
+        "schema": "https://example.com/schemas/feed-extensions/image-attributes/2026-04-07.json",
+        "spec": "https://example.com/specs/feed-extensions/image-attributes"
+      }
+    ]
+  },
   "feed_error_not_found": {
     "type": "invalid_request",
     "code": "feed_not_found",

--- a/spec/unreleased/json-schema/schema.feed.json
+++ b/spec/unreleased/json-schema/schema.feed.json
@@ -507,12 +507,31 @@
           "type": "string",
           "format": "date-time",
           "description": "Timestamp of the most recent update applied to this feed."
+        },
+        "extensions": {
+          "type": "array",
+          "description": "Extension declarations active for this feed. Each entry identifies an extension and the fields it adds to feed schema objects.",
+          "items": {
+            "$ref": "schema.extension.json#/$defs/extension_declaration"
+          },
+          "uniqueItems": true
         }
       },
       "example": {
         "id": "feed_8f3K2x",
         "target_country": "US",
-        "updated_at": "2026-03-01T00:00:00Z"
+        "updated_at": "2026-04-07T00:00:00Z",
+        "extensions": [
+          {
+            "name": "image_attributes",
+            "extends": [
+              "$.Media.description",
+              "$.Media.shot_style"
+            ],
+            "schema": "https://example.com/schemas/feed-extensions/image-attributes/2026-04-07.json",
+            "spec": "https://example.com/specs/feed-extensions/image-attributes"
+          }
+        ]
       }
     },
     "CreateFeedRequest": {

--- a/spec/unreleased/openapi/openapi.feed.yaml
+++ b/spec/unreleased/openapi/openapi.feed.yaml
@@ -614,10 +614,59 @@ components:
           type: string
           format: date-time
           description: Timestamp of the most recent update applied to this feed.
+        extensions:
+          type: array
+          description: Extension declarations active for this feed.
+          items:
+            $ref: "#/components/schemas/ExtensionDeclaration"
+          uniqueItems: true
       example:
         id: feed_8f3K2x
         target_country: US
-        updated_at: "2026-03-01T00:00:00Z"
+        updated_at: "2026-04-07T00:00:00Z"
+        extensions:
+          - name: image_attributes
+            extends:
+              - "$.Media.description"
+              - "$.Media.shot_style"
+            schema: "https://example.com/schemas/feed-extensions/image-attributes/2026-04-07.json"
+            spec: "https://example.com/specs/feed-extensions/image-attributes"
+    ExtensionDeclaration:
+      type: object
+      additionalProperties: false
+      description: Extension declaration identifying an active feed extension and which schema fields it adds.
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          pattern: ^[a-z][a-z0-9_-]*(@\d{4}-\d{2}-\d{2})?$|^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9_-]*)+(@\d{4}-\d{2}-\d{2})?$
+          description: Unique identifier for the extension.
+        extends:
+          type: array
+          items:
+            type: string
+            pattern: ^\$\.[A-Za-z][A-Za-z0-9]*(\.[A-Za-z][A-Za-z0-9_]*)*$
+            description: JSONPath expression identifying a schema field added by this extension
+          uniqueItems: true
+          description: |
+            JSONPath expressions identifying the schema fields added by this extension.
+            Format: $.<SchemaName>.<fieldName> (e.g., $.Media.description).
+        schema:
+          type: string
+          format: uri
+          description: URL to the extension's JSON Schema definition.
+        spec:
+          type: string
+          format: uri
+          description: URL to the extension's specification document.
+      example:
+        name: image_attributes
+        extends:
+          - $.Media.description
+          - $.Media.shot_style
+        schema: https://example.com/schemas/feed-extensions/image-attributes/2026-04-07.json
+        spec: https://example.com/specs/feed-extensions/image-attributes
     CreateFeedRequest:
       description: Request payload used to create a feed.
       type: object


### PR DESCRIPTION
# SEP: Feed Extensions Framework

## 📋 SEP Metadata

- **SEP Number**: #222
- **Author(s)**: Dylan Farrell / Agentic Commerce Inc. (Catalog)
- **Status**: `proposal` (awaiting sponsor)
- **Type**: [X] Major Change [ ] Process Change
- **Related Issues/RFCs**: PR #190 (Feed API), Issue #189 (Product Feeds SEP), Issue #177 (Move Extensions to Protocol Metadata), PR #123 (Sale Extension — nested extension precedent on LineItem), PR #89 (Extensions Framework + Discount Extension), `rfcs/rfc.extensions.md`, `rfcs/rfc.capability_negotiation.md`

---

## 🎯 Abstract

This PR extends the ACP Extensions Framework to cover product feeds. The base Feed API (PR #190) uses `additionalProperties: false` on every schema object, which means feed objects cannot carry any fields beyond those in the base spec. This PR adds an optional `extensions` array to `FeedMetadata` that declares which feed extensions are active, reusing the existing `ExtensionDeclaration` structure and JSONPath-based `extends` pattern from the checkout extension framework. Concrete extensions and any necessary `additionalProperties` handling are deferred to follow-up PRs.

---

## 💡 Motivation

- Feed objects benefit from additional structured data beyond the base schema. For example the `Media` schema has only five fields — agents have no way to know which image is a studio shot vs. a flat lay.
- `additionalProperties: false` on every feed schema object blocks any extension — unknown fields fail validation, so every new field requires modifying the base schema.
- The checkout extension framework already provides an existing pattern for composable schema additions — this SEP applies it to feeds.

See the SEP Issue for the full motivation.

---

## 📐 Specification

This PR makes the following normative additions in unreleased ACP:

1. **`FeedMetadata.extensions`**: Added optional `extensions` array reusing `ExtensionDeclaration` from `schema.extension.json`
2. **Schema composition rules**: Feed producers MUST NOT include undeclared fields on extensible objects; consumers SHOULD validate against `extends` whitelist and strip undeclared fields

### Extension declaration example

```json
{
  "id": "feed_8f3K2x",
  "target_country": "US",
  "updated_at": "2026-04-07T00:00:00Z",
  "extensions": [
    {
      "name": "image_attributes",
      "extends": ["$.Media.description", "$.Media.shot_style"],
      "schema": "https://example.com/schemas/feed-extensions/image-attributes/2026-04-07.json",
      "spec": "https://example.com/specs/feed-extensions/image-attributes"
    }
  ]
}
```

### Deferred: `additionalProperties` handling and concrete extensions

This PR establishes the declaration mechanism only. Feed objects retain `additionalProperties: false`. The first concrete extension PR will propose the necessary schema changes to allow extension-declared fields, choosing among the options analyzed in the SEP Issue (Section 5): schema composition via `allOf`/`unevaluatedProperties` (consistent with the checkout pattern), `additionalProperties: true` with normative whitelist, or a namespaced `extensions` object on each extensible type.

---

## 🤔 Rationale

- **Reuse checkout pattern**: `ExtensionDeclaration`, JSONPath `extends`, and the same composition rules so implementers learn one model
- **Per-feed declarations**: Extension declarations describe the feed's schema contract, not individual products
- **No negotiation**: Feed extensions are unilateral — the merchant publishes, consumers handle or ignore

See the SEP Issue for the full rationale on each design decision.

---

## 🔄 Backward Compatibility

- No existing feed endpoints change
- `FeedMetadata.extensions` is optional — feeds without extensions behave identically
- Consumers that do not support extensions ignore extension fields

---

## 🛠️ Reference Implementation

This PR includes:

- `spec/unreleased/json-schema/schema.feed.json` — `extensions` added to `FeedMetadata`
- `spec/unreleased/openapi/openapi.feed.yaml` — `ExtensionDeclaration` component and `FeedMetadata.extensions` property
- `examples/unreleased/examples.feed.json` — `get_feed_response_with_extensions` example
- `changelog/unreleased/feed-extensions-framework.md`

---

## 🔒 Security Implications

- **No new authentication or authorization changes.** Extension data is subject to the same access controls as base feed data.
- **Extension schemas from untrusted sources.** The `schema` URL points to external JSON Schemas. Consumers MUST NOT automatically fetch and execute schemas from untrusted URLs.
- **Namespace collisions.** Third-party extensions SHOULD use reverse-domain naming (e.g., `com.example.custom-extension`) to avoid collisions with core extensions.

---

## ✅ Pre-Submission Checklist

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
- [x] I have linked the SEP issue number above
- [x] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] This PR includes updates to OpenAPI/JSON schemas (if applicable)
- [x] This PR includes example requests/responses (if applicable)
- [x] This PR includes a changelog entry file in `changelog/unreleased/feed-extensions-framework.md`
- [x] I am seeking or have found a sponsor (Founding Maintainer)

---

## 📚 Additional Context

### Other related work

- **Checkout extensions** (PR #89): This SEP applies the same pattern to feeds. The two scopes are independent.
- **PR #190 (Feed API)**: This is a stacked PR on top of the base Feed API. It does not block PR #190 from landing.
- **Issue #177 (Move Extensions to Protocol Metadata)**: If it lands, feed extensions SHOULD be advertised in `protocol.extensions`. Per-feed `FeedMetadata.extensions` provides feed-specific granularity.

---

## 🙋 Questions for Reviewers

1. **Which feed objects should be extensible?** This PR defines JSONPath targets for `Product`, `Variant`, and `Media`. Should other nested schemas also be extensible?
2. **`additionalProperties` handling**: This PR defers the `additionalProperties` question to the first concrete extension PR. Should the protocol instead resolve this now, and if so, which approach is preferred: (a) schema composition via `allOf`/`unevaluatedProperties` (consistent with the checkout pattern), (b) `additionalProperties: true` with normative whitelist, or (c) a namespaced `extensions` object on each extensible type?
3. **First concrete extension**: Should the first feed extension target a top-level object like `Product` (e.g., `brand`) or a nested object like `Media` (e.g., `image_attributes`)?

---

**Note**: SEPs require unanimous approval from Founding Maintainers. See [governance.md](../docs/governance.md) and [sep-guidelines.md](../docs/sep-guidelines.md) for the full process.