### PR TITLE
Fix delegate authentication result example validation

### DIFF
--- a/changelog/unreleased/fix-delegate-authentication-result-schema.md
+++ b/changelog/unreleased/fix-delegate-authentication-result-schema.md
@@ -1,0 +1,22 @@
+## Fix Delegate Authentication Result Schema Validation
+
+Delegate authentication retrieve-session examples now validate against the
+schema when they include an `authentication_result`.
+
+### Changes
+- Expanded example validation coverage for delegate authentication and feed
+  examples.
+- Fixed `DelegateAuthenticationSessionWithResult` so `authentication_result`
+  is accepted alongside the base session fields.
+- Applied the same schema correction to the 2026-04-17 version and unreleased
+  version.
+
+### Files Updated
+- `scripts/validate-consistency.js`
+- `spec/2026-04-17/json-schema/schema.delegate_authentication.json`
+- `spec/2026-04-17/openapi/openapi.delegate_authentication.yaml`
+- `spec/unreleased/json-schema/schema.delegate_authentication.json`
+- `spec/unreleased/openapi/openapi.delegate_authentication.yaml`
+
+### Reference
+- PR: #<pr-number>

--- a/scripts/validate-consistency.js
+++ b/scripts/validate-consistency.js
@@ -540,6 +540,85 @@ function validateOpenApiExamples() {
 }
 
 // 10. Validate examples against schemas
+function getExampleSchemaRef(spec, exampleName) {
+  if (spec === 'agentic_checkout') {
+    if (exampleName === 'complete_checkout_session_response') {
+      return '#/$defs/CheckoutSessionWithOrder';
+    }
+    if (exampleName.includes('checkout_session') && !exampleName.includes('request')) {
+      return '#/$defs/CheckoutSession';
+    }
+    if (exampleName.includes('create') && exampleName.includes('request')) {
+      return '#/$defs/CheckoutSessionCreateRequest';
+    }
+    if (exampleName.includes('update') && exampleName.includes('request')) {
+      return '#/$defs/CheckoutSessionUpdateRequest';
+    }
+    if (exampleName.includes('complete') && exampleName.includes('request')) {
+      return '#/$defs/CheckoutSessionCompleteRequest';
+    }
+    if (exampleName.includes('cancel') && exampleName.includes('request')) {
+      return '#/$defs/CancelSessionRequest';
+    }
+    if (exampleName.startsWith('discovery_response_')) {
+      return '#/$defs/DiscoveryResponse';
+    }
+    if (exampleName.startsWith('error_')) {
+      return '#/$defs/Error';
+    }
+  } else if (spec === 'delegate_authentication') {
+    if (exampleName.startsWith('create_authentication_session_request')) {
+      return '#/$defs/DelegateAuthenticationCreateRequest';
+    }
+    if (exampleName.startsWith('create_authentication_session_response')) {
+      return '#/$defs/DelegateAuthenticationSession';
+    }
+    if (exampleName.startsWith('authenticate_request')) {
+      return '#/$defs/DelegateAuthenticationAuthenticateRequest';
+    }
+    if (exampleName.startsWith('authenticate_response')) {
+      return '#/$defs/DelegateAuthenticationSession';
+    }
+    if (exampleName.startsWith('retrieve_session_response')) {
+      return '#/$defs/DelegateAuthenticationSessionWithResult';
+    }
+    if (exampleName.startsWith('error_')) {
+      return '#/$defs/Error';
+    }
+  } else if (spec === 'delegate_payment') {
+    if (exampleName === 'delegate_payment_request') {
+      return '#/$defs/DelegatePaymentRequest';
+    }
+    if (exampleName === 'delegate_payment_success_response') {
+      return '#/$defs/DelegatePaymentResponse';
+    }
+    if (exampleName.startsWith('delegate_payment_error_')) {
+      return '#/$defs/Error';
+    }
+  } else if (spec === 'feed') {
+    if (exampleName.startsWith('create_feed_request')) {
+      return '#/$defs/CreateFeedRequest';
+    }
+    if (exampleName === 'create_feed_response' || exampleName === 'get_feed_response') {
+      return '#/$defs/FeedMetadata';
+    }
+    if (exampleName === 'get_products_response') {
+      return '#/$defs/ProductsResponse';
+    }
+    if (exampleName.startsWith('upsert_products_request')) {
+      return '#/$defs/UpsertProductsRequest';
+    }
+    if (exampleName === 'upsert_products_response') {
+      return '#/$defs/UpsertProductsResponse';
+    }
+    if (exampleName.startsWith('feed_error_')) {
+      return '#/$defs/Error';
+    }
+  }
+
+  return null;
+}
+
 function validateExamples() {
   console.log('\n📝 Validating Examples Against Schemas...\n');
 
@@ -569,34 +648,12 @@ function validateExamples() {
         // Add the full schema (with $defs) to AJV
         ajv.addSchema(schema);
 
+        let validatedExamples = 0;
+
         // Examples file is an object with named examples
         Object.keys(examples).forEach(exampleName => {
           const example = examples[exampleName];
-
-          // Try to infer which schema this example should validate against
-          // agentic_checkout: checkout_session_*, create*request, complete*request
-          // delegate_payment: delegate_payment_request, delegate_payment_success_response, delegate_payment_error_*
-          let schemaRef = null;
-
-          if (spec === 'agentic_checkout') {
-            if (exampleName === 'complete_checkout_session_response') {
-              schemaRef = '#/$defs/CheckoutSessionWithOrder';
-            } else if (exampleName.includes('checkout_session') && !exampleName.includes('request')) {
-              schemaRef = '#/$defs/CheckoutSession';
-            } else if (exampleName.includes('create') && exampleName.includes('request')) {
-              schemaRef = '#/$defs/CheckoutSessionCreateRequest';
-            } else if (exampleName.includes('complete') && exampleName.includes('request')) {
-              schemaRef = '#/$defs/CheckoutSessionCompleteRequest';
-            }
-          } else if (spec === 'delegate_payment') {
-            if (exampleName === 'delegate_payment_request') {
-              schemaRef = '#/$defs/DelegatePaymentRequest';
-            } else if (exampleName === 'delegate_payment_success_response') {
-              schemaRef = '#/$defs/DelegatePaymentResponse';
-            } else if (exampleName.startsWith('delegate_payment_error_')) {
-              schemaRef = '#/$defs/Error';
-            }
-          }
+          const schemaRef = getExampleSchemaRef(spec, exampleName);
 
           // Skip validation if we can't determine the schema
           if (!schemaRef) {
@@ -609,10 +666,14 @@ function validateExamples() {
             const schemaKey = schema.$id ? schema.$id + schemaRef : schemaRef;
             const validate = ajv.getSchema(schemaKey);
             if (!validate) {
-              // Schema reference not found, skip silently
+              error(
+                `Schema reference "${schemaRef}" not found for example "${exampleName}"`,
+                { version, spec, example: exampleName, schemaRef }
+              );
               return;
             }
 
+            validatedExamples++;
             const valid = validate(example);
 
             if (!valid) {
@@ -627,12 +688,13 @@ function validateExamples() {
               );
             }
           } catch (validateErr) {
-            // Skip validation errors silently - examples might be partial
+            // Some historical schemas use older JSON Schema constructs that
+            // AJV cannot compile under this validator configuration.
             return;
           }
         });
 
-        success(`Examples validated for ${version}/${spec}`);
+        success(`Examples validated for ${version}/${spec} (${validatedExamples} mapped example(s))`);
       } catch (err) {
         error(`Error validating examples for ${version}/${spec}: ${err.message}`, { version, spec });
       }

--- a/spec/2026-04-17/json-schema/schema.delegate_authentication.json
+++ b/spec/2026-04-17/json-schema/schema.delegate_authentication.json
@@ -613,18 +613,37 @@
     },
     "DelegateAuthenticationSessionWithResult": {
       "description": "The session details including the final 3DS authentication result.",
-      "allOf": [
-        { "$ref": "#/$defs/DelegateAuthenticationSessionBase" },
-        {
-          "type": "object",
-          "description": "Container for the authentication outcome",
-          "properties": {
-            "authentication_result": {
-              "$ref": "#/$defs/AuthenticationResult"
-            }
-          }
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "authentication_session_id": {
+          "type": "string",
+          "description": "Session ID for subsequent requests"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "action_required",
+            "pending",
+            "not_supported",
+            "authenticated",
+            "attempted",
+            "not_authenticated",
+            "rejected",
+            "unavailable",
+            "expired",
+            "challenge_abandoned"
+          ],
+          "description": "Session status indicating current state and next action"
+        },
+        "action": {
+          "$ref": "#/$defs/Action"
+        },
+        "authentication_result": {
+          "$ref": "#/$defs/AuthenticationResult"
         }
-      ],
+      },
+      "required": ["authentication_session_id", "status"],
       "examples": [
         {
           "authentication_session_id": "auth_session_abc123",

--- a/spec/2026-04-17/openapi/openapi.delegate_authentication.yaml
+++ b/spec/2026-04-17/openapi/openapi.delegate_authentication.yaml
@@ -522,6 +522,8 @@ components:
 
     DelegateAuthenticationSessionWithResult:
       description: Response object containing the full session state and final result.
+      type: object
+      additionalProperties: false
       example:
         authentication_session_id: "auth_session_abc123"
         status: "authenticated"
@@ -530,13 +532,35 @@ components:
           transaction_id: "c4e59ceb-a382-4d6a-bc87-385d591fa09d"
           three_ds_server_trans_id: "6edcc246-23ee-4e94-ac5d-8ae620bea7d9"
           version: "2.2.0"
-      allOf:
-        - $ref: "#/components/schemas/DelegateAuthenticationSessionBase"
-        - type: object
-          description: Extension containing the authentication result data.
-          properties:
-            authentication_result:
-              $ref: "#/components/schemas/AuthenticationResult"
+      properties:
+        authentication_session_id:
+          type: string
+          description: Session ID for subsequent requests
+        status:
+          type: string
+          enum:
+            [
+              action_required,
+              pending,
+              not_supported,
+              authenticated,
+              attempted,
+              not_authenticated,
+              rejected,
+              unavailable,
+              expired,
+              challenge_abandoned,
+            ]
+          description: |
+            Current state of the session.
+            - action_required: Browser action needed.
+            - pending: Awaiting completion.
+            - not_supported: Method not available.
+        action:
+          $ref: "#/components/schemas/Action"
+        authentication_result:
+          $ref: "#/components/schemas/AuthenticationResult"
+      required: [authentication_session_id, status]
 
     # Data Models
     PaymentMethod:

--- a/spec/unreleased/json-schema/schema.delegate_authentication.json
+++ b/spec/unreleased/json-schema/schema.delegate_authentication.json
@@ -613,18 +613,37 @@
     },
     "DelegateAuthenticationSessionWithResult": {
       "description": "The session details including the final 3DS authentication result.",
-      "allOf": [
-        { "$ref": "#/$defs/DelegateAuthenticationSessionBase" },
-        {
-          "type": "object",
-          "description": "Container for the authentication outcome",
-          "properties": {
-            "authentication_result": {
-              "$ref": "#/$defs/AuthenticationResult"
-            }
-          }
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "authentication_session_id": {
+          "type": "string",
+          "description": "Session ID for subsequent requests"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "action_required",
+            "pending",
+            "not_supported",
+            "authenticated",
+            "attempted",
+            "not_authenticated",
+            "rejected",
+            "unavailable",
+            "expired",
+            "challenge_abandoned"
+          ],
+          "description": "Session status indicating current state and next action"
+        },
+        "action": {
+          "$ref": "#/$defs/Action"
+        },
+        "authentication_result": {
+          "$ref": "#/$defs/AuthenticationResult"
         }
-      ],
+      },
+      "required": ["authentication_session_id", "status"],
       "examples": [
         {
           "authentication_session_id": "auth_session_abc123",

--- a/spec/unreleased/openapi/openapi.delegate_authentication.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_authentication.yaml
@@ -522,6 +522,8 @@ components:
 
     DelegateAuthenticationSessionWithResult:
       description: Response object containing the full session state and final result.
+      type: object
+      additionalProperties: false
       example:
         authentication_session_id: "auth_session_abc123"
         status: "authenticated"
@@ -530,13 +532,35 @@ components:
           transaction_id: "c4e59ceb-a382-4d6a-bc87-385d591fa09d"
           three_ds_server_trans_id: "6edcc246-23ee-4e94-ac5d-8ae620bea7d9"
           version: "2.2.0"
-      allOf:
-        - $ref: "#/components/schemas/DelegateAuthenticationSessionBase"
-        - type: object
-          description: Extension containing the authentication result data.
-          properties:
-            authentication_result:
-              $ref: "#/components/schemas/AuthenticationResult"
+      properties:
+        authentication_session_id:
+          type: string
+          description: Session ID for subsequent requests
+        status:
+          type: string
+          enum:
+            [
+              action_required,
+              pending,
+              not_supported,
+              authenticated,
+              attempted,
+              not_authenticated,
+              rejected,
+              unavailable,
+              expired,
+              challenge_abandoned,
+            ]
+          description: |
+            Current state of the session.
+            - action_required: Browser action needed.
+            - pending: Awaiting completion.
+            - not_supported: Method not available.
+        action:
+          $ref: "#/components/schemas/Action"
+        authentication_result:
+          $ref: "#/components/schemas/AuthenticationResult"
+      required: [authentication_session_id, status]
 
     # Data Models
     PaymentMethod:


### PR DESCRIPTION
# Fix Delegate Authentication Result Example Validation

## 🔧 Type of Change

- [x] Bug fix (non-breaking)
- [x] Tooling improvement
- [x] Example update

---

## 📝 Description

This PR fixes the delegate-authentication result response schema so examples containing `authentication_result` validate cleanly. It also extends the consistency validator to map delegate-authentication and feed examples to their schemas instead of reporting those files as validated while only checking the older checkout/payment mappings.

---

## 🎯 Motivation and Context

The retrieve-session examples for delegate authentication include `authentication_result`, and the OpenAPI route also documents result-bearing responses. The JSON Schema used `allOf` with `additionalProperties: false` on the base session schema, so validators reject `authentication_result` as an additional property. Expanding the example mapping catches this drift locally.

Fixes/Addresses: N/A

---

## 🧪 Testing

- `pnpm install --frozen-lockfile`
- `pnpm run validate:all`
- `pnpm run compile:schema`
- `node --check scripts/validate-consistency.js`
- `git diff --check`

The updated validator now maps 23 delegate-authentication examples for both `2026-04-17` and `unreleased`, plus feed examples, and all validations pass.

---

## 📸 Screenshots / Examples

Before this change, `DelegateAuthenticationSessionWithResult` inherited the base session schema through `allOf`; that base schema sets `additionalProperties: false`, so `authentication_result` was rejected. The result schema now declares the complete response object directly, including optional `authentication_result`.

---

## ✅ Checklist

Before submitting, ensure:

- [ ] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (if applicable)
- [x] I have added/updated examples (if applicable)
- [x] I have added a changelog entry file to `changelog/unreleased/fix-delegate-authentication-result-schema.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [ ] All CI checks pass

---

## 🔍 Scope Verification

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ **This is a minor, straightforward change** (confirm by checking this)

---

## 📚 Additional Notes

No payment calls, credentials, or external services were used. The change is limited to validator coverage and the delegate-authentication response schema shape already implied by the examples and OpenAPI route documentation.

---

**Review Process**: Minor changes require approval from a Steward (may be from the same organization for efficiency). See [governance.md](../docs/governance.md) for details.