### PR TITLE
docs: fix PR template links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/minor-improvement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/minor-improvement.md
@@ -80,7 +80,7 @@ Fixes/Addresses: #[issue number]
 
 Before submitting, ensure:
 
-- [ ] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
+- [ ] I have signed the [Contributor License Agreement (CLA)](../../legal/cla/INDIVIDUAL.md)
 - [ ] My change follows the project's code style and conventions
 - [ ] I have updated relevant documentation (if applicable)
 - [ ] I have added/updated examples (if applicable)
@@ -119,4 +119,4 @@ Before submitting, ensure:
 
 ---
 
-**Review Process**: Minor changes require approval from a Steward (may be from the same organization for efficiency). See [governance.md](../docs/governance.md) for details.
+**Review Process**: Minor changes require approval from a Steward (may be from the same organization for efficiency). See [governance.md](../../docs/governance.md) for details.

--- a/.github/PULL_REQUEST_TEMPLATE/sep-proposal.md
+++ b/.github/PULL_REQUEST_TEMPLATE/sep-proposal.md
@@ -123,7 +123,7 @@ Before submitting this SEP PR, ensure:
 - [ ] I have created a GitHub Issue with the `SEP` and `proposal` tags
 - [ ] I have linked the SEP issue number above
 - [ ] I have discussed this proposal in the community (Discord/GitHub Discussions)
-- [ ] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
+- [ ] I have signed the [Contributor License Agreement (CLA)](../../legal/cla/INDIVIDUAL.md)
 - [ ] This PR includes updates to OpenAPI/JSON schemas (if applicable)
 - [ ] This PR includes example requests/responses (if applicable)
 - [ ] This PR includes a changelog entry file in `changelog/unreleased/your-change-description.md`
@@ -155,4 +155,4 @@ Before submitting this SEP PR, ensure:
 
 ---
 
-**Note**: SEPs require unanimous approval from Founding Maintainers. See [governance.md](../docs/governance.md) and [sep-guidelines.md](../docs/sep-guidelines.md) for the full process.
+**Note**: SEPs require unanimous approval from Founding Maintainers. See [governance.md](../../docs/governance.md) and [sep-guidelines.md](../../docs/sep-guidelines.md) for the full process.

--- a/changelog/unreleased/fix-pr-template-links.md
+++ b/changelog/unreleased/fix-pr-template-links.md
@@ -1,0 +1,14 @@
+# Fix PR Template Links
+
+**Fixed** -- broken relative links in contributor-facing PR templates
+
+## Overview
+Correct the PR template links that point to the CLA and governance docs so contributors can open the referenced files directly from GitHub's pull request UI.
+
+## Changes
+- **Minor improvement template**: Fixed the CLA and governance doc links to resolve from `.github/PULL_REQUEST_TEMPLATE/`
+- **SEP template**: Fixed the CLA, governance, and SEP guideline links to resolve from `.github/PULL_REQUEST_TEMPLATE/`
+
+### Files Updated
+- `.github/PULL_REQUEST_TEMPLATE/minor-improvement.md`
+- `.github/PULL_REQUEST_TEMPLATE/sep-proposal.md`


### PR DESCRIPTION
## Summary
- fix broken relative links to CLA and governance docs in the minor-improvement PR template
- fix broken relative links to CLA, governance, and SEP guidelines docs in the SEP PR template
- add an unreleased changelog entry for the contributor-facing docs fix

## Testing
- verified each updated relative link resolves to an existing file locally

## AI disclosure
- This PR was written primarily by Codex with human-directed review of the scope and changes.
