### PR TITLE
fix: add 2026-04-17 feed upsert response schema

### DIFF
--- a/changelog/unreleased/add-2026-04-17-upsert-products-response-schema.md
+++ b/changelog/unreleased/add-2026-04-17-upsert-products-response-schema.md
@@ -1,0 +1,14 @@
+## Add 2026-04-17 UpsertProductsResponse schema
+
+Adds the missing `UpsertProductsResponse` definition to the 2026-04-17 feed
+JSON Schema bundle.
+
+### Changes
+
+- Added `UpsertProductsResponse` to `spec/2026-04-17/json-schema/schema.feed.json`
+- Added the matching `upsert_products_response` example to `examples/2026-04-17/examples.feed.json`
+
+### Files Updated
+
+- `spec/2026-04-17/json-schema/schema.feed.json`
+- `examples/2026-04-17/examples.feed.json`

--- a/examples/2026-04-17/examples.feed.json
+++ b/examples/2026-04-17/examples.feed.json
@@ -92,6 +92,10 @@
       }
     ]
   },
+  "upsert_products_response": {
+    "id": "feed_8f3K2x",
+    "accepted": true
+  },
   "feed_error_not_found": {
     "type": "invalid_request",
     "code": "feed_not_found",

--- a/spec/2026-04-17/json-schema/schema.feed.json
+++ b/spec/2026-04-17/json-schema/schema.feed.json
@@ -592,6 +592,26 @@
         ]
       }
     },
+    "UpsertProductsResponse": {
+      "description": "Acknowledgement returned after accepting an upsert payload for a feed.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "accepted"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Identifier for the feed whose product upsert was processed."
+        },
+        "accepted": {
+          "type": "boolean",
+          "description": "Whether the submitted product upsert payload was accepted for processing."
+        }
+      },
+      "example": {
+        "id": "feed_8f3K2x",
+        "accepted": true
+      }
+    },
     "Error": {
       "description": "Structured error returned when a feed request cannot be fulfilled.",
       "type": "object",


### PR DESCRIPTION
## 🔧 Type of Change

- [ ] Documentation fix/improvement
- [x] Bug fix (non-breaking)
- [ ] Tooling improvement
- [x] Example update
- [ ] Minor data/enum addition
- [ ] Other

---

## 📝 Description

This adds the missing `UpsertProductsResponse` schema to the 2026-04-17 feed JSON Schema bundle and adds the matching feed example.

The 2026-04-17 OpenAPI feed spec already defines `UpsertProductsResponse` and uses it as the `200` response schema for `PATCH /feeds/{id}/products`. The JSON Schema bundle for the same release did not include the response model, so tools that consume `schema.feed.json` could not validate or generate types for the upsert acknowledgement shape.

This mirrors the response schema and example that already exist in `unreleased`.

---

## 🎯 Motivation and Context

OpenAPI and JSON Schema should expose the same reusable feed response models for a released version. Without this definition, the stable 2026-04-17 JSON Schema bundle is missing a response type that the stable 2026-04-17 OpenAPI spec returns.

This is a released-version follow-up to the existing unreleased fix for the same feed schema gap.

---

## 🧪 Testing

- `pnpm run validate:all`
- `pnpm run compile:schema`
- `git diff --check`
- Targeted AJV validation of `examples/2026-04-17/examples.feed.json#upsert_products_response` against `#/$defs/UpsertProductsResponse`
- PR title/body validation with `.github/scripts/validate-pr-description.js`

---

## 📸 Screenshots / Examples

Before:

```text
2026-04-17 OpenAPI has UpsertProductsResponse: true
2026-04-17 JSON Schema has UpsertProductsResponse: false
```

After:

```text
2026-04-17 OpenAPI has UpsertProductsResponse: true
2026-04-17 JSON Schema has UpsertProductsResponse: true
```

---

## ✅ Checklist

- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (if applicable)
- [x] I have added/updated examples (if applicable)
- [x] I have added a changelog entry file to `changelog/unreleased/add-2026-04-17-upsert-products-response-schema.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [x] All CI checks pass

---

## 🔍 Scope Verification

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ **This is a minor, straightforward change** (released-version schema alignment for an existing response model)

---

## 📚 Additional Notes

No protocol surface is added here. The response model already exists in the 2026-04-17 OpenAPI spec and in the unreleased JSON Schema bundle. This change makes the 2026-04-17 JSON Schema bundle match those sources.