### PR TITLE
Fix minimal checkout request example to use line_items + currency

### DIFF
--- a/changelog/unreleased/fix-minimal-checkout-example-fields.md
+++ b/changelog/unreleased/fix-minimal-checkout-example-fields.md
@@ -1,9 +1,12 @@
-## Fix minimal checkout session request example
+## Fix checkout session request examples
 
-Corrected the `minimal` inline OpenAPI example on `POST /checkout_sessions` in the 2026-04-17 `agentic_checkout` spec. The example used an `items` field with a per-item `quantity`, but `CheckoutSessionCreateRequest` declares `additionalProperties: false` and requires `line_items`, `currency`, and `capabilities`. Anyone copying the example would send a request the schema (and any merchant validating against it) must reject.
+Corrected all four inline OpenAPI examples for `POST /checkout_sessions` in the 2026-04-17 `agentic_checkout` spec. Each example used an `items` field with a per-item `quantity` (and, in one case, a nonexistent `product_id`), but `CheckoutSessionCreateRequest` declares `additionalProperties: false` and requires `line_items`, `currency`, and `capabilities`, and `Item` only permits `id`, `name`, and `unit_amount`. Anyone copying any of these examples would send a request the schema (and any merchant validating against it) must reject.
 
 ### Changes
-- `minimal` example: replaced `items` with `line_items` (matching the `Item` schema shape) and added the required `currency` and `capabilities` fields
+- `minimal` example: replaced `items` with `line_items` and added the required `currency` and `capabilities` fields
+- `with_address` example: replaced `items` with `line_items`, dropped `quantity`, and added the required `currency` and `capabilities` fields
+- `with_first_touch_attribution` example: replaced `items` with `line_items`, dropped `quantity`, and added the required `currency` and `capabilities` fields
+- `CheckoutSessionCreateRequest` schema's own inline `example`: replaced `items`/`product_id`/`quantity` with `line_items` using the actual `Item` schema shape
 
 ### Files Updated
 - `spec/2026-04-17/openapi/openapi.agentic_checkout.yaml`

--- a/changelog/unreleased/fix-minimal-checkout-example-fields.md
+++ b/changelog/unreleased/fix-minimal-checkout-example-fields.md
@@ -1,0 +1,12 @@
+## Fix minimal checkout session request example
+
+Corrected the `minimal` inline OpenAPI example on `POST /checkout_sessions` in the 2026-04-17 `agentic_checkout` spec. The example used an `items` field with a per-item `quantity`, but `CheckoutSessionCreateRequest` declares `additionalProperties: false` and requires `line_items`, `currency`, and `capabilities`. Anyone copying the example would send a request the schema (and any merchant validating against it) must reject.
+
+### Changes
+- `minimal` example: replaced `items` with `line_items` (matching the `Item` schema shape) and added the required `currency` and `capabilities` fields
+
+### Files Updated
+- `spec/2026-04-17/openapi/openapi.agentic_checkout.yaml`
+
+### Reference
+- Issue: #278

--- a/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
+++ b/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
@@ -52,9 +52,10 @@ paths:
               with_address:
                 summary: Single item with shipping address
                 value:
-                  items:
+                  line_items:
                     - id: item_456
-                      quantity: 1
+                  currency: usd
+                  capabilities: {}
                   fulfillment_details:
                     name: test
                     phone_number: "15551234567"
@@ -70,9 +71,10 @@ paths:
               with_first_touch_attribution:
                 summary: With first-touch affiliate attribution
                 value:
-                  items:
+                  line_items:
                     - id: item_123
-                      quantity: 1
+                  currency: usd
+                  capabilities: {}
                   affiliate_attribution:
                     provider: impact.com
                     token: atp_01J8Z3WXYZ9ABC
@@ -3020,9 +3022,8 @@ components:
         - currency
         - capabilities
       example:
-        items:
-          - product_id: prod_tshirt_blue_m
-            quantity: 2
+        line_items:
+          - id: item_tshirt_blue_m
         currency: usd
         capabilities: {}
       description: Request to create a new checkout session

--- a/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
+++ b/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
@@ -45,9 +45,10 @@ paths:
               minimal:
                 summary: Single item; no fulfillment details
                 value:
-                  items:
+                  line_items:
                     - id: item_123
-                      quantity: 1
+                  currency: usd
+                  capabilities: {}
               with_address:
                 summary: Single item with shipping address
                 value:


### PR DESCRIPTION
# Fix minimal checkout session request example

## Type of Change
- [x] Documentation fix/improvement
- [x] Example update

## Description
The `minimal` inline OpenAPI example on `POST /checkout_sessions` (2026-04-17 `agentic_checkout` spec) used an `items` field with a per-item `quantity`. `CheckoutSessionCreateRequest` declares `additionalProperties: false` and requires `line_items`, `currency`, and `capabilities` — so the example was invalid against its own schema in three ways: `items` is an unexpected property, and `line_items`/`currency` are missing.

Anyone copying the example (e.g. building a client off the rendered OpenAPI docs) would ship a request the schema, and any merchant validating against it, must reject.

## Motivation and Context
Fixes: #278

## Testing
- Compared the corrected example against `CheckoutSessionCreateRequest` (requires `line_items`, `currency`, `capabilities`) and the `Item` schema (only `id` required) in the same file.
- Cross-checked shape against the curated example file `examples/2026-04-17/examples.agentic_checkout.json`, which already uses the correct `line_items`/`currency`/`capabilities` shape.
- Ran `npm run validate:consistency` — all checks pass.

## Checklist
- [x] I have signed the CLA
- [x] My change follows the project's code style and conventions
- [x] I have added a changelog entry file (`changelog/unreleased/fix-minimal-checkout-example-fields.md`)
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)

## Scope Verification
- [x] This is a minor, straightforward change