### PR TITLE
fix(spec): require Signature on delegate_authentication OpenAPI

### DIFF
--- a/changelog/unreleased/fix-delegate-authentication-signature-required.md
+++ b/changelog/unreleased/fix-delegate-authentication-signature-required.md
@@ -1,0 +1,13 @@
+## Require Signature header on Delegate Authentication OpenAPI
+
+`rfcs/rfc.delegate_authentication.md` §3.1 marks `Signature` as **REQUIRED** on client request headers. The machine-readable `spec/2026-04-17/openapi/openapi.delegate_authentication.yaml` had `required: false`, so codegen clients and validators accepted unsigned create/authenticate calls where the static bearer key was the only control on an endpoint that accepts card data and mints 3DS sessions.
+
+### Changes
+- Set `components.parameters.Signature.required` to `true` and cite the RFC requirement in the description.
+- Left `Timestamp` optional (RFC §3.1 lists it as RECOMMENDED).
+
+### Files Updated
+- `spec/2026-04-17/openapi/openapi.delegate_authentication.yaml`
+
+### Reference
+- Sibling of open PR aligning Delegate Payment Signature/Timestamp with its RFC MUST language

--- a/spec/2026-04-17/openapi/openapi.delegate_authentication.yaml
+++ b/spec/2026-04-17/openapi/openapi.delegate_authentication.yaml
@@ -357,7 +357,8 @@ components:
     Signature:
       name: Signature
       in: header
-      required: false
+      required: true
+      description: Detached JSON signature for request verification. Per the Delegate Authentication RFC §3.1, clients MUST place a base64url-encoded signature over the canonical request in this header; without it, the static bearer credential is the only control on an endpoint that accepts card data and mints 3DS sessions.
       schema: { type: string, example: "ZXltZX..." }
     Timestamp:
       name: Timestamp


### PR DESCRIPTION
## Summary

- `rfcs/rfc.delegate_authentication.md` §3.1 lists `Signature` as **REQUIRED** on client request headers (identity verification over the canonical request).
- `spec/2026-04-17/openapi/openapi.delegate_authentication.yaml` marked that parameter `required: false`.
- Codegen clients, validators, and server stubs generated from the OpenAPI therefore accept unsigned create/authenticate requests: the static bearer key becomes the only control on an endpoint that accepts card data and mints 3DS sessions.
- Flip `Signature` to `required: true` and cite the RFC. Leave `Timestamp` optional (RFC §3.1: RECOMMENDED).

Sibling of open [#285](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/pull/285) (Delegate Payment Signature/Timestamp alignment).

## Impact if unsolved

Every codegen consumer of this spec builds clients that can omit request integrity on delegated authentication. Implementers that trust the OpenAPI `required` flags will not reject unsigned traffic.

## Test plan

- [ ] Confirm OpenAPI `components.parameters.Signature.required` is `true`
- [ ] Confirm `Timestamp` remains optional
- [ ] Changelog entry present under `changelog/unreleased/`


Made with [Cursor](https://cursor.com)