### PR TITLE
SEP: Order Schema - Post-Checkout Alignment

### DIFF
--- a/changelog/unreleased/order-schema-alignment.md
+++ b/changelog/unreleased/order-schema-alignment.md
@@ -1,0 +1,69 @@
+## Order Schema: Post-Checkout Alignment
+
+### Motivation
+
+Sellers send order events — shipping, refunds, cancellations — to platforms, which fan them
+out to agents. The order model needs clear, unambiguous semantics to support this pipeline
+end-to-end.
+
+This change addresses five categories of misalignment in the order schema:
+
+1. **Quantity model was too narrow.** The 2-field model (`ordered`/`shipped`) couldn't represent
+   cancellations or returns (no way to say "3 ordered, 1 canceled, 2 shipped"). The 3-field
+   model (`ordered`/`current`/`fulfilled`) tracks the full lifecycle.
+
+2. **Status values were shipping-centric.** `shipped` and `delivered` as line item statuses
+   don't apply to pickup or digital fulfillment. The new values (`fulfilled`, `removed`) are
+   fulfillment-type-agnostic and derived directly from the quantity fields.
+
+3. **Order status overloaded "fulfilled".** Using `fulfilled` at both the order and line item
+   level would create confusion: `LineItem.status = "fulfilled"` means the seller has dispatched
+   the item (quantity-derived), while at the order level it would mean everything has been
+   received by the buyer. We use `completed` at the order level to avoid this ambiguity.
+
+4. **Fulfillment event types had gaps.** Missing `canceled` and `undeliverable` forced
+   merchants to abuse `failed_attempt` for terminal failure states. `returned` was renamed to
+   `returned_to_sender` for precision.
+
+5. **Adjustment types had redundancy.** `refund`/`partial_refund` is a false distinction (the
+   amount already tells you). `store_credit` was jargon-heavy. `chargeback` is a subtype of
+   `dispute`. `price_adjustment` was missing entirely.
+
+### Breaking Changes
+
+- **LineItem quantity**: 2-field model (`ordered`/`shipped`) → 3-field model
+  (`ordered`/`current`/`fulfilled`). `current` is now required. `fulfilled` replaces `shipped`
+  and applies to all fulfillment types (shipping, pickup, digital).
+
+- **LineItem status**: `[processing, partial, shipped, delivered, canceled]` →
+  `[processing, partial, fulfilled, removed]`. Status is now deterministically derived from
+  quantity fields: `removed` if `current==0`, `fulfilled` if `fulfilled==current`, `partial` if
+  `0 < fulfilled < current`, `processing` otherwise.
+
+- **Order status**: `delivered` → `completed`. The term `completed` avoids confusion with
+  `LineItem.status = "fulfilled"` (which triggers at dispatch time, not delivery time).
+
+- **FulfillmentEvent type**: `returned` → `returned_to_sender`. Added `canceled` and
+  `undeliverable`.
+
+- **Adjustment type**: `partial_refund` merged into `refund` (distinguish by amount).
+  `store_credit` → `credit`. `chargeback` merged into `dispute`. Added `price_adjustment`.
+
+### Semantic model
+
+The order schema now has distinct terminology at each level to avoid ambiguity:
+
+| Level | Field | Values | Meaning |
+|-------|-------|--------|---------|
+| Order | `status` | `completed` | Buyer has received everything |
+| LineItem | `status` | `fulfilled` | Seller's obligation met for this item (dispatched) |
+| Fulfillment | `status` | `delivered` | Physical/digital delivery confirmed (unchanged) |
+| FulfillmentEvent | `type` | `delivered` | The delivery event occurred (unchanged) |
+
+### Files Changed
+
+- `spec/*/json-schema/schema.agentic_checkout.json`
+- `spec/*/openapi/openapi.agentic_checkout.yaml`
+- `spec/*/openapi/openapi.agentic_checkout_webhook.yaml`
+- `examples/*/orders/*.json`
+- `rfcs/rfc.orders.md`

--- a/changelog/unreleased/order-schema-alignment.md
+++ b/changelog/unreleased/order-schema-alignment.md
@@ -49,6 +49,11 @@ This change addresses five categories of misalignment in the order schema:
 - **Adjustment type**: `partial_refund` merged into `refund` (distinguish by amount).
   `store_credit` → `credit`. `chargeback` merged into `dispute`. Added `price_adjustment`.
 
+- **Open enums**: All order-related status and type fields are now open enums (`type: string`
+  with defined values in descriptions) rather than closed enums. Implementations MUST accept
+  unrecognized values gracefully. This enables forward and backward compatibility as the
+  protocol evolves without requiring schema-breaking changes for new values.
+
 ### Semantic model
 
 The order schema now has distinct terminology at each level to avoid ambiguity:

--- a/examples/2026-04-17/orders/digital-fulfillment.json
+++ b/examples/2026-04-17/orders/digital-fulfillment.json
@@ -5,7 +5,7 @@
   "checkout_session_id": "cs_mno456",
   "permalink_url": "https://merchant.example.com/orders/ord_digital_201",
   "order_number": "ORD-2026-00201",
