### PR TITLE
fix: unwrap error envelope in delegate_payment OpenAPI examples

### DIFF
--- a/changelog/unreleased/fix-delegate-payment-error-examples.md
+++ b/changelog/unreleased/fix-delegate-payment-error-examples.md
@@ -1,0 +1,12 @@
+## Fix delegate_payment error response example shape
+
+Error response examples in `spec/unreleased/openapi/openapi.delegate_payment.yaml` wrapped the body in `{ "error": { ... } }`. The `Error` schema is `additionalProperties: false` with `type`, `code`, `message` required at the top level, and the agentic_checkout RFC §3 documents the flat shape ("Error Shape (flat)"). None of the 9 error examples validated against the schema they reference.
+
+### Changes
+- Removed the `error:` wrapper from all 9 error response examples (400, 401, 409, 422, 429, 500, 503).
+
+### Out of scope
+`type`/`code` values left unchanged. The `Error` enum gaps for 401/500/503 are handled in #161.
+
+### Files Updated
+- `spec/unreleased/openapi/openapi.delegate_payment.yaml`

--- a/spec/unreleased/openapi/openapi.delegate_payment.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_payment.yaml
@@ -116,17 +116,15 @@ paths:
               examples:
                 invalid_request_missing_field:
                   value:
-                    error:
-                      type: invalid_request
-                      code: invalid_card
-                      message: card field is required when payment_method.type=card
-                      param: payment_method.number
+                    type: invalid_request
+                    code: invalid_card
+                    message: card field is required when payment_method.type=card
+                    param: payment_method.number
                 idempotency_key_required:
                   value:
-                    error:
-                      type: invalid_request
-                      code: idempotency_key_required
-                      message: Idempotency-Key header is required
+                    type: invalid_request
+                    code: idempotency_key_required
+                    message: Idempotency-Key header is required
         "401":
           description: Unauthorized
           content:
@@ -136,10 +134,9 @@ paths:
               examples:
                 unauthorized:
                   value:
-                    error:
-                      type: unauthorized
-                      code: unauthorized
-                      message: Unauthorized
+                    type: unauthorized
+                    code: unauthorized
+                    message: Unauthorized
         "409":
           description: In-flight collision — original request still processing
           headers:
@@ -155,10 +152,9 @@ paths:
               examples:
                 idempotency_in_flight:
                   value:
-                    error:
-                      type: invalid_request
-                      code: idempotency_in_flight
-                      message: A request with this Idempotency-Key is currently being processed
+                    type: invalid_request
+                    code: idempotency_in_flight
+                    message: A request with this Idempotency-Key is currently being processed
         "422":
           description: Semantic validation error
           content:
@@ -168,17 +164,15 @@ paths:
               examples:
                 invalid_request:
                   value:
-                    error:
-                      type: invalid_request
-                      code: invalid_card
-                      message: Invalid card expiration month
-                      param: payment_method.exp_month
+                    type: invalid_request
+                    code: invalid_card
+                    message: Invalid card expiration month
+                    param: payment_method.exp_month
                 idempotency_conflict:
                   value:
-                    error:
-                      type: invalid_request
-                      code: idempotency_conflict
-                      message: Idempotency-Key has already been used with a different request body
+                    type: invalid_request
+                    code: idempotency_conflict
+                    message: Idempotency-Key has already been used with a different request body
         "429":
           description: Rate limit exceeded
           content:
@@ -188,10 +182,9 @@ paths:
               examples:
                 rate_limit_exceeded:
                   value:
-                    error:
-                      type: rate_limit_exceeded
-                      code: rate_limit_exceeded
-                      message: Rate limit exceeded
+                    type: rate_limit_exceeded
+                    code: rate_limit_exceeded
+                    message: Rate limit exceeded
         "500":
           description: Processing error
           content:
@@ -201,10 +194,9 @@ paths:
               examples:
                 internal_server_error:
                   value:
