### PR TITLE
chore: Stale PR Reminder Workflow

### DIFF
--- a/.github/workflows/stale-reminder.yml
+++ b/.github/workflows/stale-reminder.yml
@@ -1,0 +1,42 @@
+name: Stale PR Reminder
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Preview only — no comments posted, no labels added'
+        type: boolean
+        default: true
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          debug-only: ${{ inputs.dry_run }}
+
+          # PRs only — disable issues entirely
+          days-before-pr-stale: 90
+          days-before-pr-close: -1          # Never auto-close
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          stale-pr-label: 'stale'
+          exempt-draft-pr: true
+          operations-per-run: 50
+
+          stale-pr-message: |
+            Hi 👋 — Thank you for your contribution to ACP!
+
+            This PR has been inactive (no commits, comments, or reviews) for over 90 days. If this work is still relevant, please:
+            - Rebase onto `main` to resolve any merge conflicts
+            - Address any outstanding review feedback
+            - Leave a comment confirming you'd like to keep this open
+
+            If we don't hear back within **30 days**, this PR may be closed to keep the backlog manageable. You're always welcome to reopen or submit a new PR — no work is lost!
+
+            Thanks for your patience and contributions.

--- a/changelog/unreleased/stale-pr-reminder.md
+++ b/changelog/unreleased/stale-pr-reminder.md
@@ -1,0 +1,17 @@
+# Add Stale PR Reminder Workflow
+
+**Added** -- Stale PR reminder via GitHub Actions
+
+## Overview
+Adds a manually-triggered workflow using `actions/stale@v10` to identify and remind authors of PRs inactive for 90+ days. Comments are posted as
+`github-actions[bot]`. Includes a dry-run mode for previewing affected PRs before sending reminders. No auto-close behavior — closing remains a manual maintainer
+decision.
+
+## Changes
+- **Workflow**: Added `stale-reminder.yml` with `workflow_dispatch` trigger and `dry_run` input toggle
+- **Label**: Requires new `stale` label (gray `#CFD3D7`, description: "PR inactive for 90+ days")
+- **Auto-reset**: Any PR activity (comment, commit, or review) removes the `stale` label and resets the staleness clock
+- **Scope**: PRs only — issues are excluded; draft PRs are exempt
+
+### Files Added
+- `.github/workflows/stale-reminder.yml`


### PR DESCRIPTION
# Add stale PR reminder workflow

## 🔧 Type of Change
- [x] Tooling improvement

| Field | Value |
|-------|-------|
| **Issue** | #239 |
| **Title** | Add stale PR reminder workflow |
| **Author** | Lee Hwa (@lhwa) |
| **Status** | Draft |
| **Type** | Process |
| **Created** | 2026-04-25 |

---

## 📝 Description

Adds a manually-triggered GitHub Actions workflow using `[actions/stale@v10](https://github.com/actions/stale)`  to identify and remind authors of PRs that have been inactive for 90+ days.

Key behaviors:
- **Auto-discovers** all open PRs inactive for 90+ days
- **Posts a friendly reminder** as `github-actions[bot]` (not a personal account)
- **Labels** PRs with `stale` for tracking
- **Auto-resets** — any PR activity (comment, commit, or review) removes the `stale` label and resets the staleness clock
- **Never auto-closes** — closing remains a manual maintainer decision initially
- **Includes a dry-run mode** (default) so maintainers can preview which PRs would be flagged before posting comments
- **Skips draft PRs** and PRs already labeled `stale`
- **PRs only** — issues are excluded (spec discussions are long-lived by nature)

---

## 🎯 Motivation and Context

The ACP repo has PRs that have been inactive for 90+ days — some for over 6 months — with merge conflicts, unsigned CLAs, and no follow-up. There is no mechanism to notify authors or manage the growing backlog. As the project scales, this will continue to accumulate.

This is standard practice across major open-source projects:

| Project | Tool | Stale Threshold | Auto-close? |
|---------|------|----------------|-------------|
| React | `actions/stale@v9` | 90d | Yes |
| Node.js | `actions/stale@v10` | 210d | Yes |
| PyTorch | Custom `github-script` | 60d | Yes |
| Kubernetes | Custom (Prow) | 90d | Yes |

ACP currently has no lifecycle management. This PR adds a conservative first step — manual trigger, reminder only, no auto-close.

Fixes/Addresses: #239

---

## 🧪 Testing