-  "status": "delivered",
+  "status": "completed",
   "line_items": [
     {
       "id": "li_software",
@@ -13,10 +13,10 @@
       "product_id": "prod_photo_editor_pro",
       "image_url": "https://merchant.example.com/images/photo-editor.jpg",
       "url": "https://merchant.example.com/products/photo-editor-pro",
-      "quantity": { "ordered": 1, "shipped": 1 },
+      "quantity": { "ordered": 1, "current": 1, "fulfilled": 1 },
       "unit_price": 9900,
       "subtotal": 9900,
-      "status": "delivered"
+      "status": "fulfilled"
     }
   ],
   "fulfillments": [

--- a/examples/2026-04-17/orders/partial-fulfillment.json
+++ b/examples/2026-04-17/orders/partial-fulfillment.json
@@ -12,17 +12,17 @@
       "title": "Running Shoes - Size 10",
       "product_id": "prod_shoes_10",
       "image_url": "https://merchant.example.com/images/shoes.jpg",
-      "quantity": { "ordered": 3, "shipped": 3 },
+      "quantity": { "ordered": 3, "current": 3, "fulfilled": 3 },
       "unit_price": 12900,
       "subtotal": 38700,
-      "status": "shipped"
+      "status": "fulfilled"
     },
     {
       "id": "li_shirts",
       "title": "Cotton T-Shirt - Blue - Medium",
       "product_id": "prod_shirt_blue_m",
       "image_url": "https://merchant.example.com/images/shirt-blue.jpg",
-      "quantity": { "ordered": 2, "shipped": 0 },
+      "quantity": { "ordered": 2, "current": 2, "fulfilled": 0 },
       "unit_price": 2900,
       "subtotal": 5800,
       "status": "processing"

--- a/examples/2026-04-17/orders/refunded-order.json
+++ b/examples/2026-04-17/orders/refunded-order.json
@@ -5,26 +5,26 @@
   "checkout_session_id": "cs_jkl789",
   "permalink_url": "https://merchant.example.com/orders/ord_refund_101",
   "order_number": "ORD-2026-00101",
-  "status": "delivered",
+  "status": "completed",
   "line_items": [
     {
       "id": "li_headphones",
       "title": "Wireless Noise-Canceling Headphones",
       "product_id": "prod_headphones_nc",
       "image_url": "https://merchant.example.com/images/headphones.jpg",
-      "quantity": { "ordered": 2, "shipped": 2 },
+      "quantity": { "ordered": 2, "current": 2, "fulfilled": 2 },
       "unit_price": 29900,
       "subtotal": 59800,
-      "status": "delivered"
+      "status": "fulfilled"
     },
     {
       "id": "li_cable",
       "title": "USB-C Charging Cable",
       "product_id": "prod_cable_usbc",
-      "quantity": { "ordered": 1, "shipped": 1 },
+      "quantity": { "ordered": 1, "current": 1, "fulfilled": 1 },
       "unit_price": 1900,
       "subtotal": 1900,
-      "status": "delivered"
+      "status": "fulfilled"
     }
   ],
   "fulfillments": [

--- a/examples/2026-04-17/orders/shipped-order.json
+++ b/examples/2026-04-17/orders/shipped-order.json
@@ -5,7 +5,7 @@
   "checkout_session_id": "cs_def123",
   "permalink_url": "https://merchant.example.com/orders/ord_shipped_456",
   "order_number": "ORD-2026-00456",
-  "status": "delivered",
+  "status": "completed",
   "line_items": [
     {
       "id": "li_laptop",
@@ -14,19 +14,19 @@
       "description": "Apple MacBook Pro 16-inch with M3 Pro chip",
       "image_url": "https://merchant.example.com/images/mbp16.jpg",
       "url": "https://merchant.example.com/products/macbook-pro-16",
-      "quantity": { "ordered": 1, "shipped": 1 },
+      "quantity": { "ordered": 1, "current": 1, "fulfilled": 1 },
       "unit_price": 249900,
       "subtotal": 249900,
-      "status": "delivered"
+      "status": "fulfilled"
     },
     {
       "id": "li_case",
       "title": "Laptop Sleeve",
       "product_id": "prod_sleeve",
-      "quantity": { "ordered": 1, "shipped": 1 },
+      "quantity": { "ordered": 1, "current": 1, "fulfilled": 1 },
       "unit_price": 4900,
       "subtotal": 4900,
-      "status": "delivered"
+      "status": "fulfilled"
     }
   ],
   "fulfillments": [

--- a/examples/orders/digital-fulfillment.json
+++ b/examples/orders/digital-fulfillment.json
@@ -5,7 +5,7 @@
   "checkout_session_id": "cs_mno456",
   "permalink_url": "https://merchant.example.com/orders/ord_digital_201",
   "order_number": "ORD-2026-00201",
-  "status": "delivered",
+  "status": "completed",
   "line_items": [
     {
       "id": "li_software",
@@ -13,10 +13,10 @@
       "product_id": "prod_photo_editor_pro",
       "image_url": "https://merchant.example.com/images/photo-editor.jpg",
       "url": "https://merchant.example.com/products/photo-editor-pro",
-      "quantity": { "ordered": 1, "shipped": 1 },
+      "quantity": { "ordered": 1, "current": 1, "fulfilled": 1 },
       "unit_price": 9900,
       "subtotal": 9900,
-      "status": "delivered"
+      "status": "fulfilled"
     }
   ],
   "fulfillments": [

--- a/examples/orders/partial-fulfillment.json
+++ b/examples/orders/partial-fulfillment.json
@@ -12,17 +12,17 @@
       "title": "Running Shoes - Size 10",
       "product_id": "prod_shoes_10",
       "image_url": "https://merchant.example.com/images/shoes.jpg",
-      "quantity": { "ordered": 3, "shipped": 3 },
+      "quantity": { "ordered": 3, "current": 3, "fulfilled": 3 },
       "unit_price": 12900,
       "subtotal": 38700,
-      "status": "shipped"
+      "status": "fulfilled"
     },
     {
       "id": "li_shirts",
       "title": "Cotton T-Shirt - Blue - Medium",
       "product_id": "prod_shirt_blue_m",
       "image_url": "https://merchant.example.com/images/shirt-blue.jpg",
-      "quantity": { "ordered": 2, "shipped": 0 },
+      "quantity": { "ordered": 2, "current": 2, "fulfilled": 0 },
       "unit_price": 2900,
       "subtotal": 5800,
       "status": "processing"

--- a/examples/orders/refunded-order.json
+++ b/examples/orders/refunded-order.json
@@ -5,26 +5,26 @@
   "checkout_session_id": "cs_jkl789",
   "permalink_url": "https://merchant.example.com/orders/ord_refund_101",
   "order_number": "ORD-2026-00101",
-  "status": "delivered",
+  "status": "completed",
   "line_items": [
     {
       "id": "li_headphones",
       "title": "Wireless Noise-Canceling Headphones",
       "product_id": "prod_headphones_nc",
       "image_url": "https://merchant.example.com/images/headphones.jpg",
-      "quantity": { "ordered": 2, "shipped": 2 },
+      "quantity": { "ordered": 2, "current": 2, "fulfilled": 2 },
       "unit_price": 29900,
       "subtotal": 59800,
-      "status": "delivered"
+      "status": "fulfilled"
     },
     {
       "id": "li_cable",
       "title": "USB-C Charging Cable",
       "product_id": "prod_cable_usbc",
-      "quantity": { "ordered": 1, "shipped": 1 },
+      "quantity": { "ordered": 1, "current": 1, "fulfilled": 1 },
       "unit_price": 1900,
       "subtotal": 1900,
-      "status": "delivered"
+      "status": "fulfilled"
     }
   ],
   "fulfillments": [

--- a/examples/orders/shipped-order.json
+++ b/examples/orders/shipped-order.json
@@ -5,7 +5,7 @@
   "checkout_session_id": "cs_def123",
   "permalink_url": "https://merchant.example.com/orders/ord_shipped_456",
   "order_number": "ORD-2026-00456",
-  "status": "delivered",
+  "status": "completed",
   "line_items": [
     {
       "id": "li_laptop",
@@ -14,19 +14,19 @@
       "description": "Apple MacBook Pro 16-inch with M3 Pro chip",
       "image_url": "https://merchant.example.com/images/mbp16.jpg",
       "url": "https://merchant.example.com/products/macbook-pro-16",
-      "quantity": { "ordered": 1, "shipped": 1 },
+      "quantity": { "ordered": 1, "current": 1, "fulfilled": 1 },
       "unit_price": 249900,
       "subtotal": 249900,
-      "status": "delivered"
+      "status": "fulfilled"
     },
     {
       "id": "li_case",
       "title": "Laptop Sleeve",
       "product_id": "prod_sleeve",
-      "quantity": { "ordered": 1, "shipped": 1 },
+      "quantity": { "ordered": 1, "current": 1, "fulfilled": 1 },
       "unit_price": 4900,
       "subtotal": 4900,
-      "status": "delivered"
+      "status": "fulfilled"
     }
   ],
   "fulfillments": [

--- a/rfcs/rfc.orders.md
+++ b/rfcs/rfc.orders.md
@@ -527,6 +527,7 @@ An empty `adjustments: []` array means no post-order changes have occurred.
 
 ## 8. Change Log
 
+- **2026-04-30**: Open enums — Converted all order-related status and type fields from closed enums to open enums (string with documented values). Implementations MUST accept unrecognized values gracefully for forward/backward compatibility.
 - **2026-04-23**: Post-checkout alignment — 3-field quantity model (`ordered`/`current`/`fulfilled`), line item status (`processing`/`partial`/`fulfilled`/`removed`), order status `delivered`→`completed`, fulfillment event types (add `canceled`/`undeliverable`, rename `returned`→`returned_to_sender`), adjustment types (merge `refund`+`partial_refund`, rename `store_credit`→`credit`, add `price_adjustment`, merge `chargeback` into `dispute`)
 - **2026-02-11**: Totals alignment — Replaced flat `OrderTotals` object with `Total[]` array (reusing checkout spec's `Total` schema); added `amount_refunded` to `Total.type` enum
 - **2026-02-10**: Review feedback — Extended Order.status enum (`created`, `manual_review`); added `amount_refunded` to OrderTotals; documented `total` as original charge amount; added `digital_delivery` sub-object to Fulfillment; added `ready_for_pickup` status; documented per-type status applicability; clarified `Adjustment.amount` as tax-inclusive; updated webhook spec to compose Order via `$ref`; removed `refunds[]` in favor of `adjustments[]`

--- a/rfcs/rfc.orders.md
+++ b/rfcs/rfc.orders.md
@@ -12,7 +12,7 @@ tracking, and refund visibility to buyers.
 
 ## 1. Scope & Goals
 
-- Enable **per-line-item tracking** with `quantity.ordered` and `quantity.shipped`
+- Enable **per-line-item tracking** with `quantity.ordered`, `quantity.current`, and `quantity.fulfilled`
 - Provide **fulfillment tracking** for shipping, pickup, and digital delivery
 - Support **fulfillment events** as an append-only log of delivery progress
 - Track **adjustments** for refunds, credits, returns, and disputes
@@ -33,7 +33,7 @@ Agents need to answer post-purchase questions:
 |----------|---------------|
 | "Where's my order?" | `fulfillments[]` with tracking info and events |
 | "What did I order?" | `line_items[]` with product details |
-| "Which items shipped?" | `line_items[].quantity.shipped` and fulfillment line item refs |
+| "Which items shipped?" | `line_items[].quantity.fulfilled` and fulfillment line item refs |
 | "Did I get a refund?" | `adjustments[]` with status |
 | "When will it arrive?" | `fulfillments[].estimated_delivery` and event history |
 
@@ -80,15 +80,19 @@ response and progressively add richer data as their systems support it:
 
 ### 3.2 Clear Quantity Semantics
 
-The `quantity` object uses explicit field names:
+The `quantity` object uses a 3-field model:
 
 | Field | Meaning | Mutable? |
 |-------|---------|----------|
-| `ordered` | Quantity originally ordered | Yes (if partially canceled) |
-| `shipped` | Quantity handed to carrier | Yes (increases over time) |
+| `ordered` | Quantity originally ordered | No (immutable) |
+| `current` | Active quantity on the order (may decrease via cancellations/returns) | Yes |
+| `fulfilled` | Quantity that has been fulfilled (shipped, picked up, or digitally delivered) | Yes (increases over time) |
 
-Future-extensible: `delivered`, `returned`, `canceled` can be added as optional
-fields without breaking existing implementations.
+**Status derivation from quantity:**
+- `removed` if `current == 0`
+- `fulfilled` if `fulfilled == current`
+- `partial` if `0 < fulfilled < current`
+- `processing` otherwise
 
 ### 3.3 Fulfillments, Not Shipments
 
@@ -128,7 +132,7 @@ The existing `Order` schema gains optional fields:
 - `manual_review` — Order held for fraud or manual review
 - `processing` — Being prepared
 - `shipped` — All items handed to carrier
-- `delivered` — All items delivered
+- `completed` — All items delivered/received by the buyer regardless of fulfillment method
 - `canceled` — Order canceled
 
 ### 4.2 OrderLineItem
@@ -151,15 +155,17 @@ The existing `Order` schema gains optional fields:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `ordered` | integer (≥1) | Yes | Quantity ordered |
-| `shipped` | integer (≥0) | No | Quantity shipped (default 0) |
+| `ordered` | integer (≥1) | Yes | Quantity originally ordered |
+| `current` | integer (≥0) | Yes | Active quantity (may decrease via cancellations/returns) |
+| `fulfilled` | integer (≥0) | No | Quantity fulfilled (default 0) |
+
+**Line item status values:** `processing`, `partial`, `fulfilled`, `removed`
 
 **Line item status derivation:**
-- `processing` — `shipped == 0`
-- `partial` — `0 < shipped < ordered`
-- `shipped` — `shipped == ordered`
-- `delivered` — All units delivered (derived from fulfillment events)
-- `canceled` — Line item canceled
+- `removed` — `current == 0`
+- `fulfilled` — `fulfilled == current`
+- `partial` — `0 < fulfilled < current`
+- `processing` — otherwise
 
 ### 4.3 Fulfillment
 
@@ -235,11 +241,13 @@ applicable statuses for each type:
 - `processing` — Being prepared
 - `shipped` — Handed to carrier
 - `in_transit` — In carrier network
-- `out_for_delivery` — On delivery vehicle
-- `ready_for_pickup` — Ready for customer pickup
+- `out_for_delivery` — On delivery vehicle (ACP extension)
+- `ready_for_pickup` — Ready for customer pickup (ACP extension)
 - `delivered` — Successfully delivered
 - `failed_attempt` — Delivery attempt failed
-- `returned` — Returned to sender
+- `returned_to_sender` — Returned to sender
+- `canceled` — Fulfillment canceled
+- `undeliverable` — Cannot be delivered
 
 ### 4.5 Adjustment
 
@@ -256,14 +264,13 @@ applicable statuses for each type:
 | `reason` | string | No | Structured reason code |
 
 **Adjustment type values:**
-- `refund` — Full refund
-- `partial_refund` — Partial refund
-- `store_credit` — Store credit issued
+- `refund` — Refund (full or partial — distinguish by amount)
+- `credit` — Store credit issued
 - `return` — Item return processed
 - `exchange` — Item exchanged
+- `price_adjustment` — Price change (e.g., price match, coupon applied post-purchase)
 - `cancellation` — Order/item canceled
-- `dispute` — Dispute opened
-- `chargeback` — Chargeback received
+- `dispute` — Dispute or chargeback
 
 **Adjustment status values:**
 - `pending` — In progress
@@ -317,15 +324,15 @@ Order with one fulfilled and one pending fulfillment:
     {
       "id": "li_shoes",
       "title": "Running Shoes",
-      "quantity": { "ordered": 3, "shipped": 3 },
+      "quantity": { "ordered": 3, "current": 3, "fulfilled": 3 },
       "unit_price": 9900,
       "subtotal": 29700,
-      "status": "shipped"
+      "status": "fulfilled"
     },
     {
       "id": "li_shirts",
       "title": "Cotton T-Shirt",
-      "quantity": { "ordered": 2, "shipped": 0 },
+      "quantity": { "ordered": 2, "current": 2, "fulfilled": 0 },
       "unit_price": 2500,
       "subtotal": 5000,
       "status": "processing"
@@ -376,15 +383,15 @@ original charged amount:
   "id": "ord_456",
   "checkout_session_id": "cs_789",
   "permalink_url": "https://merchant.com/orders/456",
-  "status": "delivered",
+  "status": "completed",
   "line_items": [
     {
       "id": "li_headphones",
       "title": "Wireless Headphones",
-      "quantity": { "ordered": 2, "shipped": 2 },
+      "quantity": { "ordered": 2, "current": 2, "fulfilled": 2 },
       "unit_price": 14900,
       "subtotal": 29800,
-      "status": "delivered"
+      "status": "fulfilled"
     }
   ],
   "adjustments": [
@@ -419,15 +426,15 @@ Order with a software license delivered digitally:
   "id": "ord_789",
   "checkout_session_id": "cs_012",
   "permalink_url": "https://merchant.com/orders/789",
-  "status": "delivered",
+  "status": "completed",
   "line_items": [
     {
       "id": "li_software",
       "title": "Pro Photo Editor - Annual License",
-      "quantity": { "ordered": 1, "shipped": 1 },
+      "quantity": { "ordered": 1, "current": 1, "fulfilled": 1 },
       "unit_price": 9900,
       "subtotal": 9900,
-      "status": "delivered"
+      "status": "fulfilled"
     }
   ],
   "fulfillments": [
@@ -485,24 +492,24 @@ Existing integrations that previously used `refunds[]` MUST migrate to
 
 ### 7.1 Status Derivation
 
-Merchants MAY derive `status` fields from the event log:
+Merchants MAY derive `status` fields from the quantity fields:
 
 **Line item status:**
 ```
-if (shipped == 0) → "processing"
-if (shipped > 0 && shipped < ordered) → "partial"
-if (shipped == ordered) → "shipped"
-// Check fulfillment events for "delivered" status
+if (current == 0) → "removed"
+if (fulfilled == current) → "fulfilled"
+if (fulfilled > 0 && fulfilled < current) → "partial"
+else → "processing"
 ```
 
 **Order status:**
 ```
 if (order just received) → "created"
 if (held for review) → "manual_review"
-if (all line items canceled) → "canceled"
-if (all line items delivered) → "delivered"
-if (all line items shipped) → "shipped"
-if (any line item shipped) → "processing"
+if (all line items removed) → "canceled"
+if (all fulfillments delivered) → "completed"
+if (all line items fulfilled but not all delivered) → "shipped"
+if (any line item in progress) → "processing"
 else → "confirmed"
 ```
 
@@ -520,6 +527,7 @@ An empty `adjustments: []` array means no post-order changes have occurred.
 
 ## 8. Change Log
 
+- **2026-04-23**: Post-checkout alignment — 3-field quantity model (`ordered`/`current`/`fulfilled`), line item status (`processing`/`partial`/`fulfilled`/`removed`), order status `delivered`→`completed`, fulfillment event types (add `canceled`/`undeliverable`, rename `returned`→`returned_to_sender`), adjustment types (merge `refund`+`partial_refund`, rename `store_credit`→`credit`, add `price_adjustment`, merge `chargeback` into `dispute`)
 - **2026-02-11**: Totals alignment — Replaced flat `OrderTotals` object with `Total[]` array (reusing checkout spec's `Total` schema); added `amount_refunded` to `Total.type` enum
 - **2026-02-10**: Review feedback — Extended Order.status enum (`created`, `manual_review`); added `amount_refunded` to OrderTotals; documented `total` as original charge amount; added `digital_delivery` sub-object to Fulfillment; added `ready_for_pickup` status; documented per-type status applicability; clarified `Adjustment.amount` as tax-inclusive; updated webhook spec to compose Order via `$ref`; removed `refunds[]` in favor of `adjustments[]`
 - **2026-02-05**: Initial draft — Added OrderLineItem, Fulfillment, FulfillmentEvent, Adjustment, OrderTotals schemas

--- a/spec/2026-04-17/json-schema/schema.agentic_checkout.json
+++ b/spec/2026-04-17/json-schema/schema.agentic_checkout.json
@@ -2506,16 +2506,7 @@
         },
         "status": {
           "type": "string",
-          "enum": [
-            "created",
-            "confirmed",
-            "manual_review",
-            "processing",
-            "shipped",
-            "completed",
-            "canceled"
-          ],
-          "description": "Order-level status. 'completed' means all items have been delivered/received regardless of fulfillment method. Distinct from LineItem.status 'fulfilled', which indicates the seller has dispatched the item."
+          "description": "Order-level status. Implementations MUST accept unrecognized values gracefully. Defined values: 'created', 'confirmed', 'manual_review', 'processing', 'shipped', 'completed', 'canceled'. 'completed' means all items have been delivered/received regardless of fulfillment method. Distinct from LineItem.status 'fulfilled', which indicates the seller has dispatched the item."
         },
         "estimated_delivery": {
           "$ref": "#/$defs/EstimatedDelivery",
@@ -2624,13 +2615,7 @@
         },
         "status": {
           "type": "string",
-          "enum": [
-            "processing",
-            "partial",
-            "fulfilled",
-            "removed"
-          ],
-          "description": "Derived from quantity fields: 'removed' if current==0, 'fulfilled' if fulfilled==current, 'partial' if 0<fulfilled<current, 'processing' otherwise."
+          "description": "Derived from quantity fields. Implementations MUST accept unrecognized values gracefully. Defined values: 'processing', 'partial', 'fulfilled', 'removed'. Rules: 'removed' if current==0, 'fulfilled' if fulfilled==current, 'partial' if 0<fulfilled<current, 'processing' otherwise."
         }
       },
       "required": [
@@ -2725,18 +2710,7 @@
         },
         "status": {
           "type": "string",
-          "enum": [
-            "pending",
-            "processing",
-            "shipped",
-            "in_transit",
-            "out_for_delivery",
-            "ready_for_pickup",
-            "delivered",
-            "failed",
-            "canceled"
-          ],
-          "description": "Current fulfillment status. Not all statuses apply to all types."
+          "description": "Current fulfillment status. Implementations MUST accept unrecognized values gracefully. Defined values: 'pending', 'processing', 'shipped', 'in_transit', 'out_for_delivery', 'ready_for_pickup', 'delivered', 'failed', 'canceled'. Not all statuses apply to all types."
         },
         "line_items": {
           "type": "array",
@@ -2820,19 +2794,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "processing",
-            "shipped",
-            "in_transit",
-            "out_for_delivery",
-            "ready_for_pickup",
-            "delivered",
-            "failed_attempt",
-            "returned_to_sender",
-            "canceled",
-            "undeliverable"
-          ],
-          "description": "Event type. Common fulfillment lifecycle values. 'out_for_delivery' and 'ready_for_pickup' are ACP extensions for richer agent experiences."
+          "description": "Event type. Implementations MUST accept unrecognized values gracefully. Defined values: 'processing', 'shipped', 'in_transit', 'out_for_delivery', 'ready_for_pickup', 'delivered', 'failed_attempt', 'returned_to_sender', 'canceled', 'undeliverable'. 'out_for_delivery' and 'ready_for_pickup' are ACP extensions for richer agent experiences."
         },
         "occurred_at": {
           "type": "string",
@@ -2870,16 +2832,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "refund",
-            "credit",
-            "return",
-            "exchange",
-            "price_adjustment",
-            "cancellation",
-            "dispute"
-          ],
-          "description": "Type of adjustment. Use 'refund' for both full and partial refunds (distinguish by amount). 'credit' replaces 'store_credit'. 'dispute' covers chargebacks."
+          "description": "Type of adjustment. Implementations MUST accept unrecognized values gracefully. Defined values: 'refund', 'credit', 'return', 'exchange', 'price_adjustment', 'cancellation', 'dispute'. Use 'refund' for both full and partial refunds (distinguish by amount). 'credit' replaces 'store_credit'. 'dispute' covers chargebacks."
         },
         "occurred_at": {
           "type": "string",
@@ -2888,12 +2841,7 @@
         },
         "status": {
           "type": "string",
-          "enum": [
-            "pending",
-            "completed",
-            "failed"
-          ],
-          "description": "Adjustment status"
+          "description": "Adjustment status. Implementations MUST accept unrecognized values gracefully. Defined values: 'pending', 'completed', 'failed'."
         },
         "line_items": {
           "type": "array",

--- a/spec/2026-04-17/json-schema/schema.agentic_checkout.json
+++ b/spec/2026-04-17/json-schema/schema.agentic_checkout.json
@@ -2512,10 +2512,10 @@
             "manual_review",
             "processing",
             "shipped",
-            "delivered",
+            "completed",
             "canceled"
           ],
-          "description": "Order-level status. Can be derived from line item and fulfillment statuses."
+          "description": "Order-level status. 'completed' means all items have been delivered/received regardless of fulfillment method. Distinct from LineItem.status 'fulfilled', which indicates the seller has dispatched the item."
         },
         "estimated_delivery": {
           "$ref": "#/$defs/EstimatedDelivery",
@@ -2627,11 +2627,10 @@
           "enum": [
             "processing",
             "partial",
-            "shipped",
-            "delivered",
-            "canceled"
+            "fulfilled",
+            "removed"
           ],
-          "description": "Derived: processing if shipped=0, partial if 0<shipped<ordered, shipped if shipped=ordered"
+          "description": "Derived from quantity fields: 'removed' if current==0, 'fulfilled' if fulfilled==current, 'partial' if 0<fulfilled<current, 'processing' otherwise."
         }
       },
       "required": [
@@ -2641,10 +2640,11 @@
       ],
       "example": {
         "id": "oli_001",
-        "line_item_id": "item_001",
+        "title": "Running Shoes",
         "status": "fulfilled",
         "quantity": {
           "ordered": 2,
+          "current": 2,
           "fulfilled": 2
         }
       }
@@ -2652,27 +2652,33 @@
     "OrderLineItemQuantity": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Quantity tracking for an order line item.",
+      "description": "Quantity tracking for an order line item. Uses a 3-field model: ordered (original), current (active after cancellations/returns), fulfilled (completed).",
       "properties": {
         "ordered": {
           "type": "integer",
           "minimum": 1,
-          "description": "How many the customer ordered"
+          "description": "Quantity originally ordered by the customer"
         },
-        "shipped": {
+        "current": {
           "type": "integer",
           "minimum": 0,
-          "description": "How many have been handed to carrier (optional, default 0)"
+          "description": "Current active quantity on the order. May be less than ordered due to cancellations or returns. A value of 0 means the line item has been fully removed."
+        },
+        "fulfilled": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Quantity that has been fulfilled (shipped, picked up, or digitally delivered). Applies to all fulfillment types, not just shipping."
         }
       },
       "required": [
-        "ordered"
+        "ordered",
+        "current"
       ],
       "example": {
-        "ordered": 2,
-        "fulfilled": 2,
-        "cancelled": 0,
-        "returned": 0
+        "ordered": 3,
+        "current": 3,
+        "fulfilled": 2
       }
     },
     "LineItemReference": {
@@ -2822,9 +2828,11 @@
             "ready_for_pickup",
             "delivered",
             "failed_attempt",
-            "returned"
+            "returned_to_sender",
+            "canceled",
+            "undeliverable"
           ],
-          "description": "Event type"
+          "description": "Event type. Common fulfillment lifecycle values. 'out_for_delivery' and 'ready_for_pickup' are ACP extensions for richer agent experiences."
         },
         "occurred_at": {
           "type": "string",
@@ -2864,15 +2872,14 @@
           "type": "string",
           "enum": [
             "refund",
-            "partial_refund",
-            "store_credit",
+            "credit",
             "return",
             "exchange",
+            "price_adjustment",
             "cancellation",
-            "dispute",
-            "chargeback"
+            "dispute"
           ],
-          "description": "Type of adjustment"
+          "description": "Type of adjustment. Use 'refund' for both full and partial refunds (distinguish by amount). 'credit' replaces 'store_credit'. 'dispute' covers chargebacks."
         },
         "occurred_at": {
           "type": "string",

--- a/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
+++ b/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
@@ -2186,15 +2186,7 @@ components:
           description: Permanent URL where the customer can view order details
         status:
           type: string
-          enum:
-            - created
-            - confirmed
-            - manual_review
-            - processing
-            - shipped
-            - completed
-            - canceled
-          description: "Order-level status. 'completed' means all items have been delivered/received regardless of fulfillment method. Distinct from LineItem.status 'fulfilled', which indicates the seller has dispatched the item."
+          description: "Order-level status. Implementations MUST accept unrecognized values gracefully. Defined values: 'created', 'confirmed', 'manual_review', 'processing', 'shipped', 'completed', 'canceled'. 'completed' means all items have been delivered/received regardless of fulfillment method. Distinct from LineItem.status 'fulfilled', which indicates the seller has dispatched the item."
         estimated_delivery:
           $ref: "#/components/schemas/EstimatedDelivery"
         confirmation:
@@ -2273,12 +2265,7 @@ components:
           description: Optional line-item level totals breakdown using the same Total schema as checkout. Merchants who can provide richer breakdowns MAY use this alongside or instead of unit_price/subtotal.
         status:
           type: string
-          enum:
-            - processing
-            - partial
-            - fulfilled
-            - removed
-          description: "Derived from quantity fields: 'removed' if current==0, 'fulfilled' if fulfilled==current, 'partial' if 0<fulfilled<current, 'processing' otherwise."
+          description: "Derived from quantity fields. Implementations MUST accept unrecognized values gracefully. Defined values: 'processing', 'partial', 'fulfilled', 'removed'. Rules: 'removed' if current==0, 'fulfilled' if fulfilled==current, 'partial' if 0<fulfilled<current, 'processing' otherwise."
       required:
         - id
         - title
@@ -2351,18 +2338,8 @@ components:
           description: Fulfillment method type
         status:
           type: string
-          enum:
-            - pending
-            - processing
-            - shipped
-            - in_transit
-            - out_for_delivery
-            - ready_for_pickup
-            - delivered
-            - failed
-            - canceled
           description: |
-            Current fulfillment status. Not all statuses apply to all types:
+            Current fulfillment status. Implementations MUST accept unrecognized values gracefully. Defined values: 'pending', 'processing', 'shipped', 'in_transit', 'out_for_delivery', 'ready_for_pickup', 'delivered', 'failed', 'canceled'. Not all statuses apply to all types:
             - shipping: pending, processing, shipped, in_transit, out_for_delivery, delivered, failed, canceled
             - pickup: pending, processing, ready_for_pickup, delivered, failed, canceled
             - digital: pending, processing, delivered, failed, canceled
@@ -2428,18 +2405,7 @@ components:
           description: Event identifier
         type:
           type: string
-          enum:
-            - processing
-            - shipped
-            - in_transit
-            - out_for_delivery
-            - ready_for_pickup
-            - delivered
-            - failed_attempt
-            - returned_to_sender
-            - canceled
-            - undeliverable
-          description: "Event type. Common fulfillment lifecycle values. 'out_for_delivery' and 'ready_for_pickup' are ACP extensions for richer agent experiences."
+          description: "Event type. Implementations MUST accept unrecognized values gracefully. Defined values: 'processing', 'shipped', 'in_transit', 'out_for_delivery', 'ready_for_pickup', 'delivered', 'failed_attempt', 'returned_to_sender', 'canceled', 'undeliverable'. 'out_for_delivery' and 'ready_for_pickup' are ACP extensions for richer agent experiences."
         occurred_at:
           type: string
           format: date-time
@@ -2468,26 +2434,14 @@ components:
           description: Adjustment identifier
         type:
           type: string
-          enum:
-            - refund
-            - credit
-            - return
-            - exchange
-            - price_adjustment
-            - cancellation
-            - dispute
-          description: "Type of adjustment. Use 'refund' for both full and partial refunds (distinguish by amount). 'credit' replaces 'store_credit'. 'dispute' covers chargebacks."
+          description: "Type of adjustment. Implementations MUST accept unrecognized values gracefully. Defined values: 'refund', 'credit', 'return', 'exchange', 'price_adjustment', 'cancellation', 'dispute'. Use 'refund' for both full and partial refunds (distinguish by amount). 'credit' replaces 'store_credit'. 'dispute' covers chargebacks."
         occurred_at:
           type: string
           format: date-time
           description: RFC 3339 timestamp when this adjustment occurred
         status:
           type: string
-          enum:
-            - pending
-            - completed
-            - failed
-          description: Adjustment status
+          description: "Adjustment status. Implementations MUST accept unrecognized values gracefully. Defined values: 'pending', 'completed', 'failed'."
         line_items:
           type: array
           items:

--- a/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
+++ b/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
@@ -2192,9 +2192,9 @@ components:
             - manual_review
             - processing
             - shipped
-            - delivered
+            - completed
             - canceled
-          description: Order-level status. Can be derived from line item and fulfillment statuses.
+          description: "Order-level status. 'completed' means all items have been delivered/received regardless of fulfillment method. Distinct from LineItem.status 'fulfilled', which indicates the seller has dispatched the item."
         estimated_delivery:
           $ref: "#/components/schemas/EstimatedDelivery"
         confirmation:
@@ -2276,41 +2276,46 @@ components:
           enum:
             - processing
             - partial
-            - shipped
-            - delivered
-            - canceled
-          description: "Derived: processing if shipped=0, partial if 0<shipped<ordered, shipped if shipped=ordered"
+            - fulfilled
+            - removed
+          description: "Derived from quantity fields: 'removed' if current==0, 'fulfilled' if fulfilled==current, 'partial' if 0<fulfilled<current, 'processing' otherwise."
       required:
         - id
         - title
         - quantity
       example:
         id: oli_001
-        line_item_id: item_001
+        title: Running Shoes
         status: fulfilled
         quantity:
           ordered: 2
+          current: 2
           fulfilled: 2
     OrderLineItemQuantity:
       type: object
       additionalProperties: false
-      description: Quantity tracking for an order line item. 'shipped' is optional and defaults to 0.
+      description: "Quantity tracking for an order line item. Uses a 3-field model: ordered (original), current (active after cancellations/returns), fulfilled (completed)."
       properties:
         ordered:
           type: integer
           minimum: 1
-          description: How many the customer ordered
-        shipped:
+          description: Quantity originally ordered by the customer
+        current:
           type: integer
           minimum: 0
-          description: How many have been handed to carrier (optional, default 0)
+          description: Current active quantity on the order. May be less than ordered due to cancellations or returns. A value of 0 means the line item has been fully removed.
+        fulfilled:
+          type: integer
+          minimum: 0
+          default: 0
+          description: Quantity that has been fulfilled (shipped, picked up, or digitally delivered). Applies to all fulfillment types, not just shipping.
       required:
         - ordered
+        - current
       example:
-        ordered: 2
+        ordered: 3
+        current: 3
         fulfilled: 2
-        cancelled: 0
-        returned: 0
     LineItemReference:
       type: object
       additionalProperties: false
@@ -2431,8 +2436,10 @@ components:
             - ready_for_pickup
             - delivered
             - failed_attempt
-            - returned
-          description: Event type
+            - returned_to_sender
+            - canceled
+            - undeliverable
+          description: "Event type. Common fulfillment lifecycle values. 'out_for_delivery' and 'ready_for_pickup' are ACP extensions for richer agent experiences."
         occurred_at:
           type: string
           format: date-time
@@ -2463,14 +2470,13 @@ components:
           type: string
           enum:
             - refund
-            - partial_refund
-            - store_credit
+            - credit
             - return
             - exchange
+            - price_adjustment
             - cancellation
             - dispute
-            - chargeback
-          description: Type of adjustment
+          description: "Type of adjustment. Use 'refund' for both full and partial refunds (distinguish by amount). 'credit' replaces 'store_credit'. 'dispute' covers chargebacks."
         occurred_at:
           type: string
           format: date-time

--- a/spec/2026-04-17/openapi/openapi.agentic_checkout_webhook.yaml
+++ b/spec/2026-04-17/openapi/openapi.agentic_checkout_webhook.yaml
@@ -224,8 +224,7 @@ components:
       properties:
         type:
           type: string
-          enum: [order_create, order_update]
-          description: "Event type: order_create for new orders, order_update for changes to existing orders"
+          description: "Event type. Implementations MUST accept unrecognized values gracefully. Defined values: 'order_create', 'order_update'. order_create for new orders, order_update for changes to existing orders."
         data:
           $ref: "#/components/schemas/EventDataOrder"
           description: "The order object associated with this event"

--- a/spec/2026-04-17/openapi/openapi.agentic_checkout_webhook.yaml
+++ b/spec/2026-04-17/openapi/openapi.agentic_checkout_webhook.yaml
@@ -83,7 +83,7 @@ paths:
                     line_items:
                       - id: "li_shoes"
                         title: "Running Shoes"
-                        quantity: { ordered: 1, shipped: 0 }
+                        quantity: { ordered: 1, current: 1, fulfilled: 0 }
                         unit_price: 9900
                         subtotal: 9900
                     totals:
@@ -104,10 +104,10 @@ paths:
                     line_items:
                       - id: "li_shoes"
                         title: "Running Shoes"
-                        quantity: { ordered: 1, shipped: 1 }
+                        quantity: { ordered: 1, current: 1, fulfilled: 1 }
                         unit_price: 9900
                         subtotal: 9900
-                        status: "shipped"
+                        status: "fulfilled"
                     fulfillments:
                       - id: "ful_1"
                         type: "shipping"
@@ -136,7 +136,7 @@ paths:
                     id: "ord_456"
                     checkout_session_id: "checkout_session_456"
                     permalink_url: "https://example.com/orders/456"
-                    status: delivered
+                    status: completed
                     adjustments:
                       - id: "adj_1"
                         type: "refund"
@@ -236,8 +236,7 @@ components:
           type: "order"
           checkout_session_id: "cs_01HV3P3ABC123"
           permalink_url: "https://merchant.example.com/orders/ord_123456"
-          status: "shipped"
-          refunds: []
+          status: "processing"
 
     Error:
       type: object

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -2506,16 +2506,7 @@
         },
         "status": {
           "type": "string",
-          "enum": [
-            "created",
-            "confirmed",
-            "manual_review",
-            "processing",
-            "shipped",
-            "completed",
-            "canceled"
-          ],
-          "description": "Order-level status. 'completed' means all items have been delivered/received regardless of fulfillment method. Distinct from LineItem.status 'fulfilled', which indicates the seller has dispatched the item."
+          "description": "Order-level status. Implementations MUST accept unrecognized values gracefully. Defined values: 'created', 'confirmed', 'manual_review', 'processing', 'shipped', 'completed', 'canceled'. 'completed' means all items have been delivered/received regardless of fulfillment method. Distinct from LineItem.status 'fulfilled', which indicates the seller has dispatched the item."
         },
         "estimated_delivery": {
           "$ref": "#/$defs/EstimatedDelivery",
@@ -2624,13 +2615,7 @@
         },
         "status": {
           "type": "string",
-          "enum": [
-            "processing",
-            "partial",
-            "fulfilled",
-            "removed"
-          ],
-          "description": "Derived from quantity fields: 'removed' if current==0, 'fulfilled' if fulfilled==current, 'partial' if 0<fulfilled<current, 'processing' otherwise."
+          "description": "Derived from quantity fields. Implementations MUST accept unrecognized values gracefully. Defined values: 'processing', 'partial', 'fulfilled', 'removed'. Rules: 'removed' if current==0, 'fulfilled' if fulfilled==current, 'partial' if 0<fulfilled<current, 'processing' otherwise."
         }
       },
       "required": [
@@ -2725,18 +2710,7 @@
         },
         "status": {
           "type": "string",
-          "enum": [
-            "pending",
-            "processing",
-            "shipped",
-            "in_transit",
-            "out_for_delivery",
-            "ready_for_pickup",
-            "delivered",
-            "failed",
-            "canceled"
-          ],
-          "description": "Current fulfillment status. Not all statuses apply to all types."
+          "description": "Current fulfillment status. Implementations MUST accept unrecognized values gracefully. Defined values: 'pending', 'processing', 'shipped', 'in_transit', 'out_for_delivery', 'ready_for_pickup', 'delivered', 'failed', 'canceled'. Not all statuses apply to all types."
         },
         "line_items": {
           "type": "array",
@@ -2820,19 +2794,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "processing",
-            "shipped",
-            "in_transit",
-            "out_for_delivery",
-            "ready_for_pickup",
-            "delivered",
-            "failed_attempt",
-            "returned_to_sender",
-            "canceled",
-            "undeliverable"
-          ],
-          "description": "Event type. Common fulfillment lifecycle values. 'out_for_delivery' and 'ready_for_pickup' are ACP extensions for richer agent experiences."
+          "description": "Event type. Implementations MUST accept unrecognized values gracefully. Defined values: 'processing', 'shipped', 'in_transit', 'out_for_delivery', 'ready_for_pickup', 'delivered', 'failed_attempt', 'returned_to_sender', 'canceled', 'undeliverable'. 'out_for_delivery' and 'ready_for_pickup' are ACP extensions for richer agent experiences."
         },
         "occurred_at": {
           "type": "string",
@@ -2870,16 +2832,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "refund",
-            "credit",
-            "return",
-            "exchange",
-            "price_adjustment",
-            "cancellation",
-            "dispute"
-          ],
-          "description": "Type of adjustment. Use 'refund' for both full and partial refunds (distinguish by amount). 'credit' replaces 'store_credit'. 'dispute' covers chargebacks."
+          "description": "Type of adjustment. Implementations MUST accept unrecognized values gracefully. Defined values: 'refund', 'credit', 'return', 'exchange', 'price_adjustment', 'cancellation', 'dispute'. Use 'refund' for both full and partial refunds (distinguish by amount). 'credit' replaces 'store_credit'. 'dispute' covers chargebacks."
         },
         "occurred_at": {
           "type": "string",
@@ -2888,12 +2841,7 @@
         },
         "status": {
           "type": "string",
-          "enum": [
-            "pending",
-            "completed",
-            "failed"
-          ],
-          "description": "Adjustment status"
+          "description": "Adjustment status. Implementations MUST accept unrecognized values gracefully. Defined values: 'pending', 'completed', 'failed'."
         },
         "line_items": {
           "type": "array",

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -2512,10 +2512,10 @@
             "manual_review",
             "processing",
             "shipped",
-            "delivered",
+            "completed",
             "canceled"
           ],
