### PR TITLE
fix: align checkout request line_items with LineItem

### DIFF
--- a/changelog/unreleased/fix-line-item-request-schema.md
+++ b/changelog/unreleased/fix-line-item-request-schema.md
@@ -1,0 +1,15 @@
+## Fix checkout request line item schema references
+
+The checkout request schemas pointed `line_items` at `Item` instead of `LineItem` in the versioned OpenAPI files. That dropped the quantity-bearing request shape from generated clients and left the create-request examples out of sync with the schema.
+
+### Changes
+- Updated `CheckoutSessionCreateRequest.line_items` and `CheckoutSessionUpdateRequest.line_items` to reference `LineItem` in the `2026-01-30`, `2026-04-17`, and `unreleased` OpenAPI specs
+- Corrected the create-request examples to use `line_items` with `LineItem`-shaped entries
+
+### Files Updated
+- `spec/2026-01-30/openapi/openapi.agentic_checkout.yaml`
+- `spec/2026-04-17/openapi/openapi.agentic_checkout.yaml`
+- `spec/unreleased/openapi/openapi.agentic_checkout.yaml`
+
+### Reference
+- Issue: #264

--- a/spec/2026-01-30/openapi/openapi.agentic_checkout.yaml
+++ b/spec/2026-01-30/openapi/openapi.agentic_checkout.yaml
@@ -1984,7 +1984,7 @@ components:
         buyer: { $ref: "#/components/schemas/Buyer", description: "Buyer information" }
         line_items:
           type: array
-          items: { $ref: "#/components/schemas/Item" }
+          items: { $ref: "#/components/schemas/LineItem" }
           minItems: 1
           description: "Items to add to the checkout session"
         currency: { type: string, description: "ISO 4217 currency code" }
@@ -2013,9 +2013,16 @@ components:
       required: [line_items, currency, capabilities]
       example:
         line_items:
-          - id: "item_123"
-            name: "Wireless Headphones"
-            unit_amount: 7999
+          - id: "li_001"
+            item:
+              id: "item_123"
+              name: "Wireless Headphones"
+              unit_amount: 7999
+            quantity: 2
+            totals:
+              - type: "subtotal"
+                display_text: "Subtotal"
+                amount: 15998
         currency: "usd"
         capabilities:
           payment:
@@ -2041,7 +2048,7 @@ components:
         buyer: { $ref: "#/components/schemas/Buyer", description: "Updated buyer information" }
         line_items:
           type: array
-          items: { $ref: "#/components/schemas/Item" }
+          items: { $ref: "#/components/schemas/LineItem" }
           description: "Items to update in the checkout session"
         fulfillment_details: { $ref: "#/components/schemas/FulfillmentDetails", description: "Updated fulfillment contact and address" }
         fulfillment_groups:

--- a/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
+++ b/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
@@ -2975,7 +2975,7 @@ components:
         line_items:
           type: array
           items:
-            $ref: "#/components/schemas/Item"
+            $ref: "#/components/schemas/LineItem"
           minItems: 1
           description: Items to add to the checkout session
         currency:
@@ -3019,9 +3019,17 @@ components:
         - currency
         - capabilities
       example:
-        items:
-          - product_id: prod_tshirt_blue_m
+        line_items:
+          - id: item_001
+            item:
+              id: prod_tshirt_blue_m
+              name: Organic Cotton T-Shirt
+              unit_amount: 2900
             quantity: 2
+            totals:
+              - type: subtotal
+                display_text: Subtotal
+                amount: 5800
         currency: usd
         capabilities: {}
       description: Request to create a new checkout session
@@ -3034,7 +3042,7 @@ components:
         line_items:
           type: array
           items:
-            $ref: "#/components/schemas/Item"
+            $ref: "#/components/schemas/LineItem"
           description: Items to update in the checkout session
         fulfillment_details:
           $ref: "#/components/schemas/FulfillmentDetails"

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -3032,7 +3032,7 @@ components:
         line_items:
           type: array
           items:
-            $ref: "#/components/schemas/Item"
+            $ref: "#/components/schemas/LineItem"
           minItems: 1
           description: Items to add to the checkout session
         currency:
@@ -3076,9 +3076,17 @@ components:
         - currency
         - capabilities
       example:
-        items:
-          - product_id: prod_tshirt_blue_m
+        line_items:
+          - id: item_001
+            item:
+              id: prod_tshirt_blue_m
+              name: Organic Cotton T-Shirt
+              unit_amount: 2900
             quantity: 2
+            totals:
+              - type: subtotal
+                display_text: Subtotal
+                amount: 5800
         currency: usd
         capabilities: {}
       description: Request to create a new checkout session
@@ -3091,7 +3099,7 @@ components:
         line_items:
           type: array
           items:
-            $ref: "#/components/schemas/Item"
+            $ref: "#/components/schemas/LineItem"
           description: Items to update in the checkout session
         fulfillment_details:
           $ref: "#/components/schemas/FulfillmentDetails"


### PR DESCRIPTION
Issue #264 identified that the checkout request schemas still typed line_items as Item in the versioned OpenAPI specs. That dropped the quantity-bearing request shape from generated clients and left the request examples inconsistent with the schema.

This commit updates CheckoutSessionCreateRequest and CheckoutSessionUpdateRequest to reference LineItem in the 2026-01-30, 2026-04-17, and unreleased OpenAPI files. It also rewrites the create-session examples in those files to use line_items entries with item, quantity, and totals so the documented payload matches the corrected schema.

A changelog entry is included at changelog/unreleased/fix-line-item-request-schema.md.

Validation: npm run validate:all