### PR TITLE
fix(spec): require Signature on unreleased delegate OpenAPI

### DIFF
--- a/changelog/unreleased/fix-unreleased-delegate-signature-required.md
+++ b/changelog/unreleased/fix-unreleased-delegate-signature-required.md
@@ -1,0 +1,10 @@
+## Require Signature (and Timestamp) on unreleased Delegate Payment / Authentication OpenAPI
+
+`rfcs/rfc.delegate_payment.md` marks `Signature` and `Timestamp` as **REQUIRED**. `rfcs/rfc.delegate_authentication.md` §3.1 marks `Signature` as **REQUIRED**. Open PRs already align the dated `2026-04-17` OpenAPI snapshots; `spec/unreleased/` (current development, next release source) still had `required: false`, so codegen from unreleased would keep accepting unsigned money-path requests with only the static bearer key.
+
+### Changes
+- `spec/unreleased/openapi/openapi.delegate_payment.yaml`: set `Signature` and `Timestamp` `required: true` (RFC MUST).
+- `spec/unreleased/openapi/openapi.delegate_authentication.yaml`: set `Signature` `required: true` (RFC MUST). Leave `Timestamp` optional (RFC RECOMMENDED).
+
+### Reference
+- Sibling of open PRs aligning the `2026-04-17` dated specs with the same RFC MUST language.

--- a/spec/unreleased/openapi/openapi.delegate_authentication.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_authentication.yaml
@@ -357,7 +357,8 @@ components:
     Signature:
       name: Signature
       in: header
-      required: false
+      required: true
+      description: Detached JSON signature for request verification. Per the Delegate Authentication RFC §3.1, clients MUST place a base64url-encoded signature over the canonical request in this header; without it, the static bearer credential is the only control on an endpoint that accepts card data and mints 3DS sessions.
       schema: { type: string, example: "ZXltZX..." }
     Timestamp:
       name: Timestamp

--- a/spec/unreleased/openapi/openapi.delegate_payment.yaml
+++ b/spec/unreleased/openapi/openapi.delegate_payment.yaml
@@ -269,16 +269,16 @@ components:
     Signature:
       name: Signature
       in: header
-      required: false
-      description: Detached JSON signature for request verification
+      required: true
+      description: Detached JSON signature for request verification. Per the Delegate Payment RFC, clients MUST compute a detached signature with their private key and place it (base64url-encoded) in this header; without it, the static bearer credential is the only control on an endpoint that mints spendable payment tokens.
       schema:
         type: string
         example: ZXltZX...
     Timestamp:
       name: Timestamp
       in: header
-      required: false
-      description: ISO 8601 timestamp for request timing validation
+      required: true
+      description: ISO 8601 timestamp for request timing validation. Per the Delegate Payment RFC, clients MUST include this header; servers SHOULD reject requests outside an acceptable clock-skew window to prevent replay.
       schema:
         type: string
         format: date-time


### PR DESCRIPTION
## Summary
- Open PRs [#285](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/pull/285) and [#287](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/pull/287) align the dated `2026-04-17` OpenAPI snapshots with RFC MUST for `Signature` (and `Timestamp` on delegate payment).
- `spec/unreleased/` is the current-development / next-release source and still had `required: false` for those headers, so codegen from unreleased would keep accepting unsigned money-path requests with only the static bearer key.
- Flip unreleased `delegate_payment` `Signature` + `Timestamp` to required, and unreleased `delegate_authentication` `Signature` to required (leave auth `Timestamp` optional; RFC RECOMMENDED).

## Impact if unsolved
Next release snapshotted from unreleased would reintroduce optional Signature on payment-token mint and 3DS session create/authenticate endpoints.

## Test plan
- [x] `pnpm run validate:consistency` passes
- [ ] CLA Assistant (if required)


Made with [Cursor](https://cursor.com)