### PR TITLE
ADMIN: Add Contributors to Meta Corporate CLA signatories

### DIFF
--- a/legal/cla/SIGNATORIES.md
+++ b/legal/cla/SIGNATORIES.md
@@ -2,7 +2,7 @@
 
 This file tracks contributors who have signed the Agentic Commerce Protocol Contributor License Agreement as required by Section 2.4 of the Collaboration and Governance Agreement dated November 21, 2025.
 
-Last updated: 2026-04-17
+Last updated: 2026-06-03
 
 ## Corporate CLA Signatories
 
@@ -15,7 +15,7 @@ Last updated: 2026-04-17
 | commercetools Inc. | 2026-02-19 | prateek-ct | prateek-ct,lgiavedoni | #145 |
 | OpenCommerce Network Inc. | 2026-02-26 | Barak Ben-Rachel | Barak-OC,dean-harel-nekuda-ai,ilayalog,vladikk,Idan-Levin | #163 |
 | Affirm Inc. | 2026-03-09 | Ethan Melnick | vcello,mirzar,tlevy | #172 |
-| Meta Platforms, Inc. | 2026-03-19 | poshannessy | lhwa,jamesandersen,srikun,kaichen2000,bretlorimore | #185 |
+| Meta Platforms, Inc. | 2026-03-19 | poshannessy | lhwa,jamesandersen,srikun,kaichen2000,bretlorimore,vig-star,victoralt,karangoel16 | #185 |
 | Agentic Commerce Inc. (Catalog) | 2026-03-30 | Dylan Farrell | dylanfarrell,h-gunasekara,jaycatalog,lukecatalog | #206 |
 | PayPal, Inc. | 2026-04-16 | cmonty-paypal | cmonty-paypal,sjparsons,bbcoumes,pranshu-10,jvujjini,sioked,wsbrunson,shubhamkokul,wenjiezhou,remotevision,zvuki,nmikhol,praneethiyyapu,mokinator | #210 |
 


### PR DESCRIPTION
# ADMIN: Add Contributors to Meta Corporate CLA signatories

## 🔑 Admin Action

- [ ] New Corporate CLA signatory (add to SIGNATORIES.md)
- [x] Schedule A update (add/remove authorized contributors for existing Corporate CLA)
- [ ] Other administrative change: [describe]

---

## 📝 Summary

Adding three new Meta contributors to the Meta Platforms, Inc. Corporate CLA authorized contributor list (Schedule A update)

---

## 🔗 Reference

Related: #185, #186

---

## ✅ Admin Checklist

- [x] I am an admin or authorized representative
- [x] The Corporate CLA issue has been reviewed and the signatory's authority verified
- [x] GitHub usernames in Schedule A have been validated as real accounts
- [x] SIGNATORIES.md is updated to reflect this change
- [ ] CLA Assistant allowlist is updated (add/remove usernames at https://cla-assistant.io/)

---
