### PR TITLE
Add Server-Timing response headers

### DIFF
--- a/changelog/unreleased/add-server-timing-header.md
+++ b/changelog/unreleased/add-server-timing-header.md
@@ -1,0 +1,3 @@
+## Added
+
+- Document optional `Server-Timing` response headers across ACP REST OpenAPI specs and RFCs. ACP responses should use the `acp` metric with `dur` in milliseconds, for example `Server-Timing: acp;dur=42.3`.

--- a/rfcs/rfc.agentic_checkout.md
+++ b/rfcs/rfc.agentic_checkout.md
@@ -74,6 +74,7 @@ All endpoints **MUST** use HTTPS and return JSON. Amounts **MUST** be integers i
 
 - `Idempotency-Key` — echo on all POST responses
 - `Request-Id` — echo if provided
+- `Server-Timing` — optional server processing duration. When present, ACP responses **SHOULD** use the `acp` metric with `dur` in milliseconds, for example `Server-Timing: acp;dur=42.3`. This value excludes network time and is informational; clients **SHOULD** measure client-observed latency independently.
 
 **Error Shape (flat):**
 

--- a/rfcs/rfc.cart.md
+++ b/rfcs/rfc.cart.md
@@ -126,6 +126,7 @@ All endpoints follow ACP's existing HTTP conventions:
 - `Authorization: Bearer <token>` required.
 - `API-Version` header required.
 - `Idempotency-Key` required on all POST requests.
+- Responses MAY include `Server-Timing` with the `acp` metric and `dur` in milliseconds, for example `Server-Timing: acp;dur=42.3`. This value excludes network time and is informational; agents SHOULD measure client-observed latency independently.
 - Amounts in minor currency units (cents).
 
 ### 4.2 Create Cart

--- a/rfcs/rfc.delegate_authentication.md
+++ b/rfcs/rfc.delegate_authentication.md
@@ -72,6 +72,7 @@ All endpoints **MUST** use HTTPS and return JSON.
 
 - `Idempotency-Key` - echo if provided
 - `Request-Id` - echo if provided
+- `Server-Timing` - optional server processing duration. When present, ACP responses **SHOULD** use the `acp` metric with `dur` in milliseconds, for example `Server-Timing: acp;dur=42.3`. This value excludes network time and is informational; clients **SHOULD** measure client-observed latency independently.
 
 **Error Shape (flat):**
 

--- a/rfcs/rfc.delegate_payment.md
+++ b/rfcs/rfc.delegate_payment.md
@@ -58,6 +58,7 @@ The key words **MUST**, **MUST NOT**, **SHOULD**, **MAY** are to be interpreted 
 
 - On success, server **MUST** return `201 Created` with a unique token `id` and `created` timestamp.
 - Response **MUST** echo correlation data under `metadata` when applicable (e.g., `merchant_id`, `idempotency_key`).
+- Response **MAY** include `Server-Timing` with the `acp` metric and `dur` in milliseconds, for example `Server-Timing: acp;dur=42.3`. This value excludes network time and is informational; clients **SHOULD** measure client-observed latency independently.
 
 ### 2.5 Usage & Expiry
 

--- a/rfcs/rfc.product_feeds.md
+++ b/rfcs/rfc.product_feeds.md
@@ -519,6 +519,10 @@ All endpoints follow ACP REST conventions:
   explicitly authorizes public read-only access to the agent-hosted feed.
 - `API-Version` required.
 - Mutating requests SHOULD use idempotency where supported.
