### PR TITLE
docs: add missing 2026-01-16 changelog to readme listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ examples/
 changelog/
 ├── 2025-09-29.md
 ├── 2025-12-12.md
+├── 2026-01-16.md
 ├── 2026-01-30.md
 ├── 2026-04-17.md
 └── unreleased/              # Individual changelog entries (current development)

--- a/changelog/unreleased/fix-readme-changelog-listing.md
+++ b/changelog/unreleased/fix-readme-changelog-listing.md
@@ -1,0 +1,9 @@
+## Fix README changelog directory listing
+
+The Repo Structure section of `README.md` listed the `changelog/` directory contents but omitted `2026-01-16.md`, which exists on disk alongside the other dated changelogs.
+
+### Changes
+- Added the missing `2026-01-16.md` entry to the `changelog/` tree in `README.md`
+
+### Files Updated
+- `README.md`


### PR DESCRIPTION
## 🔧 Type of Change

- [x] Documentation fix/improvement

---

## 📝 Description

The Repo Structure section of `README.md` lists the `changelog/` directory contents but omits `2026-01-16.md`, which exists on disk alongside the other dated changelogs (`2025-09-29.md`, `2025-12-12.md`, `2026-01-30.md`, `2026-04-17.md`). Added the missing line so the tree matches reality.

---

## 🎯 Motivation and Context

Minor documentation correction. Readers scanning the README to find the changelog for the `2026-01-16` spec version (which is listed under `spec/` and `examples/` directly above) would not see it under `changelog/` and might assume it's missing.

---

## 🧪 Testing

- `pnpm run validate:all` passes
- Verified `changelog/2026-01-16.md` exists on disk

---

## 📸 Screenshots / Examples

Diff of the `changelog/` listing in the README Repo Structure tree:

```diff
   changelog/
     2025-09-29.md
     2025-12-12.md
+    2026-01-16.md
     2026-01-30.md
     2026-04-17.md
```

---

## ✅ Checklist

- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have added a changelog entry file to `changelog/unreleased/fix-readme-changelog-listing.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)

---

## 🔍 Scope Verification

- [x] ✅ **This is a minor, straightforward change**

---

## 📚 Additional Notes

This is a documentation-only change with no impact on the spec, examples, or any code. It simply brings the README's `changelog/` listing in line with the files already present on disk.
