### PR TITLE
fix: add UpsertProductsResponse to feed JSON Schema bundle

### DIFF
--- a/changelog/unreleased/add-upsert-products-response-schema.md
+++ b/changelog/unreleased/add-upsert-products-response-schema.md
@@ -1,0 +1,19 @@
+## Add UpsertProductsResponse to feed JSON Schema bundle
+
+**Fixed** an inconsistency between the feed OpenAPI spec and the JSON Schema bundle. `UpsertProductsResponse` is defined in `openapi.feed.yaml` and referenced as the `200` response schema for `PATCH /feeds/{id}/products`, but it was missing from `schema.feed.json`. Tools that consume the JSON Schema bundle (validators, code generators, language SDKs) had no definition for the upsert acknowledgement shape and could not validate or generate types for it.
+
+The companion `UpsertProductsRequest` schema was already mirrored in both files; the response counterpart was not. The RFC's "Required Spec Updates" section in `rfcs/rfc.product_feeds.md` §9 already lists the upsert response schema among the required JSON Schema additions, so this change completes that requirement rather than introducing new surface.
+
+### Changes
+- Added `UpsertProductsResponse` definition to the feed JSON Schema bundle, mirroring the OpenAPI shape (`id: string`, `accepted: boolean`)
+- Added an `upsert_products_response` example to the feed examples file
+- Named the schema in §5.4 of the Product Feeds RFC so the response shape is documented as a reusable type
+
+### Files Updated
+- `spec/unreleased/json-schema/schema.feed.json`
+- `examples/unreleased/examples.feed.json`
+- `rfcs/rfc.product_feeds.md`
+
+### Reference
+- Original Feed API PR: #190
+- RFC §9 (Required Spec Updates) lists "upsert response schemas" among the JSON Schema additions required for the Feed API

--- a/examples/unreleased/examples.feed.json
+++ b/examples/unreleased/examples.feed.json
@@ -92,6 +92,10 @@
       }
     ]
   },
+  "upsert_products_response": {
+    "id": "feed_8f3K2x",
+    "accepted": true
+  },
   "feed_error_not_found": {
     "type": "invalid_request",
     "code": "feed_not_found",

--- a/rfcs/rfc.product_feeds.md
+++ b/rfcs/rfc.product_feeds.md
@@ -588,7 +588,7 @@ from the request remain unchanged. Merchants SHOULD submit complete current
 product objects for each upserted product unless the seller platform documents
 field-level merge behavior.
 
-Response:
+The response uses the `UpsertProductsResponse` schema:
 
 ```json
 {

--- a/spec/unreleased/json-schema/schema.feed.json
+++ b/spec/unreleased/json-schema/schema.feed.json
@@ -592,6 +592,26 @@
         ]
       }
     },
+    "UpsertProductsResponse": {
+      "description": "Acknowledgement returned after accepting an upsert payload for a feed.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "accepted"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identifier for the feed whose product upsert was processed."
+        },
+        "accepted": {
+          "type": "boolean",
+          "description": "Whether the submitted product upsert payload was accepted for processing."
+        }
+      },
+      "example": {
+        "id": "feed_8f3K2x",
+        "accepted": true
+      }
+    },
     "Error": {
       "description": "Structured error returned when a feed request cannot be fulfilled.",
       "type": "object",


### PR DESCRIPTION
# Add UpsertProductsResponse to feed JSON Schema bundle

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Documentation fix/improvement
- [x] Example update

---

## Description

`UpsertProductsResponse` is defined in `spec/unreleased/openapi/openapi.feed.yaml` and referenced as the `200` response schema for `PATCH /feeds/{id}/products`, but it is missing from the JSON Schema bundle in `spec/unreleased/json-schema/schema.feed.json`.

Every other request/response pair in the feed spec is defined in both files. The companion `UpsertProductsRequest` is mirrored in both. The response counterpart was not.

This PR adds the missing schema, ports the OpenAPI shape (`id: string`, `accepted: boolean`) into the JSON Schema bundle, adds a matching example, and names the schema in §5.4 of the RFC so the response shape is documented as a reusable type.

---

## Motivation and Context

The two source-of-truth files for the Feed API (the OpenAPI spec and the JSON Schema bundle) drifted on this one type. Tools that consume the JSON Schema bundle for validation, code generation, or SDK type stubs had no definition for the upsert response and could not produce or validate that shape.

The RFC's "Required Spec Updates" section (`rfcs/rfc.product_feeds.md` §9) already lists the upsert response schema among the required JSON Schema additions, so this is closing a documented gap from the original Feed API SEP rather than introducing new surface.

Related: PR #190 (initial Feed API spec).

---

## Testing

- `pnpm run compile:schema` passes (all 7 unreleased schemas valid, including the updated feed bundle)
- `pnpm run validate:all` passes (examples validated against schemas, no consistency warnings, all OpenAPI fields documented)
- The new `upsert_products_response` example matches the new schema definition
- The shape is byte-identical to the OpenAPI definition at `spec/unreleased/openapi/openapi.feed.yaml:651`

---

## Screenshots / Examples

Added schema (excerpt from `schema.feed.json`):

```json
"UpsertProductsResponse": {
  "description": "Acknowledgement returned after accepting an upsert payload for a feed.",
  "type": "object",
  "additionalProperties": false,
  "required": ["id", "accepted"],
  "properties": {
    "id": {
      "type": "string",
      "description": "Identifier for the feed whose product upsert was processed."
    },
    "accepted": {
      "type": "boolean",
      "description": "Whether the submitted product upsert payload was accepted for processing."
    }
  }
}
```

Added example:

```json
"upsert_products_response": {
  "id": "feed_8f3K2x",
  "accepted": true
}
```

---

## Checklist

- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (RFC §5.4 now names the response schema)
- [x] I have added/updated examples (`upsert_products_response` in `examples.feed.json`)
- [x] I have added a changelog entry file to `changelog/unreleased/add-upsert-products-response-schema.md`
- [x] I have tested my changes locally (`pnpm run compile:schema` and `pnpm run validate:all`)
- [x] This change does NOT require a SEP (it is closing a gap left by the original Feed API SEP, no new surface)
- [x] All CI checks pass

---

## 🔍 Scope Verification

- [ ]  This adds/removes/modifies protocol features
- [ ]  This introduces breaking changes
- [ ]  This changes governance or processes
- [ ]  This is complex or controversial
- [x]  **This is a minor, straightforward change** (additive JSON Schema entry mirroring an existing OpenAPI definition; no behavioral change)

---

## Additional Notes

**Files changed:**
- `spec/unreleased/json-schema/schema.feed.json`
- `examples/unreleased/examples.feed.json`
- `rfcs/rfc.product_feeds.md`
- `changelog/unreleased/add-upsert-products-response-schema.md`
