### PR TITLE
Fix unsatisfiable authentication_result in DelegateAuthenticationSessionWithResult

### DIFF
--- a/changelog/unreleased/fix-auth-session-with-result-unsatisfiable.md
+++ b/changelog/unreleased/fix-auth-session-with-result-unsatisfiable.md
@@ -1,0 +1,40 @@
+## Fix unsatisfiable authentication_result in DelegateAuthenticationSessionWithResult
+
+**Fixed** a schema bug that makes `authentication_result` impossible to set on a
+valid `DelegateAuthenticationSessionWithResult`, even though that field is the
+only thing the type adds.
+
+`DelegateAuthenticationSessionWithResult` is
+`allOf: [DelegateAuthenticationSessionBase, { properties: { authentication_result } }]`.
+The base sets `additionalProperties: false` and does not declare
+`authentication_result`. In draft 2020-12, `additionalProperties` only considers
+the `properties` of the same schema object, not properties added by a sibling
+`allOf` branch. So the base subschema treats `authentication_result` as an unknown
+property and rejects it, which fails the whole `allOf`. Any object that includes
+`authentication_result` is therefore unsatisfiable.
+
+What this breaks:
+
+- The `200` response of the retrieve-authentication-session operation references
+  this schema.
+- The schema's own embedded `example`/`examples` include `authentication_result`,
+  so the schema does not validate the examples it ships with.
+- Every `retrieve_session_response_*` example that carries a result fails
+  validation. Ajv, Spectral, Redocly, and openapi-generator all reject them.
+
+### Fix
+
+Declare `authentication_result` as an optional property on
+`DelegateAuthenticationSessionBase` so `additionalProperties: false` permits it.
+This is the same pattern the spec already uses for `CheckoutSessionWithOrder`,
+where `order` lives on `CheckoutSessionBase` and the `WithOrder` variant builds on
+top. It stays optional because a terminal session does not always have a 3DS
+result (the `expired` example only has `authentication_session_id` and `status`),
+so requiring it would reject valid responses.
+
+No example files changed. The examples were already correct; the schema was wrong.
+
+### Files Updated
+
+- `spec/unreleased/json-schema/schema.delegate_authentication.json`
+- `spec/unreleased/openapi/openapi.delegate_authentication.yaml`

--- a/spec/unreleased/json-schema/schema.delegate_authentication.json
+++ b/spec/unreleased/json-schema/schema.delegate_authentication.json
@@ -589,6 +589,10 @@
         },
         "action": {
           "$ref": "#/$defs/Action"
+        },
+        "authentication_result": {
+          "$ref": "#/$defs/AuthenticationResult",
+          "description": "Final 3DS authentication result. Only present once the session has reached a terminal state, e.g. on the retrieve session response."
         }
       },
       "required": ["authentication_session_id", "status"],

--- a/spec/unreleased/openapi/openapi.delegate_authentication.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_authentication.yaml
@@ -505,6 +505,10 @@ components:
             - not_supported: Method not available.
         action:
           $ref: "#/components/schemas/Action"
+        authentication_result:
+          allOf:
+            - $ref: "#/components/schemas/AuthenticationResult"
+          description: Final 3DS authentication result. Only present once the session has reached a terminal state, e.g. on the retrieve session response.
       required: [authentication_session_id, status]
 
     DelegateAuthenticationSession:


### PR DESCRIPTION
## 🔧 Type of Change

- [x] Bug fix (non-breaking)

---

## 📝 Description

`DelegateAuthenticationSessionWithResult` can't validate any object that has an `authentication_result`, even though that's the only field the type adds.

It's defined as `allOf: [DelegateAuthenticationSessionBase, { properties: { authentication_result } }]`. The base sets `additionalProperties: false` and doesn't list `authentication_result`. In draft 2020-12, `additionalProperties` only looks at the `properties` of the same schema object, not at properties added by a sibling `allOf` branch. So when an instance includes `authentication_result`, the base subschema treats it as an unknown property and fails, which fails the whole `allOf`.

The fix is to declare `authentication_result` as an optional property on `DelegateAuthenticationSessionBase` so `additionalProperties: false` allows it. This is the same approach the spec already uses for `CheckoutSessionWithOrder`, where `order` lives on `CheckoutSessionBase` and the `WithOrder` variant builds on top. I kept it optional on purpose: a terminal session doesn't always have a 3DS result (the `expired` example only has `authentication_session_id` and `status`), so making it required would reject valid responses.

I didn't touch any examples. They were already correct; the schema was the problem.

---

## 🎯 Motivation and Context

The retrieve-authentication-session `200` response uses this schema, and the schema's own embedded examples include `authentication_result`, so the schema doesn't even validate the examples shipped with it. Every `retrieve_session_response_*` example that carries a result is unsatisfiable. Ajv and the usual OpenAPI tools (Spectral, Redocly, openapi-generator) reject it, and generated clients drop the field. Nothing changes for payloads that were already valid.

---

## 🧪 Testing

- Validated the `DelegateAuthenticationSessionWithResult`, `DelegateAuthenticationSession`, and `DelegateAuthenticationSessionBase` embedded examples against the fixed schema (draft 2020-12). All pass.
- Validated every `retrieve_session_response_*`, `create_authentication_session_response_*`, and `authenticate_response_*` example in `examples/unreleased/examples.delegate_authentication.json`. All pass, including `retrieve_session_response_expired` (no `authentication_result`), which is why the field has to stay optional.
- Checked that the JSON Schema and OpenAPI definitions still line up.
- `npm run validate:all` passes.

---

## 📸 Screenshots / Examples

Before (the base rejects the field because of `additionalProperties: false`):

```jsonc
// DelegateAuthenticationSessionBase
{ "additionalProperties": false,
  "properties": { "authentication_session_id": {}, "status": {}, "action": {} } }
```

After (field declared optional on the base):

```jsonc
// DelegateAuthenticationSessionBase
{ "additionalProperties": false,
  "properties": { "authentication_session_id": {}, "status": {}, "action": {},
                  "authentication_result": { "$ref": "#/$defs/AuthenticationResult" } } }
```

---

## ✅ Checklist

Before submitting, ensure:

- [ ] I have signed the [Contributor License Agreement (CLA)](../legal/cla/INDIVIDUAL.md)
- [x] My change follows the project's code style and conventions
- [x] I have updated relevant documentation (if applicable)
- [x] I have added/updated examples (if applicable)
- [x] I have added a changelog entry file to `changelog/unreleased/`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)
- [x] All CI checks pass

---

## 🔍 Scope Verification

- [ ] ❌ This adds/removes/modifies protocol features
- [ ] ❌ This introduces breaking changes
- [ ] ❌ This changes governance or processes
- [ ] ❌ This is complex or controversial
- [x] ✅ **This is a minor, straightforward change**

It's backwards compatible. The change only widens `DelegateAuthenticationSessionBase` to allow an optional field, so anything that validated before still validates, and `authentication_result` now validates too.

---

## 📚 Additional Notes

Updated both the JSON Schema bundle (`spec/unreleased/json-schema/schema.delegate_authentication.json`) and the OpenAPI file (`spec/unreleased/openapi/openapi.delegate_authentication.yaml`) so they stay in sync. Changelog entry is at `changelog/unreleased/fix-auth-session-with-result-unsatisfiable.md`.