-          "description": "Order-level status. Can be derived from line item and fulfillment statuses."
+          "description": "Order-level status. 'completed' means all items have been delivered/received regardless of fulfillment method. Distinct from LineItem.status 'fulfilled', which indicates the seller has dispatched the item."
         },
         "estimated_delivery": {
           "$ref": "#/$defs/EstimatedDelivery",
@@ -2627,11 +2627,10 @@
           "enum": [
             "processing",
             "partial",
-            "shipped",
-            "delivered",
-            "canceled"
+            "fulfilled",
+            "removed"
           ],
-          "description": "Derived: processing if shipped=0, partial if 0<shipped<ordered, shipped if shipped=ordered"
+          "description": "Derived from quantity fields: 'removed' if current==0, 'fulfilled' if fulfilled==current, 'partial' if 0<fulfilled<current, 'processing' otherwise."
         }
       },
       "required": [
@@ -2641,10 +2640,11 @@
       ],
       "example": {
         "id": "oli_001",
-        "line_item_id": "item_001",
+        "title": "Running Shoes",
         "status": "fulfilled",
         "quantity": {
           "ordered": 2,
+          "current": 2,
           "fulfilled": 2
         }
       }
@@ -2652,27 +2652,33 @@
     "OrderLineItemQuantity": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Quantity tracking for an order line item.",
