### PR TITLE
SEP: Make checkout_session_id optional in delegate_payment endpoint

### DIFF
--- a/changelog/unreleased/optional-checkout-session-id.md
+++ b/changelog/unreleased/optional-checkout-session-id.md
@@ -1,0 +1,12 @@
+# Unreleased Changes
+
+## Make allowance.checkout_session_id optional on delegate_payment endpoint
+
+### Breaking Changes
+
+- The `allowance.checkout_session_id` field becomes optional. This is breaking for server implementers who may today utilize it.
+
+### Files Updated
+
+- `spec/unreleased/json-schema/schema.delegate_payment.json`
+- `spec/unreleased/openapi/openapi.delegate_payment.yaml`

--- a/spec/unreleased/json-schema/schema.delegate_payment.json
+++ b/spec/unreleased/json-schema/schema.delegate_payment.json
@@ -218,7 +218,6 @@
         "reason",
         "max_amount",
         "currency",
-        "checkout_session_id",
         "merchant_id",
         "expires_at"
       ],

--- a/spec/unreleased/openapi/openapi.delegate_payment.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_payment.yaml
@@ -555,7 +555,6 @@ components:
         - reason
         - max_amount
         - currency
-        - checkout_session_id
         - merchant_id
         - expires_at
       example:


### PR DESCRIPTION
This is a draft PR demonstrating the change in [SEP: Make checkout_session_id optional in delegate_payment endpoint](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/issues/228)