### PR TITLE
fix: align Feed API host and array bounds

### DIFF
--- a/changelog/unreleased/fix-feed-api-host-and-array-bounds.md
+++ b/changelog/unreleased/fix-feed-api-host-and-array-bounds.md
@@ -1,0 +1,13 @@
+## Fix Feed API host and array bounds
+
+Aligns the Feed API OpenAPI server URL with the Product Feeds RFC by using an
+agent-hosted example origin. Also tightens feed validation so product upserts
+must include at least one product and each product must include at least one
+variant.
+
+### Affected files
+
+- `spec/2026-04-17/openapi/openapi.feed.yaml`
+- `spec/2026-04-17/json-schema/schema.feed.json`
+- `spec/unreleased/openapi/openapi.feed.yaml`
+- `spec/unreleased/json-schema/schema.feed.json`

--- a/spec/2026-04-17/json-schema/schema.feed.json
+++ b/spec/2026-04-17/json-schema/schema.feed.json
@@ -465,6 +465,7 @@
         "variants": {
           "type": "array",
           "description": "Purchasable variants grouped under this product.",
+          "minItems": 1,
           "items": {
             "$ref": "#/$defs/Variant"
           }
@@ -568,6 +569,7 @@
         "products": {
           "type": "array",
           "description": "Subset of products to create or update within the feed, matched by Product.id.",
+          "minItems": 1,
           "items": {
             "$ref": "#/$defs/Product"
           }

--- a/spec/2026-04-17/openapi/openapi.feed.yaml
+++ b/spec/2026-04-17/openapi/openapi.feed.yaml
@@ -11,7 +11,7 @@ info:
     `products.jsonl` contains one `Product` object per line. File ingestion replaces the full product
     set. Partial updates are only supported through `PATCH /feeds/{id}/products`.
 servers:
-  - url: https://merchant.example.com
+  - url: https://agent.example.com
 tags:
   - name: Feeds
     description: Create and manage feed resources and product catalogs
@@ -584,6 +584,7 @@ components:
         variants:
           type: array
           description: Purchasable variants grouped under this product.
+          minItems: 1
           items:
             $ref: "#/components/schemas/Variant"
       example:
@@ -675,6 +676,7 @@ components:
         products:
           type: array
           description: Subset of products to create or update within the feed, matched by Product.id.
+          minItems: 1
           items:
             $ref: "#/components/schemas/Product"
       example:

--- a/spec/unreleased/json-schema/schema.feed.json
+++ b/spec/unreleased/json-schema/schema.feed.json
@@ -465,6 +465,7 @@
         "variants": {
           "type": "array",
           "description": "Purchasable variants grouped under this product.",
+          "minItems": 1,
           "items": {
             "$ref": "#/$defs/Variant"
           }
@@ -568,6 +569,7 @@
         "products": {
           "type": "array",
           "description": "Subset of products to create or update within the feed, matched by Product.id.",
+          "minItems": 1,
           "items": {
             "$ref": "#/$defs/Product"
           }

--- a/spec/unreleased/openapi/openapi.feed.yaml
+++ b/spec/unreleased/openapi/openapi.feed.yaml
@@ -11,7 +11,7 @@ info:
     `products.jsonl` contains one `Product` object per line. File ingestion replaces the full product
     set. Partial updates are only supported through `PATCH /feeds/{id}/products`.
 servers:
-  - url: https://merchant.example.com
+  - url: https://agent.example.com
 tags:
   - name: Feeds
     description: Create and manage feed resources and product catalogs
@@ -584,6 +584,7 @@ components:
         variants:
           type: array
           description: Purchasable variants grouped under this product.
+          minItems: 1
           items:
             $ref: "#/components/schemas/Variant"
       example:
@@ -675,6 +676,7 @@ components:
         products:
           type: array
           description: Subset of products to create or update within the feed, matched by Product.id.
+          minItems: 1
           items:
             $ref: "#/components/schemas/Product"
       example:


### PR DESCRIPTION
# Fix Feed API host and array bounds

## 🔧 Type of Change

- [ ] Documentation fix/improvement
- [x] Bug fix (non-breaking)
- [ ] Tooling improvement
- [ ] Example update
- [ ] Minor data/enum addition
- [ ] Other: N/A

---

## 📝 Description

This PR fixes two small Product Feed spec inconsistencies:

- Updates the Feed API OpenAPI server URL from `https://merchant.example.com` to `https://agent.example.com`.
- Adds `minItems: 1` to `Product.variants` and `UpsertProductsRequest.products` in both the 2026-04-17 and unreleased feed schemas.

---

## 🎯 Motivation and Context

The Product Feeds RFC describes the Feed API as agent-hosted, with merchants calling it to publish and inspect feed state. The OpenAPI files currently show a merchant-hosted example origin, which points docs and client SDKs in the wrong direction.

The schema also accepts two payloads that the surrounding spec text treats as invalid: an upsert request with no products, and a product with no variants. The 400 response example already says `products must contain at least one valid Product`, and the RFC describes `Product` as grouping one or more purchasable variants.

Related: #189

---

## 🧪 Testing

- `pnpm run validate:all`
- `pnpm run compile:schema`
- `./node_modules/.bin/ajv compile --spec=draft2020 -c ajv-formats -s spec/2026-04-17/json-schema/schema.feed.json`
- `./node_modules/.bin/ajv compile --spec=draft2020 -c ajv-formats -s spec/unreleased/json-schema/schema.feed.json`
- `git diff --check`

Targeted AJV check after the change:

```text
empty upsert products: INVALID
product with empty variants: INVALID
```

---

## 📸 Screenshots / Examples

Feed API server URL:

```yaml
servers:
  - url: https://agent.example.com
```

Array bounds:

```yaml
variants:
  type: array
  minItems: 1

products:
  type: array
  minItems: 1
```

---

## ✅ Checklist

Before submitting, ensure:

- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (if applicable)
- [ ] I have added/updated examples (if applicable)
- [x] I have added a changelog entry file to `changelog/unreleased/your-change-description.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [ ] All CI checks pass

---

## 🔍 Scope Verification

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ **This is a minor, straightforward change** (confirm by checking this)

This is a schema and OpenAPI correction for Product Feed behavior already described by the RFC and error examples. It does not add a new endpoint, field, or response shape.

---

## 📚 Additional Notes

No follow-up work is required for this PR.
