### PR TITLE
fix: allow order field on CheckoutSessionWithOrder (#277)

### DIFF
--- a/changelog/unreleased/fix-checkout-session-with-order-additional-properties.md
+++ b/changelog/unreleased/fix-checkout-session-with-order-additional-properties.md
@@ -1,0 +1,25 @@
+## Fix CheckoutSessionWithOrder allOf + additionalProperties: false (#277)
+
+`CheckoutSessionWithOrder` composed `CheckoutSessionBase` via `allOf` and added the `order`
+property in a sibling branch. `CheckoutSessionBase` sets `additionalProperties: false`, and in
+JSON Schema (including OpenAPI 3.1's draft 2020-12 dialect) `additionalProperties` only sees
+properties declared in the same schema object, not properties contributed by sibling `allOf`
+branches. As a result, `order` was rejected as an unrecognized field — meaning the spec's own
+documented example response for `POST /checkout_sessions/{id}/complete` failed validation
+against its own schema. The JSON Schema mirror (`schema.agentic_checkout.json`) already declared
+`order` directly on `CheckoutSessionBase`; only the OpenAPI YAML had the broken composition.
+
+### Changes
+
+- **CheckoutSessionBase (OpenAPI)**: Added `order` as an optional property (`$ref` to `Order`)
+  directly on `CheckoutSessionBase`, matching the JSON Schema mirror. `CheckoutSessionWithOrder`
+  still marks `order` as `required` via its `allOf` extension branch.
+
+### Files Updated
+
+- `spec/2026-04-17/openapi/openapi.agentic_checkout.yaml`
+- `spec/unreleased/openapi/openapi.agentic_checkout.yaml`
+
+### Reference
+
+- Issue: #277

--- a/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
+++ b/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml
@@ -2893,6 +2893,9 @@ components:
         discounts:
           $ref: "#/components/schemas/DiscountsResponse"
           description: "Discount extension: submitted codes and applied discounts. Present when the 'discount' extension is active."
+        order:
+          $ref: "#/components/schemas/Order"
+          description: Order created when checkout is completed
       required:
         - id
         - status

--- a/spec/unreleased/openapi/openapi.agentic_checkout.yaml
+++ b/spec/unreleased/openapi/openapi.agentic_checkout.yaml
@@ -2955,6 +2955,9 @@ components:
         discounts:
           $ref: "#/components/schemas/DiscountsResponse"
           description: "Discount extension: submitted codes and applied discounts. Present when the 'discount' extension is active."
+        order:
+          $ref: "#/components/schemas/Order"
+          description: Order created when checkout is completed
       required:
         - id
         - status


### PR DESCRIPTION
# Fix CheckoutSessionWithOrder allOf + additionalProperties: false

## 🔧 Type of Change

- [x] Bug fix (non-breaking)

---

## 📝 Description

`CheckoutSessionWithOrder` is composed as `allOf: [CheckoutSessionBase, {order}]`.
`CheckoutSessionBase` sets `additionalProperties: false`. In JSON Schema (including
OpenAPI 3.1's draft 2020-12 dialect), `additionalProperties` only sees properties declared
in the *same* schema object — not properties contributed by sibling `allOf` branches. So
`order`, declared only in the sibling branch, was rejected as an unrecognized field by
`CheckoutSessionBase`'s `additionalProperties: false`. The result: the spec's own documented
example response for `POST /checkout_sessions/{id}/complete` (which includes `order`) fails
validation against its own schema.

The JSON Schema mirror (`schema.agentic_checkout.json`) already had `order` declared directly
on `CheckoutSessionBase` as an optional property — only the OpenAPI YAML had the broken
`allOf` composition. This PR brings the OpenAPI YAML in line with the already-correct JSON
Schema mirror: `order` is now declared directly on `CheckoutSessionBase` (optional), and
`CheckoutSessionWithOrder`'s `allOf` extension branch still marks it `required`.

---

## 🎯 Motivation and Context

Fixes/Addresses: #277

---

## 🧪 Testing

- Reproduced the bug by compiling the OpenAPI schema with `ajv` (draft2020) and validating the
  `CheckoutSessionWithOrder` embedded example against it: before the fix, AJV reported
  `must NOT have additional properties` (`additionalProperty: "order"`) at the root. After the
  fix, that error is gone (remaining, pre-existing/unrelated errors in the embedded `order`
  sub-object example are outside this issue's scope and not introduced by this change).
- Ran the repo's full validation suite: `npm run validate:all` — all checks pass, including
  "Examples validated for 2026-04-17/agentic_checkout" and "unreleased/agentic_checkout".
- Ran `npx ajv compile --spec=draft2020 -c ajv-formats -s 'spec/unreleased/json-schema/*.json'`
  — all schemas compile successfully.

---

## ✅ Checklist

- [x] I have signed the Contributor License Agreement (CLA)
- [x] My change follows the project's code style and conventions
- [x] I have added a changelog entry file to `changelog/unreleased/fix-checkout-session-with-order-additional-properties.md`
- [x] I have tested my changes locally
- [x] This change does NOT require a SEP (it's minor/non-breaking)

## 🔍 Scope Verification

- [x] **This is a minor, straightforward change** (confirm by checking this)

Closes #277