+- Responses MAY include `Server-Timing` with the `acp` metric and `dur` in
+  milliseconds, for example `Server-Timing: acp;dur=42.3`. This value excludes
+  network time and is informational; callers SHOULD measure client-observed
+  latency independently.
 - Errors use ACP's flat error shape:
 
 ```json

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -96,6 +96,8 @@ paths:
               description: Echo of the request correlation id
               schema:
                 type: string
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -173,6 +175,8 @@ paths:
                 type: string
                 enum:
                   - "true"
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -204,6 +208,9 @@ paths:
       responses:
         "200":
           description: Current session
+          headers:
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -288,6 +295,8 @@ paths:
                 type: string
                 enum:
                   - "true"
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -355,6 +364,8 @@ paths:
                 type: string
                 enum:
                   - "true"
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -377,6 +388,13 @@ components:
       type: http
       scheme: bearer
       bearerFormat: API Key
+  headers:
+    ServerTiming:
+      required: false
+      description: Optional merchant-reported server processing duration using the W3C Server-Timing header. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing. ACP responses SHOULD use the `acp` metric with `dur` in milliseconds, for example `acp;dur=42.3`. This excludes network time and is informational; platforms SHOULD measure client-observed latency independently.
+      schema:
+        type: string
+        example: acp;dur=42.3
   parameters:
     Authorization:
       name: Authorization

--- a/spec/unreleased/openapi/openapi.agentic_checkout_webhook.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout_webhook.yaml
@@ -154,6 +154,9 @@ paths:
       responses:
         "200":
           description: Event accepted
+          headers:
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -209,6 +212,13 @@ paths:
               schema: { $ref: "#/components/schemas/Error" }
 
 components:
+  headers:
+    ServerTiming:
+      required: false
+      description: Optional receiver-reported server processing duration using the W3C Server-Timing header. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing. ACP responses SHOULD use the `acp` metric with `dur` in milliseconds, for example `acp;dur=42.3`. This excludes network time and is informational; senders SHOULD measure client-observed latency independently.
+      schema:
+        type: string
+        example: acp;dur=42.3
   schemas:
     EventDataOrder:
       description: |

--- a/spec/unreleased/openapi/openapi.cart.yaml
+++ b/spec/unreleased/openapi/openapi.cart.yaml
@@ -61,6 +61,9 @@ paths:
       responses:
         "201":
           description: Cart created successfully
+          headers:
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -130,6 +133,9 @@ paths:
       responses:
         "200":
           description: Cart retrieved successfully
+          headers:
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -172,6 +178,9 @@ paths:
       responses:
         "200":
           description: Cart updated successfully
+          headers:
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -218,6 +227,9 @@ paths:
       responses:
         "200":
           description: Cart canceled successfully
+          headers:
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -233,6 +245,14 @@ components:
       type: http
       scheme: bearer
       bearerFormat: API Key
+
+  headers:
+    ServerTiming:
+      required: false
+      description: Optional seller-reported server processing duration using the W3C Server-Timing header. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing. ACP responses SHOULD use the `acp` metric with `dur` in milliseconds, for example `acp;dur=42.3`. This excludes network time and is informational; agents SHOULD measure client-observed latency independently.
+      schema:
+        type: string
+        example: acp;dur=42.3
 
   parameters:
     CartId:

--- a/spec/unreleased/openapi/openapi.delegate_authentication.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_authentication.yaml
@@ -114,6 +114,8 @@ paths:
             Request-Id:
               description: Echo of the request correlation id
               schema: { type: string }
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -211,6 +213,8 @@ paths:
             Request-Id:
               description: Echo of the request correlation id
               schema: { type: string }
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -270,6 +274,8 @@ paths:
             Request-Id:
               description: Echo of the request correlation id
               schema: { type: string }
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -318,6 +324,13 @@ components:
       type: http
       scheme: bearer
       bearerFormat: API Key
+  headers:
+    ServerTiming:
+      required: false
+      description: Optional server-reported processing duration using the W3C Server-Timing header. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing. ACP responses SHOULD use the `acp` metric with `dur` in milliseconds, for example `acp;dur=42.3`. This excludes network time and is informational; clients SHOULD measure client-observed latency independently.
+      schema:
+        type: string
+        example: acp;dur=42.3
 
   parameters:
     Authorization:

--- a/spec/unreleased/openapi/openapi.delegate_payment.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_payment.yaml
@@ -94,6 +94,8 @@ paths:
                 type: string
                 enum:
                   - "true"
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -215,6 +217,13 @@ components:
       type: http
       scheme: bearer
       bearerFormat: API Key
+  headers:
+    ServerTiming:
+      required: false
+      description: Optional merchant-reported server processing duration using the W3C Server-Timing header. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing. ACP responses SHOULD use the `acp` metric with `dur` in milliseconds, for example `acp;dur=42.3`. This excludes network time and is informational; platforms SHOULD measure client-observed latency independently.
+      schema:
+        type: string
+        example: acp;dur=42.3
   parameters:
     Authorization:
       name: Authorization

--- a/spec/unreleased/openapi/openapi.feed.yaml
+++ b/spec/unreleased/openapi/openapi.feed.yaml
@@ -37,6 +37,9 @@ paths:
       responses:
         "201":
           description: Feed created
+          headers:
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -72,6 +75,9 @@ paths:
       responses:
         "200":
           description: Feed metadata
+          headers:
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -107,6 +113,9 @@ paths:
       responses:
         "200":
           description: Feed products
+          headers:
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -161,6 +170,9 @@ paths:
       responses:
         "200":
           description: Product upsert accepted
+          headers:
+            Server-Timing:
+              $ref: "#/components/headers/ServerTiming"
           content:
             application/json:
               schema:
@@ -198,6 +210,13 @@ paths:
                     message: Feed not found
                     param: id
 components:
+  headers:
+    ServerTiming:
+      required: false
+      description: Optional feed-service-reported processing duration using the W3C Server-Timing header. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Server-Timing. ACP responses SHOULD use the `acp` metric with `dur` in milliseconds, for example `acp;dur=42.3`. This excludes network time and is informational; callers SHOULD measure client-observed latency independently.
+      schema:
+        type: string
+        example: acp;dur=42.3
   parameters:
     FeedId:
       name: id


### PR DESCRIPTION
# SEP: Add Server-Timing Response Headers

## 📋 SEP Metadata

- **SEP Number**: #274 - https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/issues/274
- **Author(s)**: Karan Goel / Meta
- **Status**: `proposal` (awaiting sponsor)
- **Type**: [x] Major Change [ ] Process Change
- **Related Issues/RFCs**: Related UCP PRs: Universal-Commerce-Protocol/ucp#547, Universal-Commerce-Protocol/ucp#548

---

## 🎯 Abstract

This proposal adds optional `Server-Timing` response headers across ACP REST OpenAPI 2xx responses and documents the behavior in the relevant RFCs. Implementations may use the W3C `Server-Timing` header to report business/server-side processing duration with the `acp` metric and `dur` in milliseconds, for example `Server-Timing: acp;dur=42.3`.

The header is informational only. It excludes network time, does not alter response semantics, and does not replace client-observed latency measurement. Clients and platforms should continue to measure end-to-end latency independently.

---

## 💡 Motivation

ACP currently defines several protocol-level request and response headers, but it does not provide a standard way for servers to report processing duration. UCP recently added equivalent optional `Server-Timing` guidance. Aligning ACP gives agents and platforms a consistent, standards-based signal for separating server processing time from client-observed latency during checkout, cart, feed, payment, authentication, and webhook flows.

Without a shared convention, implementers may use proprietary timing headers, inconsistent metric names, or omit server-side timing entirely, making latency analysis harder across integrations.

---

## 📐 Specification

ACP REST responses MAY include the W3C `Server-Timing` header on successful 2xx responses.

When present, ACP responses SHOULD use:

```http
Server-Timing: acp;dur=42.3
```

Where:

- `acp` is the metric name.
- `dur` is server processing duration in milliseconds.
- The value excludes network time.
- The value is informational; callers SHOULD measure client-observed latency independently.

This PR updates:

- `spec/unreleased/openapi/openapi.agentic_checkout.yaml`
- `spec/unreleased/openapi/openapi.agentic_checkout_webhook.yaml`
- `spec/unreleased/openapi/openapi.cart.yaml`
- `spec/unreleased/openapi/openapi.delegate_authentication.yaml`
- `spec/unreleased/openapi/openapi.delegate_payment.yaml`
- `spec/unreleased/openapi/openapi.feed.yaml`
- RFC guidance for checkout, cart, delegate authentication, delegate payment, and product feeds
- `changelog/unreleased/add-server-timing-header.md`

---

## 🤔 Rationale

`Server-Timing` is a standard HTTP response header, so ACP does not need a custom timing field or proprietary header. Keeping the header optional avoids imposing runtime instrumentation requirements on existing implementations. Using a single `acp` metric keeps the convention simple and mirrors the approach used in UCP, while avoiding protocol-specific endpoint metric proliferation in the base spec.

The proposal intentionally does not make the header required, does not define SLA semantics, and does not treat this value as authoritative for user-visible latency.

---

## 🔄 Backward Compatibility

This is additive and backward compatible.

- Existing clients can ignore unknown response headers.
- Existing servers do not need to emit `Server-Timing`.
- No request or response body schemas are changed.
- No deprecation or migration timeline is required.

---

## 🛠️ Reference Implementation

No runtime reference implementation is included. This PR updates the protocol OpenAPI and RFC documentation only.

---

## 🔒 Security Implications

The header may expose approximate server processing duration. Implementers should avoid putting sensitive internal system names, topology, query names, or vendor-specific details in the metric. This proposal recommends only the generic `acp` metric with a duration value.

The header does not affect authentication, authorization, signing, payment handling, or user data processing.

---

## ✅ Pre-Submission Checklist

- [x] I have created a GitHub Issue for this SEP proposal (#274; repo does not currently have `SEP`/`proposal` labels)
- [x] I have linked the SEP issue number above
- [ ] I have discussed this proposal in the community (Discord/GitHub Discussions)
- [ ] I have signed the Contributor License Agreement (CLA)
- [x] This PR includes updates to OpenAPI/JSON schemas (if applicable)
- [ ] This PR includes example requests/responses (if applicable)
- [x] This PR includes a changelog entry file in `changelog/unreleased/your-change-description.md`
- [ ] I am seeking or have found a sponsor (Founding Maintainer)

---

## 📚 Additional Context

Validation run locally:

- Ruby YAML parse for all `spec/unreleased/openapi/*.yaml`
- Structural check that all unreleased OpenAPI 2xx responses include `Server-Timing`
- `git diff --check`

`pnpm validate:consistency` could not be run locally because `pnpm`/`corepack` are not installed in this environment.

---

## 🙋 Questions for Reviewers

- Should this be accepted as a SEP-level protocol addition, or reclassified as a minor additive documentation/spec clarification?
- Should the base metric name be `acp`, or should each API surface define a more specific metric name?
- Should ACP include examples with `Server-Timing` headers in `examples/unreleased/`, or is OpenAPI/RFC documentation sufficient for an optional response header?