+      "description": "Quantity tracking for an order line item. Uses a 3-field model: ordered (original), current (active after cancellations/returns), fulfilled (completed).",
       "properties": {
         "ordered": {
           "type": "integer",
           "minimum": 1,
-          "description": "How many the customer ordered"
+          "description": "Quantity originally ordered by the customer"
         },
-        "shipped": {
+        "current": {
           "type": "integer",
           "minimum": 0,
-          "description": "How many have been handed to carrier (optional, default 0)"
+          "description": "Current active quantity on the order. May be less than ordered due to cancellations or returns. A value of 0 means the line item has been fully removed."
+        },
+        "fulfilled": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Quantity that has been fulfilled (shipped, picked up, or digitally delivered). Applies to all fulfillment types, not just shipping."
         }
       },
       "required": [
-        "ordered"
+        "ordered",
+        "current"
       ],
       "example": {
-        "ordered": 2,
-        "fulfilled": 2,
-        "cancelled": 0,
-        "returned": 0
+        "ordered": 3,
+        "current": 3,
+        "fulfilled": 2
       }
     },
     "LineItemReference": {
@@ -2822,9 +2828,11 @@
             "ready_for_pickup",
             "delivered",
             "failed_attempt",
-            "returned"
+            "returned_to_sender",
+            "canceled",
+            "undeliverable"
           ],
-          "description": "Event type"
+          "description": "Event type. Common fulfillment lifecycle values. 'out_for_delivery' and 'ready_for_pickup' are ACP extensions for richer agent experiences."
         },
         "occurred_at": {
           "type": "string",
@@ -2864,15 +2872,14 @@
           "type": "string",
           "enum": [
             "refund",
-            "partial_refund",
-            "store_credit",
+            "credit",
             "return",
             "exchange",
+            "price_adjustment",
             "cancellation",
-            "dispute",
-            "chargeback"
+            "dispute"
           ],
-          "description": "Type of adjustment"
+          "description": "Type of adjustment. Use 'refund' for both full and partial refunds (distinguish by amount). 'credit' replaces 'store_credit'. 'dispute' covers chargebacks."
         },
         "occurred_at": {
           "type": "string",

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -2186,15 +2186,7 @@ components:
           description: Permanent URL where the customer can view order details
         status:
           type: string
-          enum:
-            - created
-            - confirmed
-            - manual_review
-            - processing
-            - shipped
-            - completed
-            - canceled
-          description: "Order-level status. 'completed' means all items have been delivered/received regardless of fulfillment method. Distinct from LineItem.status 'fulfilled', which indicates the seller has dispatched the item."
+          description: "Order-level status. Implementations MUST accept unrecognized values gracefully. Defined values: 'created', 'confirmed', 'manual_review', 'processing', 'shipped', 'completed', 'canceled'. 'completed' means all items have been delivered/received regardless of fulfillment method. Distinct from LineItem.status 'fulfilled', which indicates the seller has dispatched the item."
         estimated_delivery:
           $ref: "#/components/schemas/EstimatedDelivery"
         confirmation:
@@ -2273,12 +2265,7 @@ components:
           description: Optional line-item level totals breakdown using the same Total schema as checkout. Merchants who can provide richer breakdowns MAY use this alongside or instead of unit_price/subtotal.
         status:
           type: string
-          enum:
-            - processing
-            - partial
-            - fulfilled
-            - removed
-          description: "Derived from quantity fields: 'removed' if current==0, 'fulfilled' if fulfilled==current, 'partial' if 0<fulfilled<current, 'processing' otherwise."
+          description: "Derived from quantity fields. Implementations MUST accept unrecognized values gracefully. Defined values: 'processing', 'partial', 'fulfilled', 'removed'. Rules: 'removed' if current==0, 'fulfilled' if fulfilled==current, 'partial' if 0<fulfilled<current, 'processing' otherwise."
       required:
         - id
         - title
@@ -2351,18 +2338,8 @@ components:
           description: Fulfillment method type
         status:
           type: string
-          enum:
-            - pending
-            - processing
-            - shipped
-            - in_transit
-            - out_for_delivery
-            - ready_for_pickup
-            - delivered
-            - failed
-            - canceled
           description: |
-            Current fulfillment status. Not all statuses apply to all types:
+            Current fulfillment status. Implementations MUST accept unrecognized values gracefully. Defined values: 'pending', 'processing', 'shipped', 'in_transit', 'out_for_delivery', 'ready_for_pickup', 'delivered', 'failed', 'canceled'. Not all statuses apply to all types:
             - shipping: pending, processing, shipped, in_transit, out_for_delivery, delivered, failed, canceled
             - pickup: pending, processing, ready_for_pickup, delivered, failed, canceled
             - digital: pending, processing, delivered, failed, canceled
@@ -2428,18 +2405,7 @@ components:
           description: Event identifier
         type:
           type: string
-          enum:
-            - processing
-            - shipped
-            - in_transit
-            - out_for_delivery
-            - ready_for_pickup
-            - delivered
-            - failed_attempt
-            - returned_to_sender
-            - canceled
-            - undeliverable
-          description: "Event type. Common fulfillment lifecycle values. 'out_for_delivery' and 'ready_for_pickup' are ACP extensions for richer agent experiences."
+          description: "Event type. Implementations MUST accept unrecognized values gracefully. Defined values: 'processing', 'shipped', 'in_transit', 'out_for_delivery', 'ready_for_pickup', 'delivered', 'failed_attempt', 'returned_to_sender', 'canceled', 'undeliverable'. 'out_for_delivery' and 'ready_for_pickup' are ACP extensions for richer agent experiences."
         occurred_at:
           type: string
           format: date-time
@@ -2468,26 +2434,14 @@ components:
           description: Adjustment identifier
         type:
           type: string
-          enum:
-            - refund
-            - credit
-            - return
-            - exchange
-            - price_adjustment
-            - cancellation
-            - dispute
-          description: "Type of adjustment. Use 'refund' for both full and partial refunds (distinguish by amount). 'credit' replaces 'store_credit'. 'dispute' covers chargebacks."
+          description: "Type of adjustment. Implementations MUST accept unrecognized values gracefully. Defined values: 'refund', 'credit', 'return', 'exchange', 'price_adjustment', 'cancellation', 'dispute'. Use 'refund' for both full and partial refunds (distinguish by amount). 'credit' replaces 'store_credit'. 'dispute' covers chargebacks."
         occurred_at:
           type: string
           format: date-time
           description: RFC 3339 timestamp when this adjustment occurred
         status:
           type: string
-          enum:
-            - pending
-            - completed
-            - failed
-          description: Adjustment status
+          description: "Adjustment status. Implementations MUST accept unrecognized values gracefully. Defined values: 'pending', 'completed', 'failed'."
         line_items:
           type: array
           items:

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -2192,9 +2192,9 @@ components:
             - manual_review
             - processing
             - shipped
-            - delivered
+            - completed
             - canceled
-          description: Order-level status. Can be derived from line item and fulfillment statuses.
+          description: "Order-level status. 'completed' means all items have been delivered/received regardless of fulfillment method. Distinct from LineItem.status 'fulfilled', which indicates the seller has dispatched the item."
         estimated_delivery:
           $ref: "#/components/schemas/EstimatedDelivery"
         confirmation:
@@ -2276,41 +2276,46 @@ components:
           enum:
             - processing
             - partial
-            - shipped
-            - delivered
-            - canceled
-          description: "Derived: processing if shipped=0, partial if 0<shipped<ordered, shipped if shipped=ordered"
+            - fulfilled
+            - removed
+          description: "Derived from quantity fields: 'removed' if current==0, 'fulfilled' if fulfilled==current, 'partial' if 0<fulfilled<current, 'processing' otherwise."
       required:
         - id
         - title
         - quantity
       example:
         id: oli_001
-        line_item_id: item_001
+        title: Running Shoes
         status: fulfilled
         quantity:
           ordered: 2
+          current: 2
           fulfilled: 2
     OrderLineItemQuantity:
       type: object
       additionalProperties: false
-      description: Quantity tracking for an order line item. 'shipped' is optional and defaults to 0.
+      description: "Quantity tracking for an order line item. Uses a 3-field model: ordered (original), current (active after cancellations/returns), fulfilled (completed)."
       properties:
         ordered:
           type: integer
           minimum: 1
-          description: How many the customer ordered
-        shipped:
+          description: Quantity originally ordered by the customer
+        current:
           type: integer
           minimum: 0
-          description: How many have been handed to carrier (optional, default 0)
+          description: Current active quantity on the order. May be less than ordered due to cancellations or returns. A value of 0 means the line item has been fully removed.
+        fulfilled:
+          type: integer
+          minimum: 0
+          default: 0
+          description: Quantity that has been fulfilled (shipped, picked up, or digitally delivered). Applies to all fulfillment types, not just shipping.
       required:
         - ordered
+        - current
       example:
-        ordered: 2
+        ordered: 3
+        current: 3
         fulfilled: 2
-        cancelled: 0
-        returned: 0
     LineItemReference:
       type: object
       additionalProperties: false
@@ -2431,8 +2436,10 @@ components:
             - ready_for_pickup
             - delivered
             - failed_attempt
-            - returned
-          description: Event type
+            - returned_to_sender
+            - canceled
+            - undeliverable
+          description: "Event type. Common fulfillment lifecycle values. 'out_for_delivery' and 'ready_for_pickup' are ACP extensions for richer agent experiences."
         occurred_at:
           type: string
           format: date-time
@@ -2463,14 +2470,13 @@ components:
           type: string
           enum:
             - refund
-            - partial_refund
-            - store_credit
+            - credit
             - return
             - exchange
+            - price_adjustment
             - cancellation
             - dispute
-            - chargeback
-          description: Type of adjustment
+          description: "Type of adjustment. Use 'refund' for both full and partial refunds (distinguish by amount). 'credit' replaces 'store_credit'. 'dispute' covers chargebacks."
         occurred_at:
           type: string
           format: date-time

--- a/spec/unreleased/openapi/openapi.agentic_checkout_webhook.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout_webhook.yaml
@@ -224,8 +224,7 @@ components:
       properties:
         type:
           type: string
-          enum: [order_create, order_update]
-          description: "Event type: order_create for new orders, order_update for changes to existing orders"
+          description: "Event type. Implementations MUST accept unrecognized values gracefully. Defined values: 'order_create', 'order_update'. order_create for new orders, order_update for changes to existing orders."
         data:
           $ref: "#/components/schemas/EventDataOrder"
           description: "The order object associated with this event"

--- a/spec/unreleased/openapi/openapi.agentic_checkout_webhook.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout_webhook.yaml
@@ -83,7 +83,7 @@ paths:
                     line_items:
                       - id: "li_shoes"
                         title: "Running Shoes"
-                        quantity: { ordered: 1, shipped: 0 }
+                        quantity: { ordered: 1, current: 1, fulfilled: 0 }
                         unit_price: 9900
                         subtotal: 9900
                     totals:
@@ -104,10 +104,10 @@ paths:
                     line_items:
                       - id: "li_shoes"
                         title: "Running Shoes"
-                        quantity: { ordered: 1, shipped: 1 }
+                        quantity: { ordered: 1, current: 1, fulfilled: 1 }
                         unit_price: 9900
                         subtotal: 9900
-                        status: "shipped"
+                        status: "fulfilled"
                     fulfillments:
                       - id: "ful_1"
                         type: "shipping"
@@ -136,7 +136,7 @@ paths:
                     id: "ord_456"
                     checkout_session_id: "checkout_session_456"
                     permalink_url: "https://example.com/orders/456"
-                    status: delivered
+                    status: completed
                     adjustments:
                       - id: "adj_1"
                         type: "refund"
@@ -236,8 +236,7 @@ components:
           type: "order"
           checkout_session_id: "cs_01HV3P3ABC123"
           permalink_url: "https://merchant.example.com/orders/ord_123456"
-          status: "shipped"
-          refunds: []
+          status: "processing"
 
     Error:
       type: object


### PR DESCRIPTION
# SEP: Order Schema — Post-Checkout Alignment

## 📋 SEP Metadata

- **SEP Number**:  https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/issues/233
- **Status**: `proposal` 
- **Type**: [x] Major Change [ ] Process Change
- **Related Issues/RFCs**: `rfcs/rfc.orders.md`

---

## 🎯 Abstract

This SEP updates the Order schema to support the full post-checkout order lifecycle —
shipping, fulfillment, cancellations, returns, and refunds — with clear, unambiguous
semantics at every level.

The changes fall into five areas: (1) a 3-field quantity model replacing the 2-field model,
(2) fulfillment-type-agnostic line item statuses, (3) a renamed order-level status to avoid
semantic overloading, (4) expanded fulfillment event types for terminal states, and
(5) simplified adjustment types that remove redundancy.

---

## 💡 Motivation

Sellers send order events — shipping, refunds, cancellations — to platforms, which fan them
out to agents. The order model needs clear, unambiguous semantics to support this pipeline
end-to-end.

Five problems in the current schema motivate this change:

1. **Quantity model is too narrow.** The 2-field model (`ordered`/`shipped`) cannot represent
   cancellations or returns. There is no way to express "3 ordered, 1 canceled, 2 shipped."

2. **Status values are shipping-centric.** `shipped` and `delivered` as line item statuses
   do not apply to pickup or digital fulfillment.

3. **Fulfillment event types have gaps.** Missing `canceled` and `undeliverable` force
   merchants to misuse `failed_attempt` for terminal failure states. `returned` is ambiguous
   (returned by whom? to whom?).

4. **Adjustment types have redundancy.** `refund`/`partial_refund` is a false distinction
   (the amount already tells you). `store_credit` is jargon. `chargeback` is a subtype of
   `dispute`. `price_adjustment` is missing entirely.

5. **"fulfilled" would be overloaded.** Using `fulfilled` at both the order and line item
   level creates confusion: at line item level it means the seller dispatched the item
   (quantity-derived), while at order level it would mean the buyer received everything.
   Using `completed` at the order level avoids this ambiguity.

---

## 📐 Specification

### 1. LineItem Quantity: 2-field → 3-field model

**Files:** `spec/*/json-schema/schema.agentic_checkout.json`, `spec/*/openapi/openapi.agentic_checkout.yaml`

Old model:

| Field | Type | Required |
|-------|------|----------|
| `ordered` | int ≥ 1 | Yes |
| `shipped` | int ≥ 0 | No (default 0) |

New model:

| Field | Type | Required | Description |
|-------|------|----------|-------------|
| `ordered` | int ≥ 1 | Yes | Quantity originally ordered |
| `current` | int ≥ 0 | Yes | Active quantity (decreases via cancellations/returns; 0 = removed) |
| `fulfilled` | int ≥ 0 | No (default 0) | Quantity fulfilled — shipped, picked up, or digitally delivered |

### 2. LineItem Status: fulfillment-type-agnostic values

Old enum: `[processing, partial, shipped, delivered, canceled]`

New enum: `[processing, partial, fulfilled, removed]`

Derivation (deterministic from quantity fields):
- `removed` if `current == 0`
- `fulfilled` if `fulfilled == current`
- `partial` if `0 < fulfilled < current`
- `processing` otherwise

### 3. Order Status: `delivered` → `completed`

Old enum: `[created, confirmed, manual_review, processing, shipped, delivered, canceled]`

New enum: `[created, confirmed, manual_review, processing, shipped, completed, canceled]`

`completed` means all items have been delivered/received by the buyer. This is deliberately
a different term from LineItem.status `fulfilled` to reflect the different scope:

| Level | Field | Term | Meaning |
|-------|-------|------|---------|
| Order | `status` | `completed` | Buyer has received everything |
| LineItem | `status` | `fulfilled` | Seller's obligation met (item dispatched) |
| Fulfillment | `status` | `delivered` | Delivery confirmed (unchanged) |

### 4. FulfillmentEvent Types: +3, rename 1

Old enum: `[processing, shipped, in_transit, out_for_delivery, ready_for_pickup, delivered, failed_attempt, returned]`

New enum: `[processing, shipped, in_transit, out_for_delivery, ready_for_pickup, delivered, failed_attempt, returned_to_sender, canceled, undeliverable]`

- `returned` → `returned_to_sender` (precision: returned by carrier, not by buyer)
- Added `canceled` (fulfillment canceled before shipment)
- Added `undeliverable` (terminal: address invalid, refused, etc.)

### 5. Adjustment Types: simplified

Old enum: `[refund, partial_refund, store_credit, return, exchange, cancellation, dispute, chargeback]`

New enum: `[refund, credit, return, exchange, price_adjustment, cancellation, dispute]`

- `partial_refund` merged into `refund` (distinguish by amount)
- `store_credit` → `credit`
- `chargeback` merged into `dispute`
- Added `price_adjustment` (price match, post-purchase coupon, etc.)

---

## 🤔 Rationale

**Why a 3-field quantity model?** The 2-field model (`ordered`/`shipped`) cannot represent
the state "3 ordered, 1 canceled, 2 in progress." With `current`, the model captures
post-order modifications (cancellations, returns) independently from fulfillment progress.
This also enables the `removed` status (line item fully canceled) which was previously
conflated with `canceled` (ambiguous — order-level or item-level?).

**Why `completed` instead of `fulfilled` at the order level?** `fulfilled` at the line item
level is quantity-derived and triggers when the seller dispatches the item (at ship time).
At the order level, the natural meaning of "fulfilled" is "everything is done" (customer has
received all items). Using the same word for both creates confusion — a line item can be
`fulfilled` (shipped) while the order is still `shipped` (in transit). `completed`
unambiguously means the entire order lifecycle is done.

**Why rename `returned` → `returned_to_sender`?** In commerce, "return" typically means
buyer-initiated (sending items back for a refund). But in carrier tracking, "returned"
means the carrier returned the package to the sender (failed delivery). `returned_to_sender`
eliminates this ambiguity. Buyer-initiated returns are tracked via the `return` adjustment
type.

**Why merge `refund`/`partial_refund`?** The distinction adds no information — the `amount`
field already tells you whether it's full or partial. Separate types force consumers to
handle two cases that differ only in degree.

**Why merge `chargeback` into `dispute`?** A chargeback is the mechanism by which a dispute
is executed. From the agent's perspective, the distinction is irrelevant — what matters is
that funds are contested. Merchants who need to distinguish can use the `reason` field.

---

## 🔄 Backward Compatibility

**All changes are breaking.** Field renames, enum value changes, and new required fields
(`current`) will break existing consumers that parse order payloads.

**Severity:** High for any integration consuming order webhooks or reading order data.

**Migration path:** ACP is pre-release (unreleased spec), so there are no production
consumers to migrate. These changes are being made now specifically to get the schema right
before the first stable release.

**Specific migrations:**
- `quantity.shipped` → `quantity.fulfilled`
- `quantity.current` is new and required — set to `quantity.ordered` for existing orders with no cancellations
- LineItem `status: "shipped"` → `"fulfilled"`, `"delivered"` → `"fulfilled"`, `"canceled"` → `"removed"`
- Order `status: "delivered"` → `"completed"`
- FulfillmentEvent `type: "returned"` → `"returned_to_sender"`
- Adjustment `type: "partial_refund"` → `"refund"`, `"store_credit"` → `"credit"`, `"chargeback"` → `"dispute"`

---

## 🛠️ Reference Implementation

Not yet available. The schema changes in this PR are the specification; implementation will
follow in the order event fan-out pipeline.

---

## 🔒 Security Implications

No security implications. These are schema/naming changes only — no new endpoints, no
changes to authentication, signing, or authorization.

---

## ✅ Pre-Submission Checklist

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
- [x] I have linked the SEP issue number above
- [x] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] This PR includes updates to OpenAPI/JSON schemas (if applicable)
- [x] This PR includes example requests/responses (if applicable)
- [x] This PR includes a changelog entry file in `changelog/unreleased/order-schema-alignment.md`
- [x] I am seeking or have found a sponsor (Founding Maintainer)

---

## 📚 Additional Context

### Files changed (16 files)

| Category | Files |
|----------|-------|
| JSON Schema | `spec/{unreleased,2026-04-17}/json-schema/schema.agentic_checkout.json` |
| OpenAPI | `spec/{unreleased,2026-04-17}/openapi/openapi.agentic_checkout.yaml` |
| Webhook spec | `spec/{unreleased,2026-04-17}/openapi/openapi.agentic_checkout_webhook.yaml` |
| Examples | `examples/{orders,2026-04-17/orders}/*.json` (8 files) |
| RFC | `rfcs/rfc.orders.md` |
| Changelog | `changelog/unreleased/order-schema-alignment.md` |

### Validation

`node scripts/validate-consistency.js` passes with no errors or warnings.

---

## 🙋 Questions for Reviewers

1. Should `out_for_delivery` and `ready_for_pickup` remain as ACP-specific fulfillment event
   types, or should we trim the enum to only the common set?

2. Should `exchange` remain as an adjustment type? It is ACP-specific and could be modeled
   as a `return` + new order instead.

3. Is `completed` the right term for the order-level terminal status, or would `delivered`
   (matching the Fulfillment.status value) be preferable despite the level-crossing?