- Validated YAML syntax locally (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- Tested locally with `act --input dry_run=true` against the main repo
  - Workflow ran successfully, identified 37 PRs and 65 issues
  - PRs correctly evaluated against 90-day threshold
  - Issues correctly skipped (`days-before-issue-stale: -1`)
  - Debug mode confirmed: no comments posted, no labels added
- `pnpm run validate:all` passes (no schema changes in this PR)

---

## 📸 Screenshots / Examples

**Workflow trigger UI** (Actions tab → "Stale PR Reminder" → Run workflow):
- `dry_run: true` (default) — preview which PRs would be flagged
- `dry_run: false` — post reminders and add `stale` label

**Reminder message posted on stale PRs:**

> Hi 👋 — Thank you for your contribution to ACP!
>
> This PR has been inactive (no commits, comments, or reviews) for over 90 days. If this work is still relevant, please:
> - Rebase onto `main` to resolve any merge conflicts
> - Address any outstanding review feedback
> - Leave a comment confirming you'd like to keep this open
>
> If we don't hear back within **30 days**, this PR may be closed to keep the backlog manageable. You're always welcome to reopen or submit a new PR — no work is lost!
>
> Thanks for your patience and contributions.

## 📐 Specification

### Workflow: `.github/workflows/stale-reminder.yml`

```yaml
name: Stale PR Reminder

on:
  workflow_dispatch:
    inputs:
      dry_run:
        description: 'Preview only — no comments posted, no labels added'
        type: boolean
        default: true

permissions:
  pull-requests: write

jobs:
  stale:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/stale@v10
        with:
          debug-only: ${{ inputs.dry_run }}

          # PRs only — disable issues entirely
          days-before-pr-stale: 90
          days-before-pr-close: -1          # Never auto-close
          days-before-issue-stale: -1
          days-before-issue-close: -1

          stale-pr-label: 'stale'
          exempt-draft-pr: true
          operations-per-run: 50

          stale-pr-message: |
            Hi 👋 — Thank you for your contribution to ACP!

            This PR has been inactive (no commits, comments, or reviews) for over 90 days. If this work is still relevant, please:
            - Rebase onto `main` to resolve any merge conflicts
            - Address any outstanding review feedback
            - Leave a comment confirming you'd like to keep this open

            If we don't hear back within **30 days**, this PR may be closed to keep the backlog manageable. You're always welcome to reopen or submit a new PR — no work is lost!

            Thanks for your patience and contributions.
```

---

### Label

| Label | Color | Description |
|-------|-------|-------------|
| `stale` | `#CFD3D7` (gray) | PR inactive for 90+ days |

### Behavior

| Aspect | Detail |
|--------|--------|
| **Trigger** | Manual only (`workflow_dispatch`) — no scheduled automation (can be added later to scale) |
| **Scope** | PRs only; issues are excluded |
| **Staleness threshold** | 90 days of inactivity (no commits, comments, or reviews) |
| **Auto-close** | Disabled initially (`days-before-pr-close: -1`) |
| **Dry run** | Default `true` — logs which PRs would be flagged without posting |
| **Draft PRs** | Exempt — not flagged |
| **Duplicate prevention** | PRs already labeled `stale` are skipped |
| **Auto-reset** | Any PR activity (comment, commit, or review) removes the `stale` label and resets the staleness clock |
| **Bot identity** | Comments posted as `github-actions[bot]` |

### Operational flow

1. Maintainer navigates to Actions tab → "Stale PR Reminder"
2. Clicks "Run workflow" with `dry_run: true` (default)
3. Reviews the Actions run log to see which PRs would be flagged
4. If satisfied, runs again with `dry_run: false`
5. Reminder comments are posted and `stale` label is added to identified PRs

## 🤔 Rationale

### Why manual trigger instead of scheduled automation?

Automated daily/weekly runs would add operational overhead without proportional benefit. Manual triggering gives maintainers full control over timing and lets them review the target list before acting. This can evolve to scheduled automation as the project scales.

### Why `actions/stale@v10` instead of custom scripting?

- Official GitHub-maintained action — no third-party dependency
- Built-in dry-run mode (`debug-only`)
- Handles duplicate prevention (skips already-labeled PRs)
- Auto-removes label on activity (`remove-stale-when-updated`)
- Used by React, Node.js, and many other major projects

### Why 90 days?

- Aligns with Kubernetes (90d) and React (90d)
- More generous than PyTorch (60d) and OpenAPI Spec (7d)
- More aggressive than Node.js (210d)

### Why no auto-close?

ACP PRs can require significant design work. For now, we prefer manual closing over auto-close to avoid mistakes and discouraging contributors. The reminder nudges authors to act; maintainers can manually close PRs that remain inactive after the 30-day warning period.

### Why PRs only, not issues?

Issues in a specification project often represent long-lived design discussions, feature requests, or tracking items. Auto-staling issues would create noise. PRs have a clearer lifecycle — they either get merged, updated, or abandoned.

## 🔄 Backward Compatibility

No backward compatibility concerns. This adds a new workflow file and label — no existing behavior is changed.

## 🛠️ Reference Implementation

See the workflow YAML in the Specification section above. The implementation is a single file (`.github/workflows/stale-reminder.yml`) plus one label (`stale`).

## 🔒 Security Implications

- The workflow uses the default `GITHUB_TOKEN` (automatically provided by GitHub Actions) — no additional secrets or tokens required
- `GITHUB_TOKEN` is scoped to the repository with `pull-requests: write` permission only
- No external services are called
- No code is executed beyond the official `actions/stale` action

---

## ✅ Checklist

- [x] I have signed the [[Contributor License Agreement (CLA)](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/legal/cla/INDIVIDUAL.md)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (if applicable)
- [ ] I have added/updated examples (if applicable) — N/A
- [x] I have added a changelog entry file to `changelog/unreleased/stale-pr-reminder.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [x] All CI checks pass

---

## 🔍 Scope Verification

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ **This is a minor, straightforward change**

---

## 📚 Additional Notes

- **Label required**: Create `stale` label (gray `#CFD3D7`, description: "PR inactive for 90+ days") before first live run
- **Future evolution**: Can add scheduled automation (daily/weekly) and three-tier lifecycle (stale→rotten→close) as the project scales
- **Industry references**:
  - [React — shared_stale.yml](https://github.com/facebook/react/blob/main/.github/workflows/shared_stale.yml)
  - [Node.js — stale.yml](https://github.com/nodejs/node/blob/main/.github/workflows/stale.yml)
  - [PyTorch — stale.yml](https://github.com/pytorch/pytorch/blob/main/.github/workflows/stale.yml)
  - [SSWConsulting — pr-manage-stale.yml](https://github.com/SSWConsulting/SSW.GitHub.Template/blob/main/.github/workflows/pr-manage-stale.yml)

## 📚 Additional Context

### Industry examples using `actions/stale`

- [React — shared_stale.yml](https://github.com/facebook/react/blob/main/.github/workflows/shared_stale.yml) — 90d stale, 7d close, hourly cadence
- [Node.js — stale.yml](https://github.com/nodejs/node/blob/main/.github/workflows/stale.yml) — 210d stale, 30d close, daily cadence
- [Node.js — close-stalled.yml](https://github.com/nodejs/node/blob/main/.github/workflows/close-stalled.yml) — manual fast-track via `stalled` label
- [SSWConsulting — pr-manage-stale.yml](https://github.com/SSWConsulting/SSW.GitHub.Template/blob/main/.github/workflows/pr-manage-stale.yml) — simplest example (~25 lines), no auto-close
- [Avalanchego — stale.yml](https://github.com/ava-labs/avalanchego/blob/master/.github/workflows/stale.yml) — uses `lifecycle/stale` and `lifecycle/rotten` labels

### Custom stale workflow examples

- [PyTorch — stale.yml](https://github.com/pytorch/pytorch/blob/main/.github/workflows/stale.yml) — custom `github-script`, 60d stale, PRs only
- [NVIDIA/aicr — inactive-pr-reminder.yaml](https://github.com/NVIDIA/aicr/blob/main/.github/workflows/inactive-pr-reminder.yaml) — custom PR reminder with duplicate-check logic

### Three-tier lifecycle (future consideration)

- [llm-d — stale-issues.yaml](https://github.com/llm-d/llm-d-infra/blob/main/.github/workflows/stale-issues.yaml) — chained `actions/stale` steps for stale→rotten→close

## 🙋 Questions for Reviewers

1. Is 90 days the right threshold, or should we adjust (e.g., 60 or 120)?
2. Should we add a `do-not-close` or `pinned` exempt label for important long-running PRs?
3. Should the workflow eventually move to a scheduled trigger (e.g., weekly) instead of manual-only?
4. Any concerns about the reminder message tone or content?