### PR TITLE
ADMIN: Add Meta as TSC member

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,5 +4,6 @@ Below are the current maintainers of the Agentic Commerce Protocol.
 
 ## Lead maintainers
 
+- Meta
 - OpenAI
 - Stripe

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,6 @@ Below are the current maintainers of the Agentic Commerce Protocol.
 
 ## Lead maintainers
 
-- Meta
 - OpenAI
 - Stripe
+- Meta

--- a/changelog/unreleased/add-meta-tsc-member.md
+++ b/changelog/unreleased/add-meta-tsc-member.md
@@ -1,0 +1,10 @@
+  # Add Meta as TSC Member
+
+  **Added** -- Meta as a member of the ACP Technical Steering Committee
+
+  ## Overview
+  Meta joins the ACP TSC to help steer the protocol’s development and enable merchants worldwide to participate in agentic commerce.
+
+  ## Changes
+  - **MAINTAINERS.md**: Added Meta to the maintainers list
+  - **docs/governance.md**: Added Meta as Seat 3 on the TSC with @lhwa as the representative.

--- a/changelog/unreleased/add-meta-tsc-member.md
+++ b/changelog/unreleased/add-meta-tsc-member.md
@@ -3,7 +3,7 @@
   **Added** -- Meta as a member of the ACP Technical Steering Committee
 
   ## Overview
-  Meta joins the ACP TSC to help steer the protocol’s development and enable merchants worldwide to participate in agentic commerce.
+  Meta joins the ACP TSC to help advance the protocol’s development and enable merchants worldwide to participate in agentic commerce.
 
   ## Changes
   - **MAINTAINERS.md**: Added Meta to the maintainers list

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -97,6 +97,7 @@ TSC or Founding Maintainers for more details on the process.
 |------|-------------|-------------------|
 | 1    | OpenAI      | aravindrao-openai |
 | 2    | Stripe      | prasad-stripe     |
+| 3    | Meta        | lhwa              |
 
 ---
 


### PR DESCRIPTION
# ADMIN: Add Meta as TSC member

## 🔑 Admin Action

- [x] Other administrative change: Add Meta (Seat 3, representative: @lhwa) to the TSC

---

## 📝 Summary

Adds Meta as a TSC member across project governance files:
- **MAINTAINERS.md**: Added Meta to the maintainers list
- **docs/governance.md**: Added Meta as Seat 3 with @lhwa as representative

---

## ✅ Admin Checklist

- [x] I am an admin or authorized representative
- [x] GitHub username has been validated as a real account