### PR TITLE
fix: correct MessageInfo, MessageWarning, and MessageError examples

### DIFF
--- a/changelog/unreleased/fix-message-type-examples.md
+++ b/changelog/unreleased/fix-message-type-examples.md
@@ -1,0 +1,12 @@
+## Fix MessageInfo, MessageWarning, and MessageError examples
+
+Corrected examples for all three message types in the unreleased OpenAPI spec and JSON Schema bundle. The examples introduced in #140 used fields that do not exist in any of the schemas (`id`, `message`, `display_context`) and omitted all required fields (`type`, `content_type`, `content`). Because all three schemas declare `additionalProperties: false`, the previous examples would fail schema validation in any tool that validates inline OpenAPI examples (e.g. Spectral, Redocly, openapi-generator).
+
+### Changes
+- `MessageInfo` example: replaced `id`/`message`/`display_context` with valid `type`/`content_type`/`content` fields
+- `MessageWarning` example: replaced `id`/`message` with valid `type`/`content_type`/`content` fields; retained valid `code` and `param`
+- `MessageError` example: replaced `id`/`message` with valid `type`/`content_type`/`content` fields; retained valid `code` and `param`
+
+### Files Updated
+- `spec/unreleased/openapi/openapi.agentic_checkout.yaml`
+- `spec/unreleased/json-schema/schema.agentic_checkout.json`

--- a/spec/unreleased/json-schema/schema.agentic_checkout.json
+++ b/spec/unreleased/json-schema/schema.agentic_checkout.json
@@ -1899,9 +1899,9 @@
         "content"
       ],
       "example": {
-        "id": "msg_info_01",
-        "message": "Free shipping on orders over $50",
-        "display_context": "banner"
+        "type": "info",
+        "content_type": "plain",
+        "content": "Free shipping on orders over $50"
       }
     },
     "MessageWarning": {
@@ -1978,9 +1978,10 @@
         "content"
       ],
       "example": {
-        "id": "msg_warn_01",
-        "message": "Only 2 items left in stock",
+        "type": "warning",
         "code": "low_stock",
+        "content_type": "plain",
+        "content": "Only 2 items left in stock",
         "param": "$.items[0]"
       }
     },
@@ -2065,9 +2066,10 @@
         "content"
       ],
       "example": {
-        "id": "msg_err_01",
-        "message": "Invalid email address format",
+        "type": "error",
         "code": "invalid",
+        "content_type": "plain",
+        "content": "Invalid email address format",
         "param": "$.buyer.email"
       }
     },

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -1813,9 +1813,9 @@ components:
         - content_type
         - content
       example:
-        id: msg_info_01
-        message: Free shipping on orders over $50
-        display_context: banner
+        type: info
+        content_type: plain
+        content: Free shipping on orders over $50
       description: Informational message to display to the buyer during checkout
     MessageWarning:
       type: object
@@ -1886,9 +1886,10 @@ components:
         - content_type
         - content
       example:
-        id: msg_warn_01
-        message: Only 2 items left in stock
+        type: warning
         code: low_stock
+        content_type: plain
+        content: Only 2 items left in stock
         param: $.items[0]
       description: Warning message to display to the buyer during checkout (non-blocking)
     MessageError:
@@ -1975,9 +1976,10 @@ components:
         - content_type
         - content
       example:
-        id: msg_err_01
-        message: Invalid email address format
+        type: error
         code: invalid
+        content_type: plain
+        content: Invalid email address format
         param: $.buyer.email
     GiftWrap:
       type: object


### PR DESCRIPTION
# Fix MessageInfo, MessageWarning, and MessageError examples

## 🔧 Type of Change

- [ ] Documentation fix/improvement
- [x] Bug fix (non-breaking)
- [ ] Tooling improvement
- [x] Example update
- [ ] Minor data/enum addition
- [ ] Other: [describe]

---

## 📝 Description

Corrects the inline `example` values for `MessageInfo`, `MessageWarning`, and `MessageError` in the unreleased OpenAPI spec and JSON Schema bundle.

The previous examples used fields that do not exist in any of the three schemas (`id`, `message`, `display_context`) and omitted all required fields (`type`, `content_type`, `content`). All three schemas declare `additionalProperties: false`, so the examples would fail schema validation in any tool that validates inline OpenAPI examples (e.g. Spectral, Redocly, openapi-generator).

---

## 🎯 Motivation and Context

The incorrect examples were introduced in #140 when examples were added in bulk to satisfy the new CI validation rule. The CI rule only checks for the *presence* of an example, not whether it is valid against its schema, so the mistake was not caught automatically.

---

## 🧪 Testing

- Manually verified each corrected example against the schema definition (required fields present, no extra fields, enum values valid).
- `pnpm run validate:all` passes with no errors or warnings.

---

## 📸 Screenshots / Examples

**Before (MessageError):**
```yaml
example:
  id: msg_err_01
  message: Invalid email address format
  code: invalid
  param: $.buyer.email
```

**After (MessageError):**
```yaml
example:
  type: error
  code: invalid
  content_type: plain
  content: Invalid email address format
  param: $.buyer.email
```

---

## ✅ Checklist

- [x] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (if applicable)
- [x] I have added/updated examples (if applicable)
- [x] I have added a changelog entry file to `changelog/unreleased/fix-message-type-examples.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [x] All CI checks pass

---

## 🔍 Scope Verification

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ **This is a minor, straightforward change** (confirm by checking this)

---

## 📚 Additional Notes

The same incorrect examples exist in `spec/2026-04-17/` (the current stable release) but are out of scope for this PR since that version is a historical snapshot.