### PR TITLE
fix(spec): Signature and Timestamp are REQUIRED on delegate_payment (align OpenAPI with RFC MUST)

### DIFF
--- a/spec/2026-04-17/openapi/openapi.delegate_payment.yaml
+++ b/spec/2026-04-17/openapi/openapi.delegate_payment.yaml
@@ -269,16 +269,16 @@ components:
     Signature:
       name: Signature
       in: header
-      required: false
-      description: Detached JSON signature for request verification
+      required: true
+      description: Detached JSON signature for request verification. Per the Delegate Payment RFC, clients MUST compute a detached signature with their private key and place it (base64url-encoded) in this header; without it, the static bearer credential is the only control on an endpoint that mints spendable payment tokens.
       schema:
         type: string
         example: ZXltZX...
     Timestamp:
       name: Timestamp
       in: header
-      required: false
-      description: ISO 8601 timestamp for request timing validation
+      required: true
+      description: ISO 8601 timestamp for request timing validation. Per the Delegate Payment RFC, clients MUST include this header; servers SHOULD reject requests outside an acceptable clock-skew window to prevent replay.
       schema:
         type: string
         format: date-time


### PR DESCRIPTION
## Summary

- `rfcs/rfc.delegate_payment.md` (lines 38–39): the client **MUST** place a detached, base64url-encoded signature in the `Signature` header and **MUST** include `Timestamp`.
- The machine-readable `spec/2026-04-17/openapi/openapi.delegate_payment.yaml` marked both parameters `required: false`.
- SDKs, validators, and server stubs generated from the OpenAPI therefore accept unsigned requests: the **static bearer key becomes the only control** on an endpoint that tokenizes a payment credential under an allowance.
- Flip both parameters to `required: true` and cite the RFC requirement in the descriptions.

## Impact if unsolved

Every codegen consumer of this spec builds clients that omit request signing and servers that don't demand it. A leaked bearer credential then allows arbitrary payment-token minting with no request binding and no freshness check — replay- and forgery-prone by construction.

## Test plan

- `pnpm run validate:consistency` passes (all validations green).
- Pure spec metadata change; no schema-shape or example changes.

Made with [Cursor](https://cursor.com)