### PR TITLE
docs: fix discount extension example links

### DIFF
--- a/changelog/unreleased/fix-discount-example-links.md
+++ b/changelog/unreleased/fix-discount-example-links.md
@@ -1,0 +1,14 @@
+# Fix Discount Example Links
+
+**Fixed** -- broken relative links in discount-extension example documentation
+
+## Overview
+Correct the versioned discount-extension README links so contributors can open the referenced RFCs and matching JSON Schema files directly from GitHub.
+
+## Changes
+- **2026-04-17 example**: Fixed the RFC links to resolve from the versioned example directory
+- **2026-01-30 example**: Fixed the RFC links and pointed the schema link at the matching versioned schema instead of `unreleased`
+
+### Files Updated
+- `examples/2026-04-17/discount-extension/README.md`
+- `examples/2026-01-30/discount-extension/README.md`

--- a/examples/2026-01-30/discount-extension/README.md
+++ b/examples/2026-01-30/discount-extension/README.md
@@ -124,7 +124,6 @@ When multiple discounts are stacked, `priority` determines calculation order:
 
 ## Related Documentation
 
-- [RFC: Extensions Framework](../../rfcs/rfc.extensions.md)
-- [RFC: Discount Extension](../../rfcs/rfc.discount_extension.md)
-- [JSON Schema](../../spec/unreleased/json-schema/schema.discount.json)
-
+- [RFC: Extensions Framework](../../../rfcs/rfc.extensions.md)
+- [RFC: Discount Extension](../../../rfcs/rfc.discount_extension.md)
+- [JSON Schema](../../../spec/2026-01-30/json-schema/schema.discount.json)

--- a/examples/2026-04-17/discount-extension/README.md
+++ b/examples/2026-04-17/discount-extension/README.md
@@ -124,6 +124,6 @@ When multiple discounts are stacked, `priority` determines calculation order:
 
 ## Related Documentation
 
-- [RFC: Extensions Framework](../../rfcs/rfc.extensions.md)
-- [RFC: Discount Extension](../../rfcs/rfc.discount_extension.md)
+- [RFC: Extensions Framework](../../../rfcs/rfc.extensions.md)
+- [RFC: Discount Extension](../../../rfcs/rfc.discount_extension.md)
 - [JSON Schema](../../../spec/2026-04-17/json-schema/schema.discount.json)


### PR DESCRIPTION
## Summary
- fix broken RFC links in both versioned discount-extension example READMEs
- point the 2026-01-30 example at its matching versioned schema instead of `unreleased`
- add the required changelog entry for the docs-only fix

## Validation
- verified all updated relative links resolve to existing files in the repo