-                    error:
-                      type: internal_server_error
-                      code: internal_server_error
-                      message: Internal server error
+                    type: internal_server_error
+                    code: internal_server_error
+                    message: Internal server error
         "503":
           description: Service unavailable
           content:
@@ -214,10 +206,9 @@ paths:
               examples:
                 service_unavailable:
                   value:
-                    error:
-                      type: service_unavailable
-                      code: service_unavailable
-                      message: Service unavailable
+                    type: service_unavailable
+                    code: service_unavailable
+                    message: Service unavailable
 components:
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
## Type of Change

- [ ] Documentation fix/improvement
- [x] Bug fix (non-breaking)
- [ ] Tooling improvement
- [x] Example update
- [ ] Minor data/enum addition
- [ ] Other:

---

## Description

The error response examples in `spec/unreleased/openapi/openapi.delegate_payment.yaml` wrap the body in `{ "error": { ... } }`. The `Error` schema is `additionalProperties: false` and requires `type`, `code`, `message` at the top level. RFC `rfc.agentic_checkout.md` §3 documents the same flat shape.

0 of the 9 error response examples validate against the `Error` schema they reference.

This PR removes the `error:` wrapper from all 9 examples (400, 401, 409, 422, 429, 500, 503). No `type`, `code`, or `message` values are changed.

---

## Motivation and Context

Same shape mismatch was raised in #21 (Oct 2025), which targeted the pre-versioned `spec/openapi/...` layout and is no longer mergeable. The `Error.code` enum gaps for 401/500/503 are out of scope here and being handled in #161. Leaving `type`/`code` values alone keeps this PR independent of #161 either way it lands.

Fixes part of: #21

---

## Testing

Validated all 9 examples against `components.schemas.Error` with AJV 8 (the version pinned in `package.json`):

| Status | Example | Before | After |
|---|---|---|---|
| 400 | invalid_request_missing_field | fail | pass |
| 400 | idempotency_key_required | fail | pass |
| 401 | unauthorized | fail | enum-only (#161) |
| 409 | idempotency_in_flight | fail | pass |
| 422 | invalid_request | fail | pass |
| 422 | idempotency_conflict | fail | pass |
| 429 | rate_limit_exceeded | fail | enum-only (#161) |
| 500 | internal_server_error | fail | enum-only (#161) |
| 503 | service_unavailable | fail | enum-only (#161) |

0/9 pass before, 5/9 pass after. The 4 "enum-only" rows are structurally correct but use values outside the current `type`/`code` enums.

`pnpm run compile:schema` and `pnpm run validate:all` both pass locally.

---

## Screenshots / Examples

Before:
```yaml
"401":
  content:
    application/json:
      schema:
        $ref: "#/components/schemas/Error"
      examples:
        unauthorized:
          value:
            error:
              type: unauthorized
              code: unauthorized
              message: Unauthorized
```

After:
```yaml
"401":
  content:
    application/json:
      schema:
        $ref: "#/components/schemas/Error"
      examples:
        unauthorized:
          value:
            type: unauthorized
            code: unauthorized
            message: Unauthorized
```

---

## Checklist

Before submitting, ensure:

- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [ ] I have updated relevant documentation (if applicable)
- [x] I have added/updated examples (if applicable)
- [x] I have added a changelog entry file to `changelog/unreleased/fix-delegate-payment-error-examples.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [x] All CI checks pass

---

## Scope Verification

- [ ]  This adds/removes/modifies protocol features
- [ ]  This introduces breaking changes
- [ ]  This changes governance or processes
- [ ]  This is complex or controversial
- [x] **This is a minor, straightforward change** (confirm by checking this)

---

## Additional Notes

Same wrapper bug exists in released `delegate_payment` OpenAPI for 2025-09-29, 2025-12-12, 2026-01-16, 2026-01-30, and 2026-04-17. Keeping this PR scoped to `spec/unreleased/`. Can do the released versions in a follow-up.

`scripts/validate-consistency.js` does not parse OpenAPI YAML to validate inline `examples:` blocks against the schemas they `$ref`, which is why this slipped past CI.
