### PR TITLE
fix: unwrap error envelope in released delegate_payment OpenAPI examples

### DIFF
--- a/changelog/unreleased/unwrap-error-envelope-released-delegate-payment.md
+++ b/changelog/unreleased/unwrap-error-envelope-released-delegate-payment.md
@@ -1,0 +1,23 @@
+## Unwrap error envelope in released delegate_payment OpenAPI examples
+
+Released-version follow-up to #243. #243 unwrapped the `error:` envelope from the inline error response examples in `spec/unreleased/openapi/openapi.delegate_payment.yaml` and noted the same wrapper bug existed in the released versions, to be handled in a follow-up. This is that follow-up.
+
+`Error` is `additionalProperties: false` with `type`, `code`, `message` required at the top level, so the wrapped `{ error: { ... } }` examples never validated against the schema they `$ref`. This change removes the wrapper from the affected response examples. Only the wrapper is removed — no `type`, `code`, `message`, or `param` values are changed.
+
+### Changes
+Unwrapped the `error:` envelope in error response examples across the five released `openapi.delegate_payment.yaml` files (7 each in 2025-09-29, 2025-12-12, 2026-01-16, 2026-01-30; 9 in 2026-04-17). Identical mechanical change to PR #243, applied to released versions.
+
+### Files Updated
+- `spec/2025-09-29/openapi/openapi.delegate_payment.yaml`
+- `spec/2025-12-12/openapi/openapi.delegate_payment.yaml`
+- `spec/2026-01-16/openapi/openapi.delegate_payment.yaml`
+- `spec/2026-01-30/openapi/openapi.delegate_payment.yaml`
+- `spec/2026-04-17/openapi/openapi.delegate_payment.yaml`
+
+### Notes
+After this change, the `invalid_request`-typed examples validate cleanly against `Error`. The 401/429/500/503 examples remain non-validating only because of `Error.type`/`code` enum gaps tracked in #161. The inline-example validator that detects this class of bug is added in a companion PR; once both land, its six `delegate_payment|#/components/schemas/Error|*` allowlist entries for the unwrapped examples can be removed.
+
+### Reference
+- PR: #243 (unreleased fix; deferred the released versions to this follow-up)
+- Issue: #161 (`Error` enum gaps for 401/429/500/503)
+- Issue: #21 (original report of the envelope mismatch)

--- a/spec/2025-09-29/openapi/openapi.delegate_payment.yaml
+++ b/spec/2025-09-29/openapi/openapi.delegate_payment.yaml
@@ -102,11 +102,10 @@ paths:
               examples:
                 invalid_request_missing_field:
                   value:
-                    error:
-                      type: invalid_request
-                      code: invalid_card
-                      message: "card field is required when payment_method.type=card"
-                      param: "payment_method.number"
+                    type: invalid_request
+                    code: invalid_card
+                    message: "card field is required when payment_method.type=card"
+                    param: "payment_method.number"
         "401":
           description: Unauthorized
           content:
@@ -115,10 +114,9 @@ paths:
               examples:
                 unauthorized:
                   value:
-                    error:
-                      type: unauthorized
-                      code: unauthorized
-                      message: "Unauthorized"
+                    type: unauthorized
+                    code: unauthorized
+                    message: "Unauthorized"
         "409":
           description: Idempotency conflict
           content:
@@ -127,10 +125,9 @@ paths:
               examples:
                 idem_conflict:
                   value:
-                    error:
-                      type: invalid_request
-                      code: idempotency_conflict
-                      message: "Same Idempotency-Key used with different parameters"
+                    type: invalid_request
+                    code: idempotency_conflict
+                    message: "Same Idempotency-Key used with different parameters"
         "422":
           description: Semantic validation error
           content:
@@ -139,11 +136,10 @@ paths:
               examples:
                 invalid_request:
                   value:
-                    error:
-                      type: invalid_request
-                      code: invalid_card
-                      message: "Invalid card expiration month"
-                      param: "payment_method.exp_month"
+                    type: invalid_request
+                    code: invalid_card
+                    message: "Invalid card expiration month"
+                    param: "payment_method.exp_month"
         "429":
           description: Rate limit exceeded
           content:
@@ -152,10 +148,9 @@ paths:
               examples:
                 rate_limit_exceeded:
                   value:
-                    error:
-                      type: rate_limit_exceeded
-                      code: rate_limit_exceeded
-                      message: "Rate limit exceeded"
+                    type: rate_limit_exceeded
+                    code: rate_limit_exceeded
+                    message: "Rate limit exceeded"
         "500":
           description: Processing error
           content:
@@ -164,10 +159,9 @@ paths:
               examples:
                 internal_server_error:
                   value:
-                    error:
-                      type: internal_server_error
-                      code: internal_server_error
-                      message: "Internal server error"
+                    type: internal_server_error
+                    code: internal_server_error
+                    message: "Internal server error"
         "503":
           description: Service unavailable
           content:
@@ -176,10 +170,9 @@ paths:
               examples:
                 service_unavailable:
                   value:
-                    error:
-                      type: service_unavailable
-                      code: service_unavailable
-                      message: "Service unavailable"
+                    type: service_unavailable
+                    code: service_unavailable
+                    message: "Service unavailable"
 
 components:
   securitySchemes:

--- a/spec/2025-12-12/openapi/openapi.delegate_payment.yaml
+++ b/spec/2025-12-12/openapi/openapi.delegate_payment.yaml
@@ -102,11 +102,10 @@ paths:
               examples:
                 invalid_request_missing_field:
                   value:
-                    error:
-                      type: invalid_request
-                      code: invalid_card
-                      message: "card field is required when payment_method.type=card"
-                      param: "payment_method.number"
+                    type: invalid_request
+                    code: invalid_card
+                    message: "card field is required when payment_method.type=card"
+                    param: "payment_method.number"
         "401":
           description: Unauthorized
           content:
@@ -115,10 +114,9 @@ paths:
               examples:
                 unauthorized:
                   value:
-                    error:
-                      type: unauthorized
-                      code: unauthorized
-                      message: "Unauthorized"
+                    type: unauthorized
+                    code: unauthorized
+                    message: "Unauthorized"
         "409":
           description: Idempotency conflict
           content:
@@ -127,10 +125,9 @@ paths:
               examples:
                 idem_conflict:
                   value:
-                    error:
-                      type: invalid_request
-                      code: idempotency_conflict
-                      message: "Same Idempotency-Key used with different parameters"
+                    type: invalid_request
+                    code: idempotency_conflict
+                    message: "Same Idempotency-Key used with different parameters"
         "422":
           description: Semantic validation error
           content:
@@ -139,11 +136,10 @@ paths:
               examples:
                 invalid_request:
                   value:
-                    error:
-                      type: invalid_request
-                      code: invalid_card
-                      message: "Invalid card expiration month"
-                      param: "payment_method.exp_month"
+                    type: invalid_request
+                    code: invalid_card
+                    message: "Invalid card expiration month"
+                    param: "payment_method.exp_month"
         "429":
           description: Rate limit exceeded
           content:
@@ -152,10 +148,9 @@ paths:
               examples:
                 rate_limit_exceeded:
                   value:
-                    error:
-                      type: rate_limit_exceeded
-                      code: rate_limit_exceeded
-                      message: "Rate limit exceeded"
+                    type: rate_limit_exceeded
+                    code: rate_limit_exceeded
+                    message: "Rate limit exceeded"
         "500":
           description: Processing error
           content:
@@ -164,10 +159,9 @@ paths:
               examples:
                 internal_server_error:
                   value:
-                    error:
-                      type: internal_server_error
-                      code: internal_server_error
-                      message: "Internal server error"
+                    type: internal_server_error
+                    code: internal_server_error
+                    message: "Internal server error"
         "503":
           description: Service unavailable
           content:
@@ -176,10 +170,9 @@ paths:
               examples:
                 service_unavailable:
                   value:
-                    error:
-                      type: service_unavailable
-                      code: service_unavailable
-                      message: "Service unavailable"
+                    type: service_unavailable
+                    code: service_unavailable
+                    message: "Service unavailable"
 
 components:
   securitySchemes:

--- a/spec/2026-01-16/openapi/openapi.delegate_payment.yaml
+++ b/spec/2026-01-16/openapi/openapi.delegate_payment.yaml
@@ -102,11 +102,10 @@ paths:
               examples:
                 invalid_request_missing_field:
                   value:
-                    error:
-                      type: invalid_request
-                      code: invalid_card
-                      message: "card field is required when payment_method.type=card"
-                      param: "payment_method.number"
+                    type: invalid_request
+                    code: invalid_card
+                    message: "card field is required when payment_method.type=card"
+                    param: "payment_method.number"
         "401":
           description: Unauthorized
           content:
@@ -115,10 +114,9 @@ paths:
               examples:
                 unauthorized:
                   value:
-                    error:
-                      type: unauthorized
-                      code: unauthorized
-                      message: "Unauthorized"
+                    type: unauthorized
+                    code: unauthorized
+                    message: "Unauthorized"
         "409":
           description: Idempotency conflict
           content:
@@ -127,10 +125,9 @@ paths:
               examples:
                 idem_conflict:
                   value:
-                    error:
-                      type: invalid_request
-                      code: idempotency_conflict
-                      message: "Same Idempotency-Key used with different parameters"
+                    type: invalid_request
+                    code: idempotency_conflict
+                    message: "Same Idempotency-Key used with different parameters"
         "422":
           description: Semantic validation error
           content:
@@ -139,11 +136,10 @@ paths:
               examples:
                 invalid_request:
                   value:
-                    error:
-                      type: invalid_request
-                      code: invalid_card
-                      message: "Invalid card expiration month"
-                      param: "payment_method.exp_month"
+                    type: invalid_request
+                    code: invalid_card
+                    message: "Invalid card expiration month"
+                    param: "payment_method.exp_month"
         "429":
           description: Rate limit exceeded
           content:
@@ -152,10 +148,9 @@ paths:
               examples:
                 rate_limit_exceeded:
                   value:
-                    error:
-                      type: rate_limit_exceeded
-                      code: rate_limit_exceeded
-                      message: "Rate limit exceeded"
+                    type: rate_limit_exceeded
+                    code: rate_limit_exceeded
+                    message: "Rate limit exceeded"
         "500":
           description: Processing error
           content:
@@ -164,10 +159,9 @@ paths:
               examples:
                 internal_server_error:
                   value:
-                    error:
-                      type: internal_server_error
-                      code: internal_server_error
-                      message: "Internal server error"
+                    type: internal_server_error
+                    code: internal_server_error
+                    message: "Internal server error"
         "503":
           description: Service unavailable
           content:
@@ -176,10 +170,9 @@ paths:
               examples:
                 service_unavailable:
                   value:
-                    error:
-                      type: service_unavailable
-                      code: service_unavailable
-                      message: "Service unavailable"
+                    type: service_unavailable
+                    code: service_unavailable
+                    message: "Service unavailable"
 
 components:
   securitySchemes:

--- a/spec/2026-01-30/openapi/openapi.delegate_payment.yaml
+++ b/spec/2026-01-30/openapi/openapi.delegate_payment.yaml
@@ -102,11 +102,10 @@ paths:
               examples:
                 invalid_request_missing_field:
                   value:
-                    error:
-                      type: invalid_request
-                      code: invalid_card
-                      message: "card field is required when payment_method.type=card"
-                      param: "payment_method.number"
+                    type: invalid_request
+                    code: invalid_card
+                    message: "card field is required when payment_method.type=card"
+                    param: "payment_method.number"
         "401":
           description: Unauthorized
           content:
@@ -115,10 +114,9 @@ paths:
               examples:
                 unauthorized:
                   value:
-                    error:
-                      type: unauthorized
-                      code: unauthorized
-                      message: "Unauthorized"
+                    type: unauthorized
+                    code: unauthorized
+                    message: "Unauthorized"
         "409":
           description: Idempotency conflict
           content:
@@ -127,10 +125,9 @@ paths:
               examples:
                 idem_conflict:
                   value:
-                    error:
-                      type: invalid_request
-                      code: idempotency_conflict
-                      message: "Same Idempotency-Key used with different parameters"
+                    type: invalid_request
+                    code: idempotency_conflict
+                    message: "Same Idempotency-Key used with different parameters"
         "422":
           description: Semantic validation error
           content:
@@ -139,11 +136,10 @@ paths:
               examples:
                 invalid_request:
                   value:
-                    error:
-                      type: invalid_request
-                      code: invalid_card
-                      message: "Invalid card expiration month"
-                      param: "payment_method.exp_month"
+                    type: invalid_request
+                    code: invalid_card
+                    message: "Invalid card expiration month"
+                    param: "payment_method.exp_month"
         "429":
           description: Rate limit exceeded
           content:
@@ -152,10 +148,9 @@ paths:
               examples:
                 rate_limit_exceeded:
                   value:
-                    error:
-                      type: rate_limit_exceeded
-                      code: rate_limit_exceeded
-                      message: "Rate limit exceeded"
+                    type: rate_limit_exceeded
+                    code: rate_limit_exceeded
+                    message: "Rate limit exceeded"
         "500":
           description: Processing error
           content:
@@ -164,10 +159,9 @@ paths:
               examples:
                 internal_server_error:
                   value:
-                    error:
-                      type: internal_server_error
-                      code: internal_server_error
-                      message: "Internal server error"
+                    type: internal_server_error
+                    code: internal_server_error
+                    message: "Internal server error"
         "503":
           description: Service unavailable
           content:
@@ -176,10 +170,9 @@ paths:
               examples:
                 service_unavailable:
                   value:
-                    error:
-                      type: service_unavailable
-                      code: service_unavailable
-                      message: "Service unavailable"
+                    type: service_unavailable
+                    code: service_unavailable
+                    message: "Service unavailable"
 
 components:
   securitySchemes:

--- a/spec/2026-04-17/openapi/openapi.delegate_payment.yaml
+++ b/spec/2026-04-17/openapi/openapi.delegate_payment.yaml
@@ -116,17 +116,15 @@ paths:
               examples:
                 invalid_request_missing_field:
                   value:
-                    error:
-                      type: invalid_request
-                      code: invalid_card
-                      message: card field is required when payment_method.type=card
-                      param: payment_method.number
+                    type: invalid_request
+                    code: invalid_card
+                    message: card field is required when payment_method.type=card
+                    param: payment_method.number
                 idempotency_key_required:
                   value:
-                    error:
-                      type: invalid_request
-                      code: idempotency_key_required
-                      message: Idempotency-Key header is required
+                    type: invalid_request
+                    code: idempotency_key_required
+                    message: Idempotency-Key header is required
         "401":
           description: Unauthorized
           content:
@@ -136,10 +134,9 @@ paths:
               examples:
                 unauthorized:
                   value:
-                    error:
-                      type: unauthorized
-                      code: unauthorized
-                      message: Unauthorized
+                    type: unauthorized
+                    code: unauthorized
+                    message: Unauthorized
         "409":
           description: In-flight collision — original request still processing
           headers:
@@ -155,10 +152,9 @@ paths:
               examples:
                 idempotency_in_flight:
                   value:
-                    error:
-                      type: invalid_request
-                      code: idempotency_in_flight
-                      message: A request with this Idempotency-Key is currently being processed
+                    type: invalid_request
+                    code: idempotency_in_flight
+                    message: A request with this Idempotency-Key is currently being processed
         "422":
           description: Semantic validation error
           content:
@@ -168,17 +164,15 @@ paths:
               examples:
                 invalid_request:
                   value:
-                    error:
-                      type: invalid_request
-                      code: invalid_card
-                      message: Invalid card expiration month
-                      param: payment_method.exp_month
+                    type: invalid_request
+                    code: invalid_card
+                    message: Invalid card expiration month
+                    param: payment_method.exp_month
                 idempotency_conflict:
                   value:
-                    error:
-                      type: invalid_request
-                      code: idempotency_conflict
-                      message: Idempotency-Key has already been used with a different request body
+                    type: invalid_request
+                    code: idempotency_conflict
+                    message: Idempotency-Key has already been used with a different request body
         "429":
           description: Rate limit exceeded
           content:
@@ -188,10 +182,9 @@ paths:
               examples:
                 rate_limit_exceeded:
                   value:
-                    error:
-                      type: rate_limit_exceeded
-                      code: rate_limit_exceeded
-                      message: Rate limit exceeded
+                    type: rate_limit_exceeded
+                    code: rate_limit_exceeded
+                    message: Rate limit exceeded
         "500":
           description: Processing error
           content:
@@ -201,10 +194,9 @@ paths:
               examples:
                 internal_server_error:
                   value:
-                    error:
-                      type: internal_server_error
-                      code: internal_server_error
-                      message: Internal server error
+                    type: internal_server_error
+                    code: internal_server_error
+                    message: Internal server error
         "503":
           description: Service unavailable
           content:
@@ -214,10 +206,9 @@ paths:
               examples:
                 service_unavailable:
                   value:
-                    error:
-                      type: service_unavailable
-                      code: service_unavailable
-                      message: Service unavailable
+                    type: service_unavailable
+                    code: service_unavailable
+                    message: Service unavailable
 components:
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
## Type of Change
- [x] Bug fix (non-breaking)
- [x] Example update

## Description
This is the released-version follow-up to #243, pulled out of #252 after review feedback. #252 now only adds the validator, and this PR only carries the example fix.

#243 removed the `error:` wrapper from the inline error response examples in `spec/unreleased/openapi/openapi.delegate_payment.yaml` and noted that the released versions still had the same wrapper, to be cleaned up later. This is that cleanup.

The `Error` schema is `additionalProperties: false` with `type`, `code`, and `message` required at the top level, so the wrapped `{ error: { ... } }` examples never matched the schema they reference. This PR drops the wrapper and lifts the fields up a level. None of the `type`, `code`, `message`, or `param` values change.

37 examples were unwrapped: 7 each in 2025-09-29, 2025-12-12, 2026-01-16, and 2026-01-30, and 9 in 2026-04-17.

## Motivation and Context
The wrapped examples never validated against the schema they point at, so anyone reading the spec or generating code from them gets the wrong shape for an error response. #243 fixed this for the unreleased spec and left the released versions for a separate change. Keeping it apart from the validator in #252 makes both easier to review.

## Testing
`pnpm run compile:schema` and `pnpm run validate:all` both pass. The diff only removes the wrapper line and re-indents the fields under it, so no example values change. I also ran the validator from #252 against these unwrapped files to confirm the combined result is clean.

## Screenshots / Examples
Before (`spec/2026-04-17/openapi/openapi.delegate_payment.yaml`):

```yaml
unauthorized:
  value:
    error:
      type: unauthorized
      code: unauthorized
      message: Unauthorized
```

After:

```yaml
unauthorized:
  value:
    type: unauthorized
    code: unauthorized
    message: Unauthorized
```

## Checklist
- [x] My change follows the project's code style and conventions
- [x] I added a changelog entry at `changelog/unreleased/unwrap-error-envelope-released-delegate-payment.md`
- [x] I tested locally (`pnpm run compile:schema` and `pnpm run validate:all`)
- [x] This change does not require a SEP (mechanical example fix, same shape as #243)

## Scope Verification
- [x] Minor, straightforward change. No protocol features, no schema changes, no breaking changes. Only example values lose their wrapper.

## Additional Notes
Once this and #252 both land, the `invalid_request` examples validate cleanly. The 401, 429, 500, and 503 examples still fail, but only because of the `Error` enum gaps tracked in #161, which is a separate issue. At that point the six `delegate_payment|#/components/schemas/Error|*` allowlist entries #252 adds for these examples can be removed.

Related: follows #243, companion to #252, tracks #161 and #21.
