### PR TITLE
SEP: Add Feed Update ID on Feed API Upsert Products Response

### DIFF
--- a/changelog/unreleased/add-feed-update-id.md
+++ b/changelog/unreleased/add-feed-update-id.md
@@ -1,0 +1,18 @@
+## Feed Update ID on Upsert Products Response (SEP #259)
+
+Add agent-generated feed_update_id to UpsertProductsResponse and per-product last_update_id for update version tracking and checkout price provenance.
+
+### Changes
+
+- **UpsertProductsResponse**: Added optional `feed_update_id` field — agent-generated version identifier for each accepted upsert
+- **Product**: Added optional `last_update_id` field — tracks the feed_update_id of the most recent upsert that touched each product
+
+### Files Updated
+
+- `spec/unreleased/openapi/openapi.feed.yaml`
+- `spec/unreleased/json-schema/schema.feed.json`
+- `examples/unreleased/examples.feed.json`
+
+### Reference
+
+- Issue: #259

--- a/examples/unreleased/examples.feed.json
+++ b/examples/unreleased/examples.feed.json
@@ -17,6 +17,7 @@
       {
         "id": "prod_classic_tee",
         "title": "Classic Tee",
+        "last_update_id": "upd_7kQ9mR",
         "variants": [
           {
             "id": "sku123-red-s",
@@ -94,7 +95,8 @@
   },
   "upsert_products_response": {
     "id": "feed_8f3K2x",
-    "accepted": true
+    "accepted": true,
+    "feed_update_id": "upd_7kQ9mR"
   },
   "feed_error_not_found": {
     "type": "invalid_request",

--- a/spec/unreleased/json-schema/schema.feed.json
+++ b/spec/unreleased/json-schema/schema.feed.json
@@ -468,6 +468,10 @@
           "items": {
             "$ref": "#/$defs/Variant"
           }
+        },
+        "last_update_id": {
+          "type": "string",
+          "description": "The feed_update_id of the most recent product upsert that touched this product. Absent if the agent does not support product feed update versioning."
         }
       },
       "example": {

--- a/spec/unreleased/json-schema/schema.feed.json
+++ b/spec/unreleased/json-schema/schema.feed.json
@@ -471,7 +471,8 @@
         },
         "last_update_id": {
           "type": "string",
-          "description": "The feed_update_id of the most recent product upsert that touched this product. Absent if the agent does not support product feed update versioning."
+          "readOnly": true,
+          "description": "The feed_update_id of the most recent product upsert that touched this product. Absent if the agent does not support product feed update versioning. Response only — agents MUST ignore this field if present on input."
         }
       },
       "example": {
@@ -609,11 +610,16 @@
         "accepted": {
           "type": "boolean",
           "description": "Whether the submitted product upsert payload was accepted for processing."
+        },
+        "feed_update_id": {
+          "type": "string",
+          "description": "Agent-generated version identifier for this accepted upsert. Unique within the agent's namespace. The merchant stores this as the version of the update and can verify it against Product.last_update_id on each product returned by GET /feeds/{id}/products."
         }
       },
       "example": {
         "id": "feed_8f3K2x",
-        "accepted": true
+        "accepted": true,
+        "feed_update_id": "upd_7kQ9mR"
       }
     },
     "Error": {

--- a/spec/unreleased/openapi/openapi.feed.yaml
+++ b/spec/unreleased/openapi/openapi.feed.yaml
@@ -170,6 +170,7 @@ paths:
                   value:
                     id: feed_8f3K2x
                     accepted: true
+                    feed_update_id: upd_7kQ9mR
         "400":
           description: Invalid product payload
           content:
@@ -586,6 +587,9 @@ components:
           description: Purchasable variants grouped under this product.
           items:
             $ref: "#/components/schemas/Variant"
+        last_update_id:
+          type: string
+          description: The feed_update_id of the most recent product upsert that touched this product. Absent if the agent does not support product feed update versioning.
       example:
         id: prod_classic_tee
         title: Classic Tee
@@ -662,9 +666,13 @@ components:
         accepted:
           type: boolean
           description: Whether the submitted product upsert payload was accepted for processing.
+        feed_update_id:
+          type: string
+          description: Agent generated version identifier for this accepted upsert. Unique within the agent's namespace. The merchant stores this as the version of the update and can verify it against Product.last_update_id on each product returned by GET /feeds/{id}/products.
       example:
         id: feed_8f3K2x
         accepted: true
+        feed_update_id: upd_7kQ9mR
     UpsertProductsRequest:
       description: Request payload that partially upserts products into a feed. Products omitted from the request remain unchanged.
       type: object

--- a/spec/unreleased/openapi/openapi.feed.yaml
+++ b/spec/unreleased/openapi/openapi.feed.yaml
@@ -589,7 +589,8 @@ components:
             $ref: "#/components/schemas/Variant"
         last_update_id:
           type: string
-          description: The feed_update_id of the most recent product upsert that touched this product. Absent if the agent does not support product feed update versioning.
+          readOnly: true
+          description: The feed_update_id of the most recent product upsert that touched this product. Absent if the agent does not support product feed update versioning. Response only — agents MUST ignore this field if present on input.
       example:
         id: prod_classic_tee
         title: Classic Tee


### PR DESCRIPTION
# SEP: Add Feed Update ID on Feed API Upsert Products Response

## 📋 SEP Metadata

- **SEP Number**: [[#259](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/issues/259)](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/issues/259)
- **Author(s)**: Lee Hwa / Meta
- **Status**: `proposal` (awaiting sponsor)
- **Type**: [x] Major Change [ ] Process Change
- **Related Issues/RFCs**: 
   - rfcs/rfc.product_feeds.md
   - spec/unreleased/json-schema/schema.feed.json
   - PR #190 
   - SEP #197 (Suggested Pricing)

---

## 🎯 Abstract

This SEP proposes adding an agent-generated `feed_update_id` field to `UpsertProductsResponse` and a corresponding `last_update_id` field to `Product`. The `feed_update_id` serves as a **structured version identifier** for each product feed update. When a merchant upserts products via `PATCH /feeds/{id}/products`, the agent assigns a version identifier to the accepted update and returns it in the response. The merchant stores this as the version of the update.

The same identifier is surfaced on each `Product` as `last_update_id`, readable via `GET /feeds/{id}/products`, so the merchant can verify which update version each product reflects. Tracking at the product level — rather than the feed level — enables per-item provenance: the agent can reference the specific feed update version for each product's price data at checkout (see SEP #197), and the seller can verify at the item level.

---

## 💡 Motivation

### The Problem

The Feed API's upsert response (`PATCH /feeds/{id}/products`) currently returns only `{ "id", "accepted" }`. There is no structured identifier for the update. The merchant receives a boolean confirmation but has no agent-provided reference to track the update or verify — via `GET /feeds/{id}` — which update the agent last processed.

The Feed API includes `updated_at` on `FeedMetadata`, which advances after each upsert. But `updated_at` is a bare timestamp — it answers "when was the feed last touched" but not "which specific update is the agent reflecting." Merchants need a more structured way to identify the last feed update:

1. **No structured product feed update version**: After a successful upsert, the merchant has no version identifier for the update. The only confirmation is `accepted: true`, which carries no information about the update itself. Without a version identifier, there is no way to reference this specific feed state in downstream flows — most importantly, during checkout.
2. **No version handshake at checkout**: Product feeds supply the prices that agents display to buyers during discovery. When the agent creates a checkout session, it needs to reference *which version* of the feed its prices came from (e.g., via `suggested_price.source`). Without a structured feed update version, the agent has no reliable identifier to pass as provenance. The seller cannot verify whether the agent's price data came from a known, recent feed update.
3. **No per-product readback verification**: When a merchant calls `GET /feeds/{id}/products` to inspect the agent-known state, there is no version identifier on each product. The merchant cannot answer: "Does this product reflect the update I just sent, or an earlier one?"
4. **No audit trail**: In multi-system architectures where a seller platform, OMS, or catalog system publishes feed updates on behalf of a merchant, there is no protocol-level version to trace an update from submission through agent processing to checkout.

### Why the Community Should Care

- **Seller** can use the version identifier to verify the agent's current state and validate that prices referenced at checkout trace back to a known feed update.
- **Agent platform** benefit from a clear provenance chain: feed update version → `suggested_price.source` → seller verification. This closes the gap between product discovery and checkout.
- **The protocol** needs a version handshake that connects feed updates to checkout. `updated_at` provides temporal tracking, but a structured version identifier is needed to reference a specific feed state across API boundaries (feeds → checkout).

---

## 📐 Specification

### 1. Add `feed_update_id` to `UpsertProductsResponse`

An opaque, agent-generated string that serves as the version identifier for the accepted upsert. Optional — it is RECOMMENDED that agents that support feed update versioning include it on every accepted upsert. The format is agent-defined (UUID, prefixed ID, etc.). This version identifier can be referenced as the `source` in `suggested_price` during checkout, enabling sellers to verify that an agent's price data traces back to a known feed update.

**Updated schema:**

```json
{
  "UpsertProductsResponse": {
    "type": "object",
    "additionalProperties": false,
    "required": ["id", "accepted"],
    "properties": {
      "id": {
        "type": "string",
        "description": "Identifier for the feed whose product upsert was processed."
      },
      "accepted": {
        "type": "boolean",
        "description": "Whether the submitted product upsert payload was accepted for processing."
      },
      "feed_update_id": {
        "type": "string",
        "description": "Agent-generated version identifier for this accepted upsert. Unique within the agent's namespace. The merchant stores this as the version of the update and can verify it against Product.last_update_id on each product returned by GET /feeds/{id}/products."
      }
    },
    "example": {
      "id": "feed_8f3K2x",
      "accepted": true,
      "feed_update_id": "upd_7kQ9mR"
    }
  }
}
```

### 2. Add `last_update_id` to `Product`

The version identifier (`feed_update_id`) of the most recent upsert that touched this product. Readable via `GET /feeds/{id}/products` on each product in the response. Absent if the agent does not support update versioning. Merchants and seller platforms use this to confirm which feed update version each product reflects.

**Updated schema (new field on Product):**

```json
{
  "Product": {
    "type": "object",
    "additionalProperties": false,
    "required": ["id", "variants"],
    "properties": {
      "id": {
        "type": "string",
        "description": "Stable global identifier for this product."
      },
      "title": {
        "type": "string",
        "description": "Display title for the product."
      },
      "last_update_id": {
        "type": "string",
        "description": "The feed_update_id (version identifier) of the most recent product upsert that touched this product. Absent if the agent does not support update versioning."
      },
      "...": "other existing Product fields unchanged"
    },
    "example": {
      "id": "prod_classic_tee",
      "title": "Classic Tee",
      "last_update_id": "upd_7kQ9mR",
      "variants": [
        {
          "id": "sku124-red-m",
          "title": "Classic Tee - Red / Medium"
        }
      ]
    }
  }
}
```

### 3. Agent Behavior

> When the agent accepts a product upsert (`PATCH /feeds/{id}/products`):
>
> 1. It is RECOMMENDED that the agent generate a unique `feed_update_id` and include it in the `UpsertProductsResponse`. Agents that support update versioning are RECOMMENDED to include it on every accepted upsert.
> 2. When `feed_update_id` is returned, the agent MUST set `last_update_id` on each `Product` that was created or updated by this upsert.
> 3. When present, the agent MUST return the same `last_update_id` on each affected product in subsequent `GET /feeds/{id}/products` calls until a newer upsert touches that product.
> 4. The format of `feed_update_id` is agent-defined. It MUST be a non-empty string. It is RECOMMENDED that agents use a format that avoids collisions (e.g., UUID, prefixed counter, or ULID).

### 4. Merchant Behavior

> After receiving a `UpsertProductsResponse`:
>
> 1. It is RECOMMENDED that the merchant store `feed_update_id` as the version for this upsert.
> 2. To verify the agent reflects a specific update, the merchant calls `GET /feeds/{id}/products` and compares `last_update_id` on each product against the stored version.
> 3. If a product's `last_update_id` matches, that product reflects the merchant's upsert (or a later one that superseded it).
> 4. Different products in the same feed may have different `last_update_id` values if they were touched by different upserts.

### 5. Example Flows

**Feed update → readback verification → checkout version handshake:**

Step 1 — Merchant upserts products with pricing:

```http
PATCH /feeds/feed_8f3K2x/products HTTP/1.1
API-Version: unreleased
Content-Type: application/json

{
  "products": [
    {
      "id": "prod_classic_tee",
      "title": "Classic Tee",
      "variants": [
        {
          "id": "sku124-red-m",
          "title": "Classic Tee - Red / Medium",
          "price": {
            "amount": 1999,
            "currency": "USD"
          },
          "availability": {
            "available": true,
            "status": "in_stock"
          }
        }
      ]
    }
  ]
}
```

Response — agent returns the feed update version:

```json
{
  "id": "feed_8f3K2x",
  "accepted": true,
  "feed_update_id": "upd_7kQ9mR"
}
```

Step 2 — Merchant verifies via per-product readback:

```http
GET /feeds/feed_8f3K2x/products HTTP/1.1
API-Version: unreleased
```

```json
{
  "products": [
    {
      "id": "prod_classic_tee",
      "title": "Classic Tee",
      "last_update_id": "upd_7kQ9mR",
      "variants": [
        {
          "id": "sku124-red-m",
          "title": "Classic Tee - Red / Medium",
          "price": {
            "amount": 1999,
            "currency": "USD"
          },
          "availability": {
            "available": true,
            "status": "in_stock"
          }
        }
      ]
    }
  ]
}
```

Merchant confirms `last_update_id` on the product matches `upd_7kQ9mR` — this product reflects the specific update. At checkout, the agent can reference `upd_7kQ9mR` as the `feed_update_id` in `suggested_price.source` (a structured `PriceSource` object — see SEP #197). This is a best-effort mechanism: it is RECOMMENDED that the seller verify the feed update version and honor the price, but if the seller does not honor it, the checkout proceeds normally with the seller's current pricing breakdown.

---

## 🤔 Rationale

### Why agent-generated instead of merchant-supplied?

Merchant-supplied IDs shift uniqueness responsibility to the merchant. Merchants may use non-unique values (timestamps, incrementing counters that reset) or inconsistent formats. Agent-generated IDs are guaranteed unique within the agent's namespace — the agent controls the format and collision avoidance.

### Why optional on both the response and product?

Making `feed_update_id` optional on the response allows agents to adopt update versioning incrementally without a breaking change. It is RECOMMENDED that agents that support it include it on every accepted upsert. On products, `last_update_id` is absent if the agent does not support update versioning.

### Why per-product instead of per-feed?

The version handshake at checkout is per-item — each line item references its own price provenance. A feed-level `last_update_id` would only reflect the most recent upsert, but different products in the same feed may have been updated by different upserts at different times. Per-product versioning lets the merchant (and the agent at checkout) reference the specific update version for each product independently.

### Why is the version handshake important?

Product feeds supply the prices agents display during discovery. At checkout, the agent needs to tell the seller where its price data came from. The `feed_update_id` is the natural provenance reference: "this price was observed in feed update `upd_7kQ9mR`." The seller can verify this is a known feed version and that the price was valid in that version. Without a structured version identifier, the agent has no reliable `source` to pass in `suggested_price`, breaking the feed-to-checkout provenance chain.

### Why not use `updated_at` alone?

Timestamps answer "when" but not "which." While `updated_at` can serve as a rough reference to the feed update, a structured version identifier provides a stronger provenance reference — one that deterministically identifies a specific feed state the seller can verify across the feed → checkout boundary.

### Why not sequence numbers?

Sequential integers imply strict total ordering — upsert N+1 always follows upsert N. In distributed agent architectures, strict ordering may not hold (concurrent processing, partitioned feeds). Opaque string IDs avoid implying ordering semantics the agent can't guarantee.

---

## 🔄 Backward Compatibility

- **Additive change**: `feed_update_id` is a new optional field on `UpsertProductsResponse`. Existing clients that don't read it are unaffected. Agents that don't generate it continue to return valid responses.
- **`last_update_id`** is a new optional field on `Product`. Existing clients reading products via `GET /feeds/{id}/products` will see an additional field they can ignore.
- **No breaking changes**: No existing fields are modified or removed. No existing behavior changes.
- **Severity**: None. Fully additive and backward compatible.

---

## 🛠️ Reference Implementation

Not yet available. Will provide before status "Final."

---

## 🔒 Security Implications

- **No sensitive data**: `feed_update_id` is an opaque agent-generated string. It does not contain PII, pricing data, or merchant secrets.
- **No new authentication surface**: The field is returned on existing authenticated endpoints. No new auth mechanisms required.
- **Enumeration risk**: `feed_update_id` values are returned only to authenticated callers who already have access to the feed. The identifier format should not be predictable (avoid sequential integers) to prevent information leakage about update frequency.
- **No new attack vectors**: Reading `last_update_id` via `GET /feeds/{id}/products` uses the same authorization as reading product data. No escalation of access.

---

## ✅ Pre-Submission Checklist

Before submitting this SEP PR, ensure:

- [x] I have created a GitHub Issue with the `SEP` and `proposal` tags
- [x] I have linked the SEP issue number above
- [ ] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [x] I have signed the [[Contributor License Agreement (CLA)](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/compare/legal/cla/INDIVIDUAL.md)](../legal/cla/INDIVIDUAL.md)
- [x] This PR includes updates to OpenAPI/JSON schemas (if applicable)
- [x] This PR includes example requests/responses (if applicable)
- [x] This PR includes a changelog entry file in `changelog/unreleased/add-feed-update-id.md`
- [ ] I am seeking or have found a sponsor (Founding Maintainer)

---

## 📚 Additional Context

### Relationship to Suggested Pricing (SEP #197)

SEP #197 proposes adding `suggested_price` to `Item` on `CheckoutSessionCreateRequest`, with a structured `PriceSource` object as the `source` field. `PriceSource` includes `feed_id`, `channel`, `feed_update_id`, and `updated_at`. The `feed_update_id` proposed here is the natural value for `PriceSource.feed_update_id` when the agent's price data comes from a product feed. Together, these two SEPs create a best-effort version handshake:

1. Merchant publishes feed update → agent returns `feed_update_id: "upd_7kQ9mR"`
2. Agent indexes products from that feed version
3. At checkout, agent passes `suggested_price.source.feed_update_id: "upd_7kQ9mR"`
4. It is RECOMMENDED that the seller verify `upd_7kQ9mR` is a known feed version and honor the price if valid — but if not honored, the checkout proceeds normally with the seller's current pricing breakdown

Without `feed_update_id`, the `PriceSource` in `suggested_price` has no structured per-product version to reference.

---

## 🙋 Questions for Reviewers

1. Should `last_update_id` on each product be cleared after a full replacement ingestion, or should it persist as a reference to the last API-based upsert that touched that product?
3. Should the spec recommend a specific format for `feed_update_id` or leave it entirely agent-defined?
