### PR TITLE
fix: nest PaymentHandler.display_order under properties (#279)

### DIFF
--- a/changelog/unreleased/fix-payment-handler-display-order-indentation.md
+++ b/changelog/unreleased/fix-payment-handler-display-order-indentation.md
@@ -1,0 +1,16 @@
+## Fix PaymentHandler.display_order OpenAPI indentation (#279)
+
+`display_order` in `PaymentHandler` was indented as a sibling of `properties`/`required` instead of nested inside `properties`, so OpenAPI validators silently dropped it as an unrecognized schema-object keyword. With `additionalProperties: false` on `PaymentHandler`, this meant a handler object that set `display_order` — the exact usage the field's own description invites — failed schema validation, contradicting the field's documented purpose. The JSON Schema mirror (`schema.agentic_checkout.json`) already nested the field correctly; only the OpenAPI YAML had the indentation bug.
+
+### Changes
+
+- **PaymentHandler (OpenAPI)**: Re-indented `display_order` two spaces to nest it under `properties`, matching the existing JSON Schema definition.
+
+### Files Updated
+
+- `spec/2026-04-17/openapi/openapi.agentic_checkout.yaml`
+- `spec/unreleased/openapi/openapi.agentic_checkout.yaml`
+
+### Reference
+
+- Issue: #279

--- a/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
+++ b/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
@@ -1117,9 +1117,9 @@ components:
         config:
           type: object
           description: Handler-specific configuration
-      display_order:
-        type: integer
-        description: Optional merchant-suggested display order (lower = higher preference). Suggestive only; platform/agent MAY reorder.
+        display_order:
+          type: integer
+          description: Optional merchant-suggested display order (lower = higher preference). Suggestive only; platform/agent MAY reorder.
       required:
         - id
         - name

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -1177,9 +1177,9 @@ components:
         config:
           type: object
           description: Handler-specific configuration
-      display_order:
-        type: integer
-        description: Optional merchant-suggested display order (lower = higher preference). Suggestive only; platform/agent MAY reorder.
+        display_order:
+          type: integer
+          description: Optional merchant-suggested display order (lower = higher preference). Suggestive only; platform/agent MAY reorder.
       required:
         - id
         - name


### PR DESCRIPTION
# Fix PaymentHandler.display_order OpenAPI indentation

## 🔧 Type of Change

- [x] Bug fix (non-breaking)

---

## 📝 Description

In `openapi.agentic_checkout.yaml` (both `2026-04-17` and `unreleased`), `PaymentHandler.display_order` is indented as a sibling of `properties:`/`required:` rather than nested inside `properties:`. Since `display_order` isn't a recognized OpenAPI/JSON-Schema keyword at the schema-object level, it's silently ignored there — and because `PaymentHandler` sets `additionalProperties: false`, a handler object that actually sets `display_order` (exactly what the field's own description invites merchants to do) fails schema validation with "unexpected field display_order".

The JSON Schema mirror (`schema.agentic_checkout.json`) already nests `display_order` correctly under `properties` in both versions — only the hand-maintained OpenAPI YAML had the indentation bug, so this brings the two representations back in sync.

## 🎯 Motivation and Context

Fixes/Addresses: #279

## 🧪 Testing

- Parsed both modified YAML files with a YAML loader and confirmed `display_order` now resolves under `components.schemas.PaymentHandler.properties`.
- Ran `pnpm install && pnpm run validate:all` — full validation suite passes (field types, descriptions, examples-against-schema across all versions), including the existing `display_order` example entries in `examples/2026-04-17/examples.agentic_checkout.json` and `examples/unreleased/examples.agentic_checkout.json`, which now validate against the corrected schema.

## ✅ Checklist

- [x] My change follows the project's code style and conventions
- [x] I have added a changelog entry file to `changelog/unreleased/fix-payment-handler-display-order-indentation.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)

## 🔍 Scope Verification

- [x] **This is a minor, straightforward change** (confirm by checking this)

## 📚 Additional Notes

Two-line indentation fix, scoped only to the affected schema — no behavior/field changes beyond making `display_order` actually usable per its own documented intent.
