### PR TITLE
fix: improve IntentTrace and CancelSessionRequest embedded examples

### DIFF
--- a/changelog/unreleased/fix-intent-trace-embedded-examples.md
+++ b/changelog/unreleased/fix-intent-trace-embedded-examples.md
@@ -1,0 +1,7 @@
+## Correct field name in IntentTrace and CancelSessionRequest examples
+
+The inline `example:` blocks on `IntentTrace` and `CancelSessionRequest` in `spec/unreleased/` used `description`, which is not a property of `IntentTrace` — the intended field is `trace_summary`. Renamed the field in both examples so they match the schema definition and the dedicated examples in `examples/<version>/examples.agentic_checkout.json`.
+
+### Files Updated
+- `spec/unreleased/json-schema/schema.agentic_checkout.json`
+- `spec/unreleased/openapi/openapi.agentic_checkout.yaml`

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -3672,7 +3672,7 @@
       ],
       "example": {
         "reason_code": "buyer_initiated",
-        "description": "Customer requested to complete checkout",
+        "trace_summary": "Customer requested to complete checkout",
         "metadata": {}
       }
     },
@@ -3687,7 +3687,7 @@
       "example": {
         "intent_trace": {
           "reason_code": "buyer_cancelled",
-          "description": "Customer decided not to purchase"
+          "trace_summary": "Customer decided not to purchase"
         }
       }
     },

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -3312,7 +3312,7 @@ components:
         - reason_code
       example:
         reason_code: buyer_initiated
-        description: Customer requested to complete checkout
+        trace_summary: Customer requested to complete checkout
         metadata: {}
       description: Structured reason for why a buyer action was taken, used for analytics and debugging
     CancelSessionRequest:
@@ -3323,7 +3323,7 @@ components:
       example:
         intent_trace:
           reason_code: buyer_cancelled
-          description: Customer decided not to purchase
+          trace_summary: Customer decided not to purchase
       description: Request to cancel a checkout session
     Error:
       type: object


### PR DESCRIPTION
## 🔧 Type of Change

- [x] Documentation fix/improvement
- [ ] Bug fix (non-breaking)
- [ ] Tooling improvement
- [x] Example update
- [ ] Minor data/enum addition
- [ ] Other:

---

## 📝 Description

The inline `example:` blocks on `IntentTrace` and `CancelSessionRequest` in `spec/unreleased/` use `description`, which is **not a defined property** of `IntentTrace` - the schema's field is `trace_summary`.

The examples still validate today because `IntentTrace` doesn't set `additionalProperties: false`, but they're misleading. They show a field that isn't part of the schema and don't match the canonical examples in `examples/<version>/examples.agentic_checkout.json`, which use `trace_summary`.

This PR renames `description` → `trace_summary` in both example blocks (JSON Schema + OpenAPI).

---

## 🎯 Motivation and Context

Spec examples are reference material that implementers copy. An example showing a `description` field that the schema doesn't define can lead to the wrong payload shape downstream.

Addresses: no prior issue - found while reviewing the embedded examples against their own schemas.

Related: PR #54 (original IntentTrace SEP), PR #151 (examples file additions).

---

## 🧪 Testing

- `pnpm run compile:schema` passes (all 7 unreleased schemas valid)
- `pnpm run validate:all` passes (0 errors, 0 warnings)

---

## 📸 Screenshots / Examples

`IntentTrace.example` — before:
```json
{
  "reason_code": "buyer_initiated",
  "description": "Customer requested to complete checkout",
  "metadata": {}
}
```
`IntentTrace.example` — after:
```json
{
  "reason_code": "buyer_initiated",
  "trace_summary": "Customer requested to complete checkout",
  "metadata": {}
}
```
`CancelSessionRequest.example` — before:
```json
{
  "intent_trace": {
    "reason_code": "buyer_cancelled",
    "description": "Customer decided not to purchase"
  }
}
```
`CancelSessionRequest.example` — after:
```json
{
  "intent_trace": {
    "reason_code": "buyer_cancelled",
    "trace_summary": "Customer decided not to purchase"
  }
}
```

---

## ✅ Checklist

- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (if applicable)
- [x] I have added/updated examples (if applicable)
- [x] I have added a changelog entry file to `changelog/unreleased/fix-intent-trace-embedded-examples.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [x] All CI checks pass

---

## 🔍 Scope Verification

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ **This is a minor, straightforward change**

---

## 📚 Additional Notes

- Scoped to `spec/unreleased/`. The same field-name issue exists in the released `spec/2026-04-17/` examples. Happy to open a follow-up if useful.
- I originally also normalized the `reason_code` values, but dropped that per review feedback - `reason_code` is an intentionally open enum (RFC §7.2), so those values weren't invalid. This PR is now strictly the `description` → `trace_summary` correction.