### PR TITLE
fix(spec/2026-01-30): refund amount example type matches schema

### DIFF
--- a/changelog/unreleased/fix-refund-amount-example-type.md
+++ b/changelog/unreleased/fix-refund-amount-example-type.md
@@ -1,0 +1,12 @@
+## Fix Refund amount example type in 2026-01-30 webhook spec
+
+The `order_updated` example in `openapi.agentic_checkout_webhook.yaml` showed `amount: "1.00"` (string) for a refund. The `Refund.amount` schema in the same file defines `amount` as an `integer` in minor units (e.g. `100` cents for `$1.00`). The example contradicted the schema and could confuse implementers and tooling.
+
+### Changes
+- Corrected the refund example to use `amount: 100` (integer minor units, consistent with the schema and other examples in the file such as the `total` line item at line 117)
+
+### Files Updated
+- `spec/2026-01-30/openapi/openapi.agentic_checkout_webhook.yaml`
+
+### Reference
+- Issue: #220

--- a/spec/2026-01-30/openapi/openapi.agentic_checkout_webhook.yaml
+++ b/spec/2026-01-30/openapi/openapi.agentic_checkout_webhook.yaml
@@ -65,7 +65,7 @@ paths:
                     status: shipped
                     refunds:
                       - type: original_payment
-                        amount: "1.00"
+                        amount: 100
       responses:
         "200":
           description: Event accepted


### PR DESCRIPTION
## Summary

The `order_updated` example in `spec/2026-01-30/openapi/openapi.agentic_checkout_webhook.yaml` showed `amount: "1.00"` (string) for a refund. The `Refund.amount` schema in the same file (lines 111-114) defines `amount` as an `integer` in minor units (e.g. `100` cents for `$1.00`). The example contradicted its own schema.

Other examples in the file (e.g. line item `total` at line 117) correctly use integer minor units.

Fixes #220.

## Changes

- `spec/2026-01-30/openapi/openapi.agentic_checkout_webhook.yaml` line 68: `amount: "1.00"` → `amount: 100`
- `changelog/unreleased/fix-refund-amount-example-type.md` added

## Scope

Single-version fix per the issue's citation of 2026-01-30. The newer `2026-04-17` spec replaces `refunds[]` with `adjustments[]` (already integer), so no fix needed there. Older spec versions (`2025-09-29`, `2025-12-12`, `2026-01-16`) contain the same string-form example — happy to extend the PR if maintainers prefer those frozen releases be left as-is or also corrected.

## Checklist

- [x] CLA — will sign on first PR via the bot
- [x] Branch from main: `fix/refund-amount-example-type`
- [x] Changelog entry added in `changelog/unreleased/`
- [x] Single-purpose, minimal scope
- [x] Linked issue: